### PR TITLE
fix: grammatical errors in documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,7 @@ whether the inclusion evidence for a Bitcoin transaction is valid.
 ### [BTC Checkpoint](../x/btccheckpoint)
 
 The BTC Checkpoint module verifies Babylon’s BTC checkpoints
-reported by the Vigilante Reporter, and
+reported by the Vigilante Reporter  and
 provides the confirmation status of these checkpoints to the Checkpointing
 module based on their depth according to the BTC Light Client module.
 
@@ -140,7 +140,7 @@ A standalone program that monitors:
   on the Bitcoin ledger to inform Babylon about them.
 - The execution of BTC Staking slashing transactions in the case
   of a finality provider double voting.
-  In the case of non-execution the monitor extracts the finality provider's
+  In the case of non-execution, the monitor extracts the finality provider's
   private key and executes the slashing.
 - The execution of a selective slashing attack launched
   by a finality provider. In this case,
@@ -169,12 +169,12 @@ has been developed to enable these functionalities:
   Daemon program connecting to a Bitcoin wallet and Babylon.
 - [BTC Staker Dashboard](https://github.com/babylonchain/btc-staking-dashboard):
   Web application connecting to a Bitcoin wallet extension and the Babylon API.
-  Should only be used for testing purposes.
+  It should only be used for testing purposes.
 - Wallet Integrations (TBD)
 
 ### [Finality Provider](https://github.com/babylonchain/finality-provider)
 
-A standalone program that allows for the registration and
+A standalone program that allows the registration and
 maintenance of a finality provider.
 It monitors for a finality provider's inclusion in the active set, commits
 [Extractable One Time Signature (EOTS)](https://docs.babylonchain.io/assets/files/btc_staking_litepaper-32bfea0c243773f0bfac63e148387aef.pdf)

--- a/docs/run-node.md
+++ b/docs/run-node.md
@@ -44,7 +44,7 @@ The `gentxs` directory contains the genesis transactions. It contains
 transactions that assign bbn tokens to a single address that is defined for each
 node.
 
-The `node0` directory contains the following,
+The `node0` directory contains the following:
 
 ```console
 $ ls .testnet/node0/babylond

--- a/docs/staking-script.md
+++ b/docs/staking-script.md
@@ -9,25 +9,25 @@ The locked Bitcoin contributes to Babylon chain's economic security and generate
 yields for the Bitcoin stakers.
 The protocol has the following important properties:
 
-1. The staking is trustless and self-custodial, meaning it does not require
-   bridging, wrapping, 3rd-party custody/multi-sig, or oracle.
+1. Staking is trustless and self-custodial, meaning it does not require
+   bridging, wrapping, 3rd-party custody/multi-sig, or oracles.
 2. The stake voting power is delegatable, a common feature of Delegated PoS
    (DPoS) protocols.
-3. Stake security: the staked bitcoin is slashed if and only if the BTC staker
-   itself (and in case of delegation, its delegatee) is malicious. This implies
+3. Stake security: the staked Bitcoin is slashed if and only if the BTC staker
+   itself (and in the case of delegation, its delegatee) is malicious. This implies
    that, even if the Babylon chain is compromised and taken over by malicious
    actors, as long as the BTC staker itself (and the validator it delegates to
    in case of delegation) is not malicious, its bitcoin stake is secure.
 4. The protocol supports fractional slashing, meaning the protocol can be
    configured so that when slashing happens, only a fraction of the staked
    bitcoins are slashed, and the rest is returned to the staker.
-5. The protocol allows stakers to on-demand unbond, On-demand unbonding, means
+5. The protocol allows stakers to on-demand unbond. On-demand unbonding, means
    the BTC staker can withdraw from staking with an unbonding delay.
 6. Atomic slashing, meaning that if a delegator is slashed, then all the
    delegators of the same delegatee, including the delegatee's self-delegation,
    will be subject to slashing. In other words, the delegatee cannot
    selectively harm any specific delegator.
-7. (WIP) restakable, meaning that the same bitcoin can be staked to secure
+7. (WIP) Restakable, meaning that the same Bitcoin can be staked to secure
    multiple PoS chains and earn multiple PoS yields
 
 
@@ -39,7 +39,7 @@ in staking scripts. Note that a staking transaction can be funded from
 arbitrary UTXO, including those owned by multisig/MPC/threshold accounts.
 Thus, `<StakerPk>` is not necessarily the address of the source of the fund.
 Rather, it is the controller and beneficiary of the stake after its creation.
-- **Finality Provider**: A Finality Provider is the an entity that votes
+- **Finality Provider**: A Finality Provider is an entity that votes
 in the finality round to provide security assurance to the PoS chain.
 
 The Bitcoin staker can choose a specific Finality Provider to delegate
@@ -58,8 +58,8 @@ that were introduced through the Taproot upgrade.
 
 ## Staking Flow
 
-Following diagram shows how different transactions described in following
-paragraphs create and spend different bitcoin outputs:
+The following diagram shows how different transactions described in following
+paragraphs create and spend different Bitcoin outputs:
 
 ```mermaid
 stateDiagram-v2
@@ -92,7 +92,7 @@ stateDiagram-v2
     change_staking --> [*]: Withdrawal transaction
 ```
 
-Withdrawal transactions are btc transactions which transfer bitcoins to the btc
+Withdrawal transactions are BTC transactions which transfer Bitcoins to the BTC
 staker wallet.
 
 ## Types of special transactions
@@ -105,16 +105,16 @@ There are three special transaction types recognized by the Babylon chain:
 
 ### Staking Transaction
 
-A BTC Staker gains voting power by creating a staking transaction. This is a
-Bitcoin transaction that commits a certain amount of to-be-staked bitcoin to
-Babylon recognized BTC staking scripts. These scripts lock the stake for a
+The BTC staker gains voting power by creating a staking transaction. This is a
+Bitcoin transaction that commits a certain amount of to-be-staked Bitcoin to
+Babylon-recognized BTC staking scripts. These scripts lock the stake for a
 chosen amount of BTC blocks and enable other features such as unbonding and
 slashable safety.
 
 The requirements for a valid staking transaction are:
 
-- it can contain arbitrary number of inputs
-- it can contain arbitrary number of outputs. One of those outputs must be
+- It can contain an arbitrary number of inputs.
+- It can contain an arbitrary number of outputs. One of those outputs must be
   a Taproot output committing to the BTC staking scripts recognized by Babylon.
   Henceforth known as `Staking Output`.
 
@@ -125,9 +125,9 @@ their stake before their originally committed timelock has expired.
 
 The requirements for a valid unbonding transaction are:
 
-- it contains exactly one input which points to staking transaction's `Staking
+- It contains exactly one input which points to the staking transaction's `Staking
 Output`.
-- it contains exactly one output which must be a Taproot output committing to
+- It contains exactly one output which must be a Taproot output committing to
   the BTC unbonding scripts recognized by Babylon. Henceforth known as `Unbonding
 Output`.
 
@@ -138,29 +138,29 @@ finality provider they have delegated to) perform an offense.
 
 The requirements for a valid slashing transaction are:
 
-- it must have exactly one input pointing to either the staking output or the
-  unbonding output
-- it must have exactly two outputs, the first sending the slashed fraction of
-  the funds to a burn address specified in the Babylon chain's parameters and the
-  second sending the remaining funds to output which can be unlocked by staker
-  after the timelock
-- the fee for the slashing transactions must be larger than or equal to the
+- It must have exactly one input pointing to either the staking output or the
+  unbonding output.
+- It must have exactly two outputs, the first sending the slashed fraction of
+  the funds to a burn address specified in the Babylon chain's parameters, and the
+  second sending the remaining funds to an output which can be unlocked by the staker
+  after the timelock.
+- The fee for the slashing transactions must be larger than or equal to the
   minimal fee specified in Babylon's parameters
 
 ## Staking and Unbonding output scripts
 
-In the below scripts, there are three entities, each represented by BTC public
+In the scripts below, there are three entities, each represented by a BTC public
 key:
 
-- `StakerPK` - BTC staker public key
-- `FinalityProviderPk` - finality provider public key
+- `StakerPK` - BTC staker public key.
+- `FinalityProviderPk` - finality provider public key.
 - `CovenantPk1..CovenantPkN` - public keys of covenant committee members
 There must be no duplicated public keys in created scripts.
-For example, `StakerPK` must never be equal to `FinalityProviderPk`
+For example, `StakerPK` must never be equal to `FinalityProviderPk`.
 
 ### Staking output
 
-The staking output is a taproot output which can only be spent through a script
+The staking output is a Taproot output which can only be spent through a script
 spending path.
 The key spending path is disabled by using the "Nothing Up My Sleeve"
 (NUMS) point as internal key. Chosen point is the one described in
@@ -214,7 +214,7 @@ where:
 
 Signatures from a quorum of the covenant committee are required to ensure that
 this script is not used for on-demand unlocking without the stake going through
-an unbonding period. reward all covenant members for their work.
+an unbonding period. Reward all covenant members for their work.
 
 #### 3. Slashing path
 
@@ -230,11 +230,11 @@ delegators in the case of double signing. It commits to a script:
 
 where:
 
-- `StakerPK` is the BTC staker's public key
+- `StakerPK` is the BTC staker's public key.
 - `FinalityProviderPk` is the BTC public key of the finality provider to which
   the staker delegates their stake
 - `CovenantPk1..CovenantPkN` are the lexicographically sorted public keys of the
-  current covenant committee members recognized by the Babylon chain
+  current covenant committee members recognized by the Babylon chain.
 - `CovenantThreshold` is a Babylon parameter denoting how many covenant
   committee member signatures are required.
 
@@ -242,9 +242,9 @@ This path can only be executed with the collaboration of the BTC staker,
 finality provider, and covenant committee.
 It is used in following way:
 
-- for stake to become active, staker must publish pre signed slashing transaction
-- covenant committee validates such transaction, and publish its own signatures.
-- the only signature missing to send slashing transaction is finality provider
+- For stake to become active, staker must publish pre-signed slashing transaction.
+- The covenant committee validates such transaction, and publish its own signatures.
+- The only signature missing to send the slashing transaction is finality provider
   signature. If finality provider private key leaks due to infractions, anyone can
   sign slashing transaction and send slashing transaction to Bitcoin network.
 
@@ -255,21 +255,21 @@ The main difference between the unbonding and slashing paths is the existence of
 
 This leads to following system wide repercussions:
 
-- for staking request to become active, btc staker needs to provide valid
+- For staking request to become active, btc staker needs to provide valid
   unbonding transaction in this staking request. This staking request will become
-  active only when `CovenantThreshold` signatures will be received by Babylon
-  chain. Lack of `FinalityProviderPk` in unbonding path, means that after
-  delegation becomes active, staker can send unbonding transaction any time
-  without asking finality provider for permission.
-- existence of `FinalityProviderPk` in slashing path, coupled with the fact that
-  btc staker needs to provide pre-signed slashing transaction which needs to be
+  active only when the `CovenantThreshold` signatures are received by the Babylon
+  chain. The lack of `FinalityProviderPk` in the unbonding path, means that after
+  delegation becomes active, staker can send an unbonding transaction at any time
+  without asking the finality provider for permission.
+- The existence of `FinalityProviderPk` in the slashing path, coupled with the fact that
+  BTC staker needs to provide pre-signed slashing transaction which needs to be
   signed by covenant committee for delegation request to become active, leads to
   situation in which the only signature missing to send slashing transaction to
-  btc is signature of finality provider.
+  BTC is signature of finality provider.
 
 ### Unbonding output
 
-Unbonding output is a taproot output which can be only spent through script
+Unbonding output is a Taproot output which can be only spent through script
 spending path. The key spending path is disabled by using "Nothing Up My Sleeve"
 (NUMS) point as internal key. Chosen point is the one described in BIP341 i.e H
 = lift_x(0x50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0)
@@ -289,7 +289,7 @@ Bitcoin blocks. It commits to a script of the form:
 
 where:
 
-- `<StakerPK>` is btc staker public key
+- `<StakerPK>` is BTC staker public key.
 - `<TimelockBlocks>` is unbonding time. It must be lower or equal 65535, but larger
   than `max(MinUnbondingTime, CheckpointFinalizationTimeout)`. `MinUnbondingTime`
   and `CheckpointFinalizationTimeout` are Babylon parameters.
@@ -308,16 +308,16 @@ delegators in the case of double signing. It commits to a script:
 
 where:
 
-- `StakerPK` is the BTC staker's public key
+- `StakerPK` is the BTC staker's public key.
 - `FinalityProviderPk` is the BTC public key of the finality provider to which
-  the staker delegates their stake
+  the staker delegates their stake.
 - `CovenantPk1..CovenantPkN` are the lexicographically sorted public keys of the
-  current covenant committee members recognized by the Babylon chain
+  current covenant committee members recognized by the Babylon chain.
 - `CovenantThreshold` is a Babylon parameter denoting how many covenant
   committee member signatures are required.
 
 #### Existence of Slashing path in Unbonding output
 
 The fact that slashing path exists in unbonding output means that even if staker
-is unbonding he can be slashed if finality provider commits infraction during
+is unbonding, he can be slashed if the finality provider commits an infraction during
 unbonding time.

--- a/docs/transaction-impl-spec.md
+++ b/docs/transaction-impl-spec.md
@@ -9,10 +9,10 @@ the Bitcoin transactions specified by the Bitcoin Staking protocol.
 
 ## Prerequisites
 
-- [Scripts doc](staking-script.md) - document which defines how different
+- [Scripts doc](staking-script.md) -a document which defines how different
 Bitcoin Staking scripts look like
 - [BIP341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)-
-a document specifying how to spend taproot outputs
+a document specifying how to spend Taproot outputs
 
 ## System parameters
 
@@ -50,7 +50,7 @@ This key is described in the
 [BIP341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs)
 specification.
 
-The use of this key as an internal public key disables spending from taproot output
+The use of this key as an internal public key disables spending from Taproot output
 through the key spending path.
 The construction of this key can be found [here](../btcstaking/types.go?plain=1#L27).
 
@@ -64,14 +64,14 @@ which locks Bitcoin in the Bitcoin Staking script.
 #### Requirements
 
 For the transaction to be considered a valid staking transaction, it must:
-- have a taproot output which has the key spending path disabled
+- Have a Taproot output which has the key spending path disabled
 and commits to a script tree composed of three scripts::
 timelock script, unbonding script, slashing script.
 This output is henceforth known as the `staking_output` and
 the value in this output is known as `staking_amount`
-- have `OP_RETURN` output which contains: `global_parameters.tag`,
- `version`, `staker_pk`,`finality_provider_pk`, `staking_time`
-- all the values must be valid for the `global_parameters` which are applicable at
+- Have `OP_RETURN` output which contains: `global_parameters.tag`,
+ `version`, `staker_pk`, `finality_provider_pk`, `staking_time`
+- All the values must be valid for the `global_parameters` which are applicable at
 the height in which the staking transaction is included in the BTC ledger.
 
 
@@ -91,17 +91,17 @@ type V0OpReturnData struct {
 The implementation of the struct can be found [here](../btcstaking/identifiable_staking.go?pain=1#L52)
 
 Fields description:
-- `Tag` - 4 bytes, tag which is used to identify the staking transaction
+- `Tag` - 4 bytes, a tag which is used to identify the staking transaction
 among other transactions in the Bitcoin ledger.
 It is specified in the `global_parameters.Tag` field.
-- `Version` - 1 byte, current version of the OP_RETURN output
+- `Version` - 1 byte, the current version of the OP_RETURN output.
 - `StakerPublicKey` - 32 bytes, staker public key. The same key must be used in
-the scripts used to create the taproot output in the staking transaction.
+the scripts used to create the Taproot output in the staking transaction.
 - `FinalityProviderPublicKey` - 32 bytes, finality provider public key. The same key
-must be used in the scripts used to create the taproot output in the
+must be used in the scripts used to create the Taproot output in the
 staking transaction.
 - `StakingTime` - 2 bytes big-endian unsigned number, staking time.
-The same timelock time must be used in scripts used to create the taproot
+The same timelock time must be used in scripts used to create the Taproot
 output in the staking transaction.
 
 
@@ -117,8 +117,8 @@ StakingDataPkScript = 0x6a || 0x47 || SerializedStakingData
 ```
 
 where:
-- 0x6a - is byte marker representing OP_RETURN op code
-- 0x47 - is byte marker representing OP_DATA_71 op code, which pushed 71 bytes onto the stack
+- 0x6a - is byte marker representing OP_RETURN op code.
+- 0x47 - is byte marker representing OP_DATA_71 op code, which pushed 71 bytes onto the stack.
 
 The final OP_RETURN output will have the following shape:
 ```
@@ -143,21 +143,21 @@ Data needed to create `staking_output`:
 will be used in every script. This key needs to be put in the OP_RETURN output
 in the staking transaction.
 - `finality_provider_public_key` - chosen by the user sending the staking
-transaction. It will be used as `<FinalityPk>` in `slashing_script`. In the
-lock-only network there is no slashing, so this key has mostly informative purposes.
+transaction. It will be used as `<FinalityPk>` in the `slashing_script`. In the
+lock-only network, there is no slashing, so this key has mostly informative purposes.
 This key needs to be put in the OP_RETURN output of the staking transaction.
 - `staking_time` - chosen by the user sending the staking transaction. It will
-be used as locking time in the `timelock_script`. It must be a valid `uint16` number,
+be used as the locking time in the `timelock_script`. It must be a valid `uint16` number,
 in the range `global_parameters.min_staking_time <= staking_time <= global_parameters.max_staking_time`.
 It needs to be put in the OP_RETURN output of the staking transaction.
 - `covenant_committee_public_keys` - it can be retrieved from
-`global_parameters.covenant_pks`. It is set of covenant committee public keys which
+`global_parameters.covenant_pks`. It is a set of covenant committee public keys which
 will be put in `unbonding_script` and `slashing_script`.
 - `covenant_committee_quorum` - it can be retrieved from
-`global_parameters.covenant_quorum`. It is quorum of covenant committee
-member required to authorize spending using `unbonding_script` or `slashing_script`
-- `staking_amout` - chosen by the user, it will be placed in `staking_output.value`
-- `btc_network` - btc network on which staking transactions will take place
+`global_parameters.covenant_quorum`. It is the quorum of covenant committee
+members required to authorize spending using the `unbonding_script` or `slashing_script`.
+- `staking_amout` - chosen by the user, it will be placed in `staking_output.value`.
+- `btc_network` - the BTC network on which staking transactions will take place.
 
 #### Building OP_RETURN and staking output implementation
 
@@ -182,16 +182,16 @@ staking transaction.
 
 The suggested way of creating and sending a staking transaction using
 [bitcoind](https://github.com/bitcoin/bitcoin) is:
-1. create `staker_key` in the bitcoind wallet
-2. create unfunded and not signed staking transaction using
-the `BuildV0IdentifiableStakingOutputsAndTx` function
-3. serialize the unfunded and not signed staking transaction to `staking_transaction_hex`
-4. call `bitcoin-cli fundrawtransaction "staking_transaction_hex"` to
+1. Create `staker_key` in the bitcoind wallet.
+2. Create unfunded and not signed staking transaction using
+the `BuildV0IdentifiableStakingOutputsAndTx` function.
+3. Serialize the unfunded and not signed staking transaction to `staking_transaction_hex`.
+4. Call `bitcoin-cli fundrawtransaction "staking_transaction_hex"` to
 retrieve `funded_staking_transaction_hex`.
 The bitcoind wallet will automatically choose unspent outputs to fund this transaction.
-5. call `bitcoin-cli signrawtransactionwithwallet "funded_staking_transaction_hex"`.
+5. Call `bitcoin-cli signrawtransactionwithwallet "funded_staking_transaction_hex"`.
 This call will sign all inputs of the transaction and return `signed_staking_transaction_hex`.
-6. call `bitcoin-cli sendrawtransaction "signed_staking_transaction_hex"`
+6. Call `bitcoin-cli sendrawtransaction "signed_staking_transaction_hex"`.
 
 ### Unbonding transaction
 
@@ -201,14 +201,14 @@ locked Bitcoin stake prior to its original timelock expiration.
 #### Requirements
 
 For the transaction to be considered a valid unbonding transaction, it must:
-- have exactly one input and one output
-- input must be valid a staking output
-- output must be a taproot output. This taproot output must have disabled
+- Have exactly one input and one output.
+- Input must be a valid staking output.
+- Output must be a Taproot output. This Taproot output must have disabled
 the key spending path, and committed to script tree composed of two scripts:
 the timelock script and the slashing script. This output is henceforth known
-as the `unbonding_output`
-- timelock in the time lock script must be equal to `global_parameters.unbonding_time`
-- value in the unbonding output must be equal to `staking_output.value - global_parameters.unbonding_fee`
+as the `unbonding_output`.
+- Timelock in the timelock script must be equal to `global_parameters.unbonding_time`.
+- Value in the unbonding output must be equal to `staking_output.value - global_parameters.unbonding_fee`.
 
 #### Building Unbonding output
 
@@ -230,23 +230,23 @@ func BuildUnbondingInfo(
 ```
 
 where:
-- `stakerKey`- must be the same key as the staker key in `staking_transaction`
+- `stakerKey`- must be the same key as the staker key in `staking_transaction`.
 - `fpKeys` - must contain one key, which is the same finality provider key used
-in `staking_transaction`
-- `covenantKeys`- are the same covenant keys as used in `staking_transaction`
-- `covenantQuorum` - is the same quorum as used in `staking_transaction`
-- `unbondingTime` - is equal to `global_parameters.unbonding_time`
-- `unbondingAmount` - is equal to `staking_amount - global_parameters.unbonding_fee`
+in `staking_transaction`.
+- `covenantKeys`- are the same covenant keys as used in `staking_transaction`.
+- `covenantQuorum` - is the same quorum as used in `staking_transaction`.
+- `unbondingTime` - is equal to `global_parameters.unbonding_time`.
+- `unbondingAmount` - is equal to `staking_amount - global_parameters.unbonding_fee`.
 
-## Spending taproot outputs
+## Spending Taproot outputs
 
-To create transactions which spend from taproot outputs, either staking output
+To create transactions which spend from Taproot outputs, either staking output
 or unbonding output, providing signatures satisfying the script is not enough.
 
 The spender must also provide:
-- the whole script which is being spent
-- the control block which contains: leaf version, internal public key, and proof of
-inclusion of the given script in the script tree
+- The whole script which is being spent.
+- The control block which contains: leaf version, internal public key, and proof of
+inclusion of the given script in the script tree.
 
 Given that creating scripts is deterministic for given data, it is possible to
 avoid storing scripts by re-building scripts when the need arises.
@@ -254,7 +254,7 @@ avoid storing scripts by re-building scripts when the need arises.
 ### Re-creating script and control block
 
 To build the script and control block necessary to spend from a staking output through the
-timelock script, the following function could be implemented
+timelock script, the following function could be implemented.
 
 ```go
 import (
@@ -309,7 +309,7 @@ func buildTimelockScriptAndControlBlock(
 The returned script and control block can be used to either build the witness directly
 or to put them in a PSBT which can be used by bitcoind to create the witness.
 
-### Creating PSBT to get signature for given taproot path from Bitcoind
+### Creating PSBT to get signature for given Taproot path from Bitcoind
 
 To avoid creating signatures/witness manually,
 Bitcoind's [walletprocesspsbt](https://developer.bitcoin.org/reference/rpc/walletprocesspsbt.html)


### PR DESCRIPTION
Corrected typos and grammatical mistakes in multiple documentation files. These changes are intended to enhance the overall quality and readability of the documentation, making it easier for users and contributors to understand and follow.

