### PR TITLE
fix: Epoch initial height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Bug Fixes
+
+* [#93](https://github.com/babylonlabs-io/babylon/pull/93) fix genesis epoch
+  initialization.
+
 ## v0.10.0
 
 ### State Machine Breaking

--- a/x/checkpointing/keeper/grpc_query_bls_test.go
+++ b/x/checkpointing/keeper/grpc_query_bls_test.go
@@ -34,7 +34,7 @@ func FuzzQueryBLSKeySet(f *testing.F) {
 		types.RegisterQueryServer(queryHelper, ck)
 		queryClient := types.NewQueryClient(queryHelper)
 		msgServer := checkpointingkeeper.NewMsgServerImpl(ck)
-		genesisVal := ek.GetValidatorSet(helper.Ctx, 0)[0]
+		genesisVal := ek.GetValidatorSet(helper.Ctx, 1)[0]
 		genesisBLSPubkey, err := ck.GetBlsPubKey(helper.Ctx, genesisVal.Addr)
 		require.NoError(t, err)
 

--- a/x/checkpointing/keeper/val_bls_set_test.go
+++ b/x/checkpointing/keeper/val_bls_set_test.go
@@ -28,7 +28,7 @@ func FuzzGetValidatorBlsKeySet(f *testing.F) {
 		queryHelper := baseapp.NewQueryServerTestHelper(helper.Ctx, helper.App.InterfaceRegistry())
 		types.RegisterQueryServer(queryHelper, ck)
 		msgServer := checkpointingkeeper.NewMsgServerImpl(ck)
-		genesisVal := ek.GetValidatorSet(helper.Ctx, 0)[0]
+		genesisVal := ek.GetValidatorSet(helper.Ctx, 1)[0]
 		genesisBLSPubkey, err := ck.GetBlsPubKey(helper.Ctx, genesisVal.Addr)
 		require.NoError(t, err)
 

--- a/x/epoching/keeper/epoch_val_set_test.go
+++ b/x/epoching/keeper/epoch_val_set_test.go
@@ -23,7 +23,7 @@ func FuzzEpochValSet(f *testing.F) {
 		ctx, keeper := helper.Ctx, helper.App.EpochingKeeper
 		valSet, err := helper.App.StakingKeeper.GetLastValidators(helper.Ctx)
 		require.NoError(t, err)
-		getValSet := keeper.GetValidatorSet(ctx, 0)
+		getValSet := keeper.GetValidatorSet(ctx, 1)
 		require.Equal(t, len(valSet), len(getValSet))
 		for i := range getValSet {
 			consAddr, err := valSet[i].GetConsAddr()
@@ -37,7 +37,7 @@ func FuzzEpochValSet(f *testing.F) {
 		params := keeper.GetParams(ctx)
 
 		// generate a random number of new blocks
-		for i := uint64(0); i < params.EpochInterval; i++ {
+		for i := uint64(1); i < params.EpochInterval; i++ {
 			ctx, err = helper.ApplyEmptyBlockWithVoteExtension(r)
 			require.NoError(t, err)
 		}

--- a/x/epoching/keeper/epochs.go
+++ b/x/epoching/keeper/epochs.go
@@ -37,10 +37,13 @@ func (k Keeper) InitEpoch(ctx context.Context) *types.Epoch {
 	if header.Height > 0 {
 		panic("InitEpoch can be invoked only at genesis")
 	}
+	genesisEpoch := types.NewEpoch(0, 1, 0, &header.Time)
+	k.setEpochInfo(ctx, 0, &genesisEpoch)
 	epochInterval := k.GetParams(ctx).EpochInterval
-	epoch := types.NewEpoch(0, epochInterval, 0, &header.Time)
-	k.setEpochInfo(ctx, 0, &epoch)
-	return &epoch
+	firstEpoch := types.NewEpoch(1, epochInterval, 1, &header.Time)
+	k.setEpochInfo(ctx, 1, &firstEpoch)
+
+	return &genesisEpoch
 }
 
 // GetEpoch fetches the current epoch

--- a/x/epoching/keeper/epochs.go
+++ b/x/epoching/keeper/epochs.go
@@ -39,9 +39,6 @@ func (k Keeper) InitEpoch(ctx context.Context) *types.Epoch {
 	}
 	genesisEpoch := types.NewEpoch(0, 1, 0, &header.Time)
 	k.setEpochInfo(ctx, 0, &genesisEpoch)
-	epochInterval := k.GetParams(ctx).EpochInterval
-	firstEpoch := types.NewEpoch(1, epochInterval, 1, &header.Time)
-	k.setEpochInfo(ctx, 1, &firstEpoch)
 
 	return &genesisEpoch
 }


### PR DESCRIPTION
When we initialize epoch, we should also initialize epoch 1. Otherwise, epoch 0 will be accessed