### PR TITLE
Fix shadowing in retry library 

### DIFF
--- a/types/retry/retry.go
+++ b/types/retry/retry.go
@@ -52,7 +52,8 @@ func isExpectedErr(err error) bool {
 }
 
 // Do executes a func with retry
-// TODO: check if this is needed, because is not being used.
+// TODO: Remove this function, and make our programs to depend on retires based
+// on some standard retry library
 func Do(sleep time.Duration, maxSleepTime time.Duration, retryableFunc func() error) error {
 	if err := retryableFunc(); err != nil {
 		if isUnrecoverableErr(err) {
@@ -66,9 +67,10 @@ func Do(sleep time.Duration, maxSleepTime time.Duration, retryableFunc func() er
 		}
 
 		// Add some randomness to prevent thrashing
-		jitter, err := randDuration(int64(sleep))
-		if err != nil {
-			return err
+		// TODO: This duration should be passed by the caller
+		jitter, randomnessErr := randDuration(int64(sleep))
+		if randomnessErr != nil {
+			return randomnessErr
 		}
 		sleep = sleep + jitter/2
 

--- a/types/retry/retry_test.go
+++ b/types/retry/retry_test.go
@@ -1,9 +1,11 @@
 package retry
 
 import (
-	"github.com/stretchr/testify/require"
+	"errors"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnrecoverableError(t *testing.T) {
@@ -18,4 +20,14 @@ func TestExpectedError(t *testing.T) {
 		return expectedErrors[0]
 	})
 	require.NoError(t, err)
+}
+
+func TestDoNotShadowAnError(t *testing.T) {
+	var expectedError = errors.New("expected error")
+
+	err := Do(1*time.Second, 1*time.Second, func() error {
+		return expectedError
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, expectedError)
 }


### PR DESCRIPTION
We have regression in our retry library. 

Due to this regression all errors returned by provided functions are shadowed by error from - `jitter, err := randDuration(int64(sleep))`

This makes vigilante tests fail - https://github.com/babylonlabs-io/vigilante/actions/runs/10281209916/job/28451257642?pr=5