### PR TITLE
chore: add version argument for e2e-initialization

### DIFF
--- a/contrib/images/Makefile
+++ b/contrib/images/Makefile
@@ -1,6 +1,7 @@
 RELAYER_TAG := $(shell grep '^ENV RELAYER_TAG' cosmos-relayer/Dockerfile | cut -f3 -d\ )
 BABYLON_FULL_PATH := $(shell git rev-parse --show-toplevel)
 BABYLON_VERSION_BEFORE_UPGRADE ?= v0.9.1
+E2E_INIT_CHAIN_VERSION_BEFORE_UPGRADE ?= v0.9.3
 
 all: babylond cosmos-relayer
 
@@ -27,7 +28,7 @@ e2e-init-chain-rmi:
 
 e2e-init-chain:
 	@DOCKER_BUILDKIT=1 docker build -t babylonlabs-io/babylond-e2e-init-chain --build-arg E2E_SCRIPT_NAME=chain --platform=linux/x86_64 \
-		-f e2e-initialization/init.Dockerfile ${BABYLON_FULL_PATH}
+		-f e2e-initialization/init.Dockerfile --build-arg VERSION="${E2E_INIT_CHAIN_VERSION_BEFORE_UPGRADE}" ${BABYLON_FULL_PATH}
 
 e2e-init-chain-rmi:
 	docker rmi babylonlabs-io/babylond-e2e-init-chain 2>/dev/null; true

--- a/contrib/images/Makefile
+++ b/contrib/images/Makefile
@@ -1,7 +1,6 @@
 RELAYER_TAG := $(shell grep '^ENV RELAYER_TAG' cosmos-relayer/Dockerfile | cut -f3 -d\ )
 BABYLON_FULL_PATH := $(shell git rev-parse --show-toplevel)
-BABYLON_VERSION_BEFORE_UPGRADE ?= v0.9.1
-E2E_INIT_CHAIN_VERSION_BEFORE_UPGRADE ?= v0.9.3
+BABYLON_VERSION_BEFORE_UPGRADE ?= v0.9.3
 
 all: babylond cosmos-relayer
 
@@ -28,7 +27,7 @@ e2e-init-chain-rmi:
 
 e2e-init-chain:
 	@DOCKER_BUILDKIT=1 docker build -t babylonlabs-io/babylond-e2e-init-chain --build-arg E2E_SCRIPT_NAME=chain --platform=linux/x86_64 \
-		-f e2e-initialization/init.Dockerfile --build-arg VERSION="${E2E_INIT_CHAIN_VERSION_BEFORE_UPGRADE}" ${BABYLON_FULL_PATH}
+		-f e2e-initialization/init.Dockerfile --build-arg VERSION="${BABYLON_VERSION_BEFORE_UPGRADE}" ${BABYLON_FULL_PATH}
 
 e2e-init-chain-rmi:
 	docker rmi babylonlabs-io/babylond-e2e-init-chain 2>/dev/null; true

--- a/contrib/images/e2e-initialization/init.Dockerfile
+++ b/contrib/images/e2e-initialization/init.Dockerfile
@@ -1,10 +1,18 @@
 FROM golang:1.21 as build-env
 
 ARG E2E_SCRIPT_NAME
+# Version to build. Default is empty
+ARG VERSION
 
 # Copy All
 WORKDIR /go/src/github.com/babylonlabs-io/babylon
 COPY ./ /go/src/github.com/babylonlabs-io/babylon/
+
+# Handle if version is set
+RUN if [ -n "${VERSION}" ]; then \
+        git fetch origin tag ${VERSION} --no-tags; \
+        git checkout -f ${VERSION}; \
+    fi
 
 RUN LEDGER_ENABLED=false LINK_STATICALLY=false E2E_SCRIPT_NAME=${E2E_SCRIPT_NAME} make e2e-build-script
 


### PR DESCRIPTION
Add version argument for initialization docker for e2e tests to run with arguments and types expected by the pre-upgraded state