### PR TITLE
feat: btcstaking parameters upgrade

### DIFF
--- a/app/upgrades/signetlaunch/btcstaking_params.go
+++ b/app/upgrades/signetlaunch/btcstaking_params.go
@@ -1,0 +1,26 @@
+package signetlaunch
+
+// TODO Some default parameters. Consider how to switch those depending on network:
+// mainnet, testnet, devnet etc.
+const BtcStakingParamStr = `
+	{
+  "covenant_pks": [
+    "43311589af63c2adda04fcd7792c038a05c12a4fe40351b3eb1612ff6b2e5a0e",
+    "d415b187c6e7ce9da46ac888d20df20737d6f16a41639e68ea055311e1535dd9",
+    "d27cd27dbff481bc6fc4aa39dd19405eb6010237784ecba13bab130a4a62df5d",
+    "a3e107fee8879f5cf901161dbf4ff61c252ba5fec6f6407fe81b9453d244c02c",
+    "c45753e856ad0abb06f68947604f11476c157d13b7efd54499eaa0f6918cf716"
+  ],
+  "covenant_quorum": 3,
+  "min_staking_value_sat": "1000",
+  "max_staking_value_sat": "10000000000",
+  "min_staking_time_blocks": 10,
+  "max_staking_time_blocks": 65535,
+  "slashing_pk_script": "dqkUAQEBAQEBAQEBAQEBAQEBAQEBAQGIrA==",
+  "min_slashing_tx_fee_sat": "1000",
+  "slashing_rate": "0.100000000000000000",
+  "min_unbonding_time_blocks": 0,
+  "unbonding_fee_sat": "1000",
+  "min_commission_rate": "0.03",
+  "max_active_finality_providers": 100
+}`

--- a/app/upgrades/signetlaunch/btcstaking_params_test.go
+++ b/app/upgrades/signetlaunch/btcstaking_params_test.go
@@ -1,0 +1,16 @@
+package signetlaunch_test
+
+import (
+	"testing"
+
+	"github.com/babylonlabs-io/babylon/app"
+	v1 "github.com/babylonlabs-io/babylon/app/upgrades/signetlaunch"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHardCodedParamsAreValid(t *testing.T) {
+	bbnApp := app.NewTmpBabylonApp()
+	loadedParamas, err := v1.LoadBtcStakingParamsFromData(bbnApp.AppCodec())
+	require.NoError(t, err)
+	require.NoError(t, loadedParamas.Validate())
+}

--- a/app/upgrades/signetlaunch/upgrades_test.go
+++ b/app/upgrades/signetlaunch/upgrades_test.go
@@ -73,6 +73,12 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 				resp, err := s.app.BTCStakingKeeper.FinalityProviders(s.ctx, &types.QueryFinalityProvidersRequest{})
 				s.NoError(err)
 				oldFPsLen = len(resp.FinalityProviders)
+
+				// Before upgrade, the params should be different
+				paramsFromUpgrade, err := v1.LoadBtcStakingParamsFromData(s.app.AppCodec())
+				s.NoError(err)
+				moduleParams := s.app.BTCStakingKeeper.GetParams(s.ctx)
+				s.NotEqualValues(moduleParams, paramsFromUpgrade)
 			},
 			func() {
 				// inject upgrade plan
@@ -128,6 +134,12 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 					s.EqualValues(fpFromKeeper.Commission.String(), fpInserted.Commission.String())
 					s.EqualValues(fpFromKeeper.Pop.String(), fpInserted.Pop.String())
 				}
+
+				// Afer upgrade, the params should be the same
+				paramsFromUpgrade, err := v1.LoadBtcStakingParamsFromData(s.app.AppCodec())
+				s.NoError(err)
+				moduleParams := s.app.BTCStakingKeeper.GetParams(s.ctx)
+				s.EqualValues(moduleParams, paramsFromUpgrade)
 			},
 		},
 	}

--- a/test/e2e/software_upgrade_e2e_signet_launch_test.go
+++ b/test/e2e/software_upgrade_e2e_signet_launch_test.go
@@ -100,4 +100,14 @@ func (s *SoftwareUpgradeSignetLaunchTestSuite) TestUpgradeSignetLaunch() {
 		s.EqualValues(fpFromKeeper.Commission.String(), fpInserted.Commission.String())
 		s.EqualValues(fpFromKeeper.Pop.String(), fpInserted.Pop.String())
 	}
+
+	// check that staking params correctly deserialize and that they are the same
+	// as the one from the data
+	stakingParams := n.QueryBTCStakingParams()
+
+	paramsFromData, err := v1.LoadBtcStakingParamsFromData(bbnApp.AppCodec())
+	s.NoError(err)
+
+	s.EqualValues(paramsFromData, *stakingParams)
+
 }


### PR DESCRIPTION
- Add parameters upgrade from TGE chain
- Add e2e test

Depends on fixing: https://github.com/babylonlabs-io/babylon/pull/46, so that `init-chain` docker image can be build from TGE version i.e before upgrade