### PR TITLE
chore: release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
+* [#91](https://github.com/babylonlabs-io/babylon/pull/91) fix testnet command
+by add ibc default gen state and min gas price specification of `1ubbn`
 * [#93](https://github.com/babylonlabs-io/babylon/pull/93) fix genesis epoch
   initialization.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+## v0.10.1
+
 ### Bug Fixes
 
 * [#91](https://github.com/babylonlabs-io/babylon/pull/91) fix testnet command


### PR DESCRIPTION
After this is merged into `release/v0.10.x`, a new tag will be released 