### PR TITLE
feat(ADR-028): refunding transaction fee for certain txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### State Machine Breaking
 
+* [#125](https://github.com/babylonlabs-io/babylon/pull/125) Implement ADR-028 and
+refund transaction fee for certain transactions from protocol stakeholders
 * [#107](https://github.com/babylonlabs-io/babylon/pull/107) Implement ADR-027 and
 enable in-protocol minimum gas price
 * [#103](https://github.com/babylonlabs-io/babylon/pull/103) Add token distribution

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,6 @@ mockgen_cmd=go run github.com/golang/mock/mockgen@v1.6.0
 mocks: $(MOCKS_DIR) ## Generate mock objects for testing
 	$(mockgen_cmd) -source=x/checkpointing/types/expected_keepers.go -package mocks -destination testutil/mocks/checkpointing_expected_keepers.go
 	$(mockgen_cmd) -source=x/checkpointing/keeper/bls_signer.go -package mocks -destination testutil/mocks/bls_signer.go
-	$(mockgen_cmd) -source=x/zoneconcierge/types/expected_keepers.go -package types -destination x/zoneconcierge/types/mocked_keepers.go
 	$(mockgen_cmd) -source=x/btcstaking/types/expected_keepers.go -package types -destination x/btcstaking/types/mocked_keepers.go
 	$(mockgen_cmd) -source=x/finality/types/expected_keepers.go -package types -destination x/finality/types/mocked_keepers.go
 	$(mockgen_cmd) -source=x/incentive/types/expected_keepers.go -package types -destination x/incentive/types/mocked_keepers.go

--- a/app/app.go
+++ b/app/app.go
@@ -111,6 +111,7 @@ import (
 	"github.com/babylonlabs-io/babylon/x/finality"
 	finalitytypes "github.com/babylonlabs-io/babylon/x/finality/types"
 	"github.com/babylonlabs-io/babylon/x/incentive"
+	incentivekeeper "github.com/babylonlabs-io/babylon/x/incentive/keeper"
 	incentivetypes "github.com/babylonlabs-io/babylon/x/incentive/types"
 	"github.com/babylonlabs-io/babylon/x/monitor"
 	monitortypes "github.com/babylonlabs-io/babylon/x/monitor/types"
@@ -512,6 +513,12 @@ func NewBabylonApp(
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
 	app.SetAnteHandler(anteHandler)
+
+	// set postHandler
+	postHandler := sdk.ChainPostDecorators(
+		incentivekeeper.NewRefundTxDecorator(&app.IncentiveKeeper),
+	)
+	app.SetPostHandler(postHandler)
 
 	// must be before Loading version
 	// requires the snapshot store to be created and registered as a BaseAppOption

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -432,6 +432,7 @@ func (ak *AppKeepers) InitKeepers(
 		appCodec,
 		runtime.NewKVStoreService(keys[btclightclienttypes.StoreKey]),
 		*btcConfig,
+		&ak.IncentiveKeeper,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -498,6 +498,7 @@ func (ak *AppKeepers) InitKeepers(
 		// setting the finality keeper as nil for now
 		// need to set it after finality keeper is initiated
 		nil,
+		&ak.IncentiveKeeper,
 		btcNetParams,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)

--- a/test/e2e/btc_staking_e2e_test.go
+++ b/test/e2e/btc_staking_e2e_test.go
@@ -239,7 +239,7 @@ func (s *BTCStakingTestSuite) Test2SubmitCovenantSignature() {
 			)
 			// wait for a block so that above txs take effect
 			nonValidatorNode.WaitForNextBlock()
-		})
+		}, true)
 	}
 
 	// wait for a block so that above txs take effect
@@ -362,7 +362,7 @@ func (s *BTCStakingTestSuite) Test3CommitPublicRandomnessAndSubmitFinalitySignat
 		s.Equal(activatedHeight, finalizedBlocks[0].Height)
 		s.Equal(appHash.Bytes(), finalizedBlocks[0].AppHash)
 		s.T().Logf("the block %d is finalized", activatedHeight)
-	})
+	}, true)
 
 	// ensure finality provider has received rewards after the block is finalised
 	fpRewardGauges, err := nonValidatorNode.QueryRewardGauge(fpBabylonAddr)
@@ -474,7 +474,7 @@ func (s *BTCStakingTestSuite) Test5SubmitStakerUnbonding() {
 		nonValidatorNode.BTCUndelegate(&stakingTxHash, delUnbondingSig)
 		// wait for a block so that above txs take effect
 		nonValidatorNode.WaitForNextBlock()
-	})
+	}, true)
 
 	// Wait for unbonded delegations to be created
 	var unbondedDelsResp []*bstypes.BTCDelegationResponse

--- a/test/e2e/btc_staking_e2e_test.go
+++ b/test/e2e/btc_staking_e2e_test.go
@@ -237,9 +237,9 @@ func (s *BTCStakingTestSuite) Test2SubmitCovenantSignature() {
 				bbn.NewBIP340SignatureFromBTCSig(covUnbondingSigs[i]),
 				covenantUnbondingSlashingSigs[i].AdaptorSigs,
 			)
+			// wait for a block so that above txs take effect
+			nonValidatorNode.WaitForNextBlock()
 		})
-		// wait for a block so that above txs take effect
-		nonValidatorNode.WaitForNextBlock()
 	}
 
 	// wait for a block so that above txs take effect
@@ -352,17 +352,17 @@ func (s *BTCStakingTestSuite) Test3CommitPublicRandomnessAndSubmitFinalitySignat
 	nonValidatorNode.SubmitRefundableTxWithAssertion(func() {
 		// submit finality signature
 		nonValidatorNode.AddFinalitySig(s.cacheFP.BtcPk, activatedHeight, &randListInfo.PRList[idx], *randListInfo.ProofList[idx].ToProto(), appHash, eotsSig)
-	})
 
-	// ensure vote is eventually cast
-	var finalizedBlocks []*ftypes.IndexedBlock
-	s.Eventually(func() bool {
-		finalizedBlocks = nonValidatorNode.QueryListBlocks(ftypes.QueriedBlockStatus_FINALIZED)
-		return len(finalizedBlocks) > 0
-	}, time.Minute, time.Millisecond*50)
-	s.Equal(activatedHeight, finalizedBlocks[0].Height)
-	s.Equal(appHash.Bytes(), finalizedBlocks[0].AppHash)
-	s.T().Logf("the block %d is finalized", activatedHeight)
+		// ensure vote is eventually cast
+		var finalizedBlocks []*ftypes.IndexedBlock
+		s.Eventually(func() bool {
+			finalizedBlocks = nonValidatorNode.QueryListBlocks(ftypes.QueriedBlockStatus_FINALIZED)
+			return len(finalizedBlocks) > 0
+		}, time.Minute, time.Millisecond*50)
+		s.Equal(activatedHeight, finalizedBlocks[0].Height)
+		s.Equal(appHash.Bytes(), finalizedBlocks[0].AppHash)
+		s.T().Logf("the block %d is finalized", activatedHeight)
+	})
 
 	// ensure finality provider has received rewards after the block is finalised
 	fpRewardGauges, err := nonValidatorNode.QueryRewardGauge(fpBabylonAddr)
@@ -472,9 +472,9 @@ func (s *BTCStakingTestSuite) Test5SubmitStakerUnbonding() {
 	nonValidatorNode.SubmitRefundableTxWithAssertion(func() {
 		// submit the message for creating BTC undelegation
 		nonValidatorNode.BTCUndelegate(&stakingTxHash, delUnbondingSig)
+		// wait for a block so that above txs take effect
+		nonValidatorNode.WaitForNextBlock()
 	})
-	// wait for a block so that above txs take effect
-	nonValidatorNode.WaitForNextBlock()
 
 	// Wait for unbonded delegations to be created
 	var unbondedDelsResp []*bstypes.BTCDelegationResponse

--- a/test/e2e/configurer/chain/commands.go
+++ b/test/e2e/configurer/chain/commands.go
@@ -235,10 +235,10 @@ func (n *NodeConfig) FinalizeSealedEpochs(startEpoch uint64, lastEpoch uint64) {
 		n.SubmitRefundableTxWithAssertion(func() {
 			n.InsertHeader(&opReturn1.HeaderBytes)
 			n.InsertHeader(&opReturn2.HeaderBytes)
-		})
+		}, true)
 		n.SubmitRefundableTxWithAssertion(func() {
 			n.InsertProofs(opReturn1.SpvProof, opReturn2.SpvProof)
-		})
+		}, true)
 
 		n.WaitForCondition(func() bool {
 			ckpt, err := n.QueryRawCheckpoint(checkpoint.Ckpt.EpochNum)
@@ -453,6 +453,7 @@ func (n *NodeConfig) TxGovVote(from string, propID int, option govv1.VoteOption,
 // and asserts that the tx fee is refunded
 func (n *NodeConfig) SubmitRefundableTxWithAssertion(
 	f func(),
+	shouldBeRefunded bool,
 ) {
 	// balance before submitting the refundable tx
 	submitterBalanceBefore, err := n.QueryBalances(n.PublicAddress)
@@ -464,5 +465,9 @@ func (n *NodeConfig) SubmitRefundableTxWithAssertion(
 	// ensure the tx fee is refunded and the balance is not changed
 	submitterBalanceAfter, err := n.QueryBalances(n.PublicAddress)
 	require.NoError(n.t, err)
-	require.Equal(n.t, submitterBalanceBefore, submitterBalanceAfter)
+	if shouldBeRefunded {
+		require.Equal(n.t, submitterBalanceBefore, submitterBalanceAfter)
+	} else {
+		require.True(n.t, submitterBalanceBefore.IsAllGT(submitterBalanceAfter))
+	}
 }

--- a/test/e2e/configurer/chain/commands.go
+++ b/test/e2e/configurer/chain/commands.go
@@ -232,9 +232,10 @@ func (n *NodeConfig) FinalizeSealedEpochs(startEpoch uint64, lastEpoch uint64) {
 		tx2 := datagen.CreatOpReturnTransaction(r, p2)
 		opReturn2 := datagen.CreateBlockWithTransaction(r, opReturn1.HeaderBytes.ToBlockHeader(), tx2)
 
-		n.InsertHeader(&opReturn1.HeaderBytes)
-		n.InsertHeader(&opReturn2.HeaderBytes)
-
+		n.SubmitRefundableTxWithAssertion(func() {
+			n.InsertHeader(&opReturn1.HeaderBytes)
+			n.InsertHeader(&opReturn2.HeaderBytes)
+		})
 		n.SubmitRefundableTxWithAssertion(func() {
 			n.InsertProofs(opReturn1.SpvProof, opReturn2.SpvProof)
 		})

--- a/test/e2e/configurer/chain/commands_btcstaking.go
+++ b/test/e2e/configurer/chain/commands_btcstaking.go
@@ -150,7 +150,7 @@ func (n *NodeConfig) AddCovenantSigs(covPK *bbn.BIP340PubKey, stakingTxHash stri
 	// used key
 	cmd = append(cmd, "--from=val")
 	// gas
-	cmd = append(cmd, "--gas=auto", "--gas-adjustment=1.3")
+	cmd = append(cmd, "--gas=auto", "--gas-adjustment=2")
 
 	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
 	require.NoError(n.t, err)

--- a/testutil/keeper/btclightclient.go
+++ b/testutil/keeper/btclightclient.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"context"
 	"testing"
 
 	"cosmossdk.io/core/header"
@@ -26,6 +27,10 @@ import (
 	btclightclientt "github.com/babylonlabs-io/babylon/x/btclightclient/types"
 )
 
+type MockIncentiveKeeper struct{}
+
+func (mik MockIncentiveKeeper) IndexRefundableMsg(ctx context.Context, msg sdk.Msg) {}
+
 func BTCLightClientKeeper(t testing.TB) (*btclightclientk.Keeper, sdk.Context) {
 	k, ctx, _ := BTCLightClientKeeperWithCustomParams(t, btclightclientt.DefaultParams())
 	return k, ctx
@@ -40,7 +45,10 @@ func NewBTCHeaderBytesList(chain []*wire.BlockHeader) []bbn.BTCHeaderBytes {
 	return chainBytes
 }
 
-func BTCLightClientKeeperWithCustomParams(t testing.TB, p btclightclientt.Params) (*btclightclientk.Keeper, sdk.Context, corestore.KVStoreService) {
+func BTCLightClientKeeperWithCustomParams(
+	t testing.TB,
+	p btclightclientt.Params,
+) (*btclightclientk.Keeper, sdk.Context, corestore.KVStoreService) {
 	storeKey := storetypes.NewKVStoreKey(btclightclientt.StoreKey)
 
 	db := dbm.NewMemDB()
@@ -52,12 +60,12 @@ func BTCLightClientKeeperWithCustomParams(t testing.TB, p btclightclientt.Params
 	cdc := codec.NewProtoCodec(registry)
 
 	testCfg := bbn.ParseBtcOptionsFromConfig(bapp.TmpAppOptions())
-
 	stServ := runtime.NewKVStoreService(storeKey)
 	k := btclightclientk.NewKeeper(
 		cdc,
 		stServ,
 		testCfg,
+		&MockIncentiveKeeper{},
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 

--- a/testutil/keeper/btcstaking.go
+++ b/testutil/keeper/btcstaking.go
@@ -28,6 +28,7 @@ func BTCStakingKeeper(
 	btclcKeeper types.BTCLightClientKeeper,
 	btccKeeper types.BtcCheckpointKeeper,
 	finalityKeeper types.FinalityKeeper,
+	iKeeper types.IncentiveKeeper,
 ) (*keeper.Keeper, sdk.Context) {
 	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
 
@@ -45,6 +46,7 @@ func BTCStakingKeeper(
 		btclcKeeper,
 		btccKeeper,
 		finalityKeeper,
+		iKeeper,
 		&chaincfg.SimNetParams,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)

--- a/x/btccheckpoint/keeper/msg_server.go
+++ b/x/btccheckpoint/keeper/msg_server.go
@@ -22,7 +22,7 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 }
 
 // TODO at some point add proper logging of error
-// TODO emit some events for external consumers. Those should be probably emited
+// TODO emit some events for external consumers. Those should be probably emitted
 // at EndBlockerCallback
 func (ms msgServer) InsertBTCSpvProof(ctx context.Context, req *types.MsgInsertBTCSpvProof) (*types.MsgInsertBTCSpvProofResponse, error) {
 
@@ -92,7 +92,8 @@ func (ms msgServer) InsertBTCSpvProof(ctx context.Context, req *types.MsgInsertB
 		return nil, err
 	}
 
-	// At this point, the BTC checkpoint is considered the first valid one for the epoch.
+	// At this point, the BTC checkpoint is considered the first valid submission
+	// for the epoch.
 	// Thus, we can safely consider this message as refundable
 	ms.k.incentiveKeeper.IndexRefundableMsg(sdkCtx, req)
 

--- a/x/btccheckpoint/keeper/msg_server.go
+++ b/x/btccheckpoint/keeper/msg_server.go
@@ -92,6 +92,10 @@ func (ms msgServer) InsertBTCSpvProof(ctx context.Context, req *types.MsgInsertB
 		return nil, err
 	}
 
+	// At this point, the BTC checkpoint is considered the first valid one for the epoch.
+	// Thus, we can safely consider this message as refundable
+	ms.k.incentiveKeeper.IndexRefundableMsg(sdkCtx, req)
+
 	return &types.MsgInsertBTCSpvProofResponse{}, nil
 }
 

--- a/x/btccheckpoint/types/expected_keepers.go
+++ b/x/btccheckpoint/types/expected_keepers.go
@@ -2,8 +2,10 @@ package types
 
 import (
 	"context"
+
 	txformat "github.com/babylonlabs-io/babylon/btctxformatter"
 	bbn "github.com/babylonlabs-io/babylon/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type BTCLightClientKeeper interface {
@@ -40,4 +42,5 @@ type CheckpointingKeeper interface {
 
 type IncentiveKeeper interface {
 	RewardBTCTimestamping(ctx context.Context, epoch uint64, rewardDistInfo *RewardDistInfo)
+	IndexRefundableMsg(ctx context.Context, msg sdk.Msg)
 }

--- a/x/btccheckpoint/types/mock_keepers.go
+++ b/x/btccheckpoint/types/mock_keepers.go
@@ -6,6 +6,7 @@ import (
 
 	txformat "github.com/babylonlabs-io/babylon/btctxformatter"
 	bbn "github.com/babylonlabs-io/babylon/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type MockBTCLightClientKeeper struct {
@@ -96,4 +97,7 @@ func (ck MockCheckpointingKeeper) SetCheckpointForgotten(ctx context.Context, ep
 }
 
 func (ik *MockIncentiveKeeper) RewardBTCTimestamping(ctx context.Context, epoch uint64, rewardDistInfo *RewardDistInfo) {
+}
+
+func (ik *MockIncentiveKeeper) IndexRefundableMsg(ctx context.Context, msg sdk.Msg) {
 }

--- a/x/btclightclient/keeper/keeper.go
+++ b/x/btclightclient/keeper/keeper.go
@@ -22,6 +22,7 @@ type (
 		cdc          codec.BinaryCodec
 		storeService corestoretypes.KVStoreService
 		hooks        types.BTCLightClientHooks
+		iKeeper      types.IncentiveKeeper
 		btcConfig    bbn.BtcConfig
 		bl           *types.BtcLightClient
 		authority    string
@@ -34,6 +35,7 @@ func NewKeeper(
 	cdc codec.BinaryCodec,
 	storeService corestoretypes.KVStoreService,
 	btcConfig bbn.BtcConfig,
+	iKeeper types.IncentiveKeeper,
 	authority string,
 ) Keeper {
 	bl := types.NewBtcLightClientFromParams(btcConfig.NetParams())
@@ -42,6 +44,7 @@ func NewKeeper(
 		cdc:          cdc,
 		storeService: storeService,
 		hooks:        nil,
+		iKeeper:      iKeeper,
 		btcConfig:    btcConfig,
 		bl:           bl,
 		authority:    authority,

--- a/x/btclightclient/keeper/msg_server.go
+++ b/x/btclightclient/keeper/msg_server.go
@@ -48,10 +48,16 @@ func (m msgServer) InsertHeaders(ctx context.Context, msg *types.MsgInsertHeader
 	}
 
 	err := m.k.InsertHeadersWithHookAndEvents(sdkCtx, msg.Headers)
-
 	if err != nil {
 		return nil, err
 	}
+
+	// At this point, the headers have been inserted, and the inserted
+	// headers extend the current chain or a fork that is longer than
+	// the current chain.
+	// Thus, we can safely consider this message as refundable
+	m.k.iKeeper.IndexRefundableMsg(sdkCtx, msg)
+
 	return &types.MsgInsertHeadersResponse{}, nil
 }
 

--- a/x/btclightclient/types/expected_keepers.go
+++ b/x/btclightclient/types/expected_keepers.go
@@ -2,10 +2,16 @@ package types
 
 import (
 	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type BTCLightClientHooks interface {
 	AfterBTCRollBack(ctx context.Context, headerInfo *BTCHeaderInfo)       // Must be called after the chain is rolled back
 	AfterBTCRollForward(ctx context.Context, headerInfo *BTCHeaderInfo)    // Must be called after the chain is rolled forward
 	AfterBTCHeaderInserted(ctx context.Context, headerInfo *BTCHeaderInfo) // Must be called after a header is inserted
+}
+
+type IncentiveKeeper interface {
+	IndexRefundableMsg(ctx context.Context, msg sdk.Msg)
 }

--- a/x/btcstaking/genesis_test.go
+++ b/x/btcstaking/genesis_test.go
@@ -17,7 +17,7 @@ func TestGenesis(t *testing.T) {
 		Params: []*types.Params{&p},
 	}
 
-	k, ctx := keepertest.BTCStakingKeeper(t, nil, nil, nil)
+	k, ctx := keepertest.BTCStakingKeeper(t, nil, nil, nil, nil)
 	btcstaking.InitGenesis(ctx, *k, genesisState)
 	got := btcstaking.ExportGenesis(ctx, *k)
 	require.NotNil(t, got)

--- a/x/btcstaking/keeper/btc_height_index_test.go
+++ b/x/btcstaking/keeper/btc_height_index_test.go
@@ -23,7 +23,7 @@ func FuzzBTCHeightIndex(f *testing.F) {
 
 		// mock BTC light client
 		btclcKeeper := types.NewMockBTCLightClientKeeper(ctrl)
-		keeper, ctx := keepertest.BTCStakingKeeper(t, btclcKeeper, nil, nil)
+		keeper, ctx := keepertest.BTCStakingKeeper(t, btclcKeeper, nil, nil, nil)
 
 		// randomise Babylon height and BTC height
 		babylonHeight := datagen.RandomInt(r, 100)

--- a/x/btcstaking/keeper/grpc_query_test.go
+++ b/x/btcstaking/keeper/grpc_query_test.go
@@ -29,7 +29,7 @@ func FuzzActivatedHeight(f *testing.F) {
 		r := rand.New(rand.NewSource(seed))
 
 		// Setup keeper and context
-		keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil)
+		keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil, nil)
 		ctx = sdk.UnwrapSDKContext(ctx)
 
 		// not activated yet
@@ -54,7 +54,7 @@ func FuzzFinalityProviders(f *testing.F) {
 		r := rand.New(rand.NewSource(seed))
 
 		// Setup keeper and context
-		keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil)
+		keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil, nil)
 		ctx = sdk.UnwrapSDKContext(ctx)
 
 		// Generate random finality providers and add them to kv store
@@ -119,7 +119,7 @@ func FuzzFinalityProvider(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
 		r := rand.New(rand.NewSource(seed))
 		// Setup keeper and context
-		keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil)
+		keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil, nil)
 		ctx = sdk.UnwrapSDKContext(ctx)
 
 		// Generate random finality providers and add them to kv store
@@ -175,7 +175,7 @@ func FuzzPendingBTCDelegations(f *testing.F) {
 		btclcKeeper := types.NewMockBTCLightClientKeeper(ctrl)
 		btccKeeper := types.NewMockBtcCheckpointKeeper(ctrl)
 		btccKeeper.EXPECT().GetParams(gomock.Any()).Return(btcctypes.DefaultParams()).AnyTimes()
-		keeper, ctx := testkeeper.BTCStakingKeeper(t, btclcKeeper, btccKeeper, nil)
+		keeper, ctx := testkeeper.BTCStakingKeeper(t, btclcKeeper, btccKeeper, nil, nil)
 
 		// covenant and slashing addr
 		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)
@@ -279,7 +279,7 @@ func FuzzFinalityProviderPowerAtHeight(f *testing.F) {
 		r := rand.New(rand.NewSource(seed))
 
 		// Setup keeper and context
-		keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil)
+		keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil, nil)
 
 		// random finality provider
 		fp, err := datagen.GenRandomFinalityProvider(r)
@@ -328,7 +328,7 @@ func FuzzFinalityProviderCurrentVotingPower(f *testing.F) {
 		r := rand.New(rand.NewSource(seed))
 
 		// Setup keeper and context
-		keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil)
+		keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil, nil)
 
 		// random finality provider
 		fp, err := datagen.GenRandomFinalityProvider(r)
@@ -380,7 +380,7 @@ func FuzzActiveFinalityProvidersAtHeight(f *testing.F) {
 		btclcKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: 10}).AnyTimes()
 		btccKeeper := types.NewMockBtcCheckpointKeeper(ctrl)
 		btccKeeper.EXPECT().GetParams(gomock.Any()).Return(btcctypes.DefaultParams()).AnyTimes()
-		keeper, ctx := testkeeper.BTCStakingKeeper(t, btclcKeeper, btccKeeper, nil)
+		keeper, ctx := testkeeper.BTCStakingKeeper(t, btclcKeeper, btccKeeper, nil, nil)
 
 		// covenant and slashing addr
 		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)
@@ -500,7 +500,7 @@ func FuzzFinalityProviderDelegations(f *testing.F) {
 		btclcKeeper := types.NewMockBTCLightClientKeeper(ctrl)
 		btccKeeper := types.NewMockBtcCheckpointKeeper(ctrl)
 		btccKeeper.EXPECT().GetParams(gomock.Any()).Return(btcctypes.DefaultParams()).AnyTimes()
-		keeper, ctx := testkeeper.BTCStakingKeeper(t, btclcKeeper, btccKeeper, nil)
+		keeper, ctx := testkeeper.BTCStakingKeeper(t, btclcKeeper, btccKeeper, nil, nil)
 
 		// covenant and slashing addr
 		covenantSKs, covenantPKs, covenantQuorum := datagen.GenCovenantCommittee(r)

--- a/x/btcstaking/keeper/keeper.go
+++ b/x/btcstaking/keeper/keeper.go
@@ -22,6 +22,7 @@ type (
 		btclcKeeper    types.BTCLightClientKeeper
 		btccKeeper     types.BtcCheckpointKeeper
 		FinalityKeeper types.FinalityKeeper
+		iKeeper        types.IncentiveKeeper
 
 		hooks types.BtcStakingHooks
 
@@ -39,6 +40,7 @@ func NewKeeper(
 	btclcKeeper types.BTCLightClientKeeper,
 	btccKeeper types.BtcCheckpointKeeper,
 	finalityKeeper types.FinalityKeeper,
+	iKeeper types.IncentiveKeeper,
 
 	btcNet *chaincfg.Params,
 	authority string,
@@ -50,6 +52,7 @@ func NewKeeper(
 		btclcKeeper:    btclcKeeper,
 		btccKeeper:     btccKeeper,
 		FinalityKeeper: finalityKeeper,
+		iKeeper:        iKeeper,
 
 		hooks: nil,
 

--- a/x/btcstaking/keeper/keeper_test.go
+++ b/x/btcstaking/keeper/keeper_test.go
@@ -46,11 +46,16 @@ func NewHelper(
 	btccKeeper *types.MockBtcCheckpointKeeper,
 	finalityKeeper *types.MockFinalityKeeper,
 ) *Helper {
-	k, ctx := keepertest.BTCStakingKeeper(t, btclcKeeper, btccKeeper, finalityKeeper)
+	ctrl := gomock.NewController(t)
+
+	// mock refundable messages
+	iKeeper := types.NewMockIncentiveKeeper(ctrl)
+	iKeeper.EXPECT().IndexRefundableMsg(gomock.Any(), gomock.Any()).AnyTimes()
+
+	k, ctx := keepertest.BTCStakingKeeper(t, btclcKeeper, btccKeeper, finalityKeeper, iKeeper)
 	ctx = ctx.WithHeaderInfo(header.Info{Height: 1})
 	msgSrvr := keeper.NewMsgServerImpl(*k)
 
-	ctrl := gomock.NewController(t)
 	mockedHooks := types.NewMockBtcStakingHooks(ctrl)
 	mockedHooks.EXPECT().AfterFinalityProviderActivated(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	k.SetHooks(mockedHooks)

--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -472,8 +472,10 @@ func (ms msgServer) AddCovenantSigs(goCtx context.Context, req *types.MsgAddCove
 
 	// at this point, the covenant signatures are verified and are not duplicated.
 	// Thus, we can safely consider this message as refundable
-	// TODO: currently we refund tx fee for covenant signatures even if the BTC
-	// delegation already has a covenant quorum. Should we refund in this case?
+	// NOTE: currently we refund tx fee for covenant signatures even if the BTC
+	// delegation already has a covenant quorum. This is to ensure that covenant
+	// members do not spend transaction fee, even if they submit covenant signatures
+	// late.
 	ms.iKeeper.IndexRefundableMsg(ctx, req)
 
 	return &types.MsgAddCovenantSigsResponse{}, nil

--- a/x/btcstaking/keeper/params_test.go
+++ b/x/btcstaking/keeper/params_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGetParams(t *testing.T) {
-	k, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil)
+	k, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil, nil)
 	params := types.DefaultParams()
 
 	err := k.SetParams(ctx, params)
@@ -23,7 +23,7 @@ func TestGetParams(t *testing.T) {
 }
 
 func TestGetParamsVersions(t *testing.T) {
-	k, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil)
+	k, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil, nil)
 	params := types.DefaultParams()
 
 	pv := k.GetParamsWithVersion(ctx)
@@ -56,7 +56,7 @@ func FuzzParamsVersioning(f *testing.F) {
 	datagen.AddRandomSeedsToFuzzer(f, 10)
 	f.Fuzz(func(t *testing.T, seed int64) {
 		r := rand.New(rand.NewSource(seed))
-		k, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil)
+		k, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil, nil)
 		numVersionsToGenerate := r.Intn(100) + 1
 		params0 := k.GetParams(ctx)
 		var generatedParams []*types.Params

--- a/x/btcstaking/keeper/query_params_test.go
+++ b/x/btcstaking/keeper/query_params_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestParamsQuery(t *testing.T) {
-	keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil)
+	keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil, nil)
 	params := types.DefaultParams()
 
 	err := keeper.SetParams(ctx, params)
@@ -22,7 +22,7 @@ func TestParamsQuery(t *testing.T) {
 }
 
 func TestParamsByVersionQuery(t *testing.T) {
-	keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil)
+	keeper, ctx := testkeeper.BTCStakingKeeper(t, nil, nil, nil, nil)
 
 	// starting with `1` as BTCStakingKeeper creates params with version 0
 	params1 := types.DefaultParams()

--- a/x/btcstaking/types/expected_keepers.go
+++ b/x/btcstaking/types/expected_keepers.go
@@ -6,6 +6,7 @@ import (
 	bbn "github.com/babylonlabs-io/babylon/types"
 	btcctypes "github.com/babylonlabs-io/babylon/x/btccheckpoint/types"
 	btclctypes "github.com/babylonlabs-io/babylon/x/btclightclient/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type BTCLightClientKeeper interface {
@@ -24,4 +25,8 @@ type FinalityKeeper interface {
 
 type BtcStakingHooks interface {
 	AfterFinalityProviderActivated(ctx context.Context, fpPk *bbn.BIP340PubKey) error
+}
+
+type IncentiveKeeper interface {
+	IndexRefundableMsg(ctx context.Context, msg sdk.Msg)
 }

--- a/x/btcstaking/types/mocked_keepers.go
+++ b/x/btcstaking/types/mocked_keepers.go
@@ -11,6 +11,7 @@ import (
 	types "github.com/babylonlabs-io/babylon/types"
 	types0 "github.com/babylonlabs-io/babylon/x/btccheckpoint/types"
 	types1 "github.com/babylonlabs-io/babylon/x/btclightclient/types"
+	types2 "github.com/cosmos/cosmos-sdk/types"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -188,4 +189,39 @@ func (m *MockBtcStakingHooks) AfterFinalityProviderActivated(ctx context.Context
 func (mr *MockBtcStakingHooksMockRecorder) AfterFinalityProviderActivated(ctx, fpPk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFinalityProviderActivated", reflect.TypeOf((*MockBtcStakingHooks)(nil).AfterFinalityProviderActivated), ctx, fpPk)
+}
+
+// MockIncentiveKeeper is a mock of IncentiveKeeper interface.
+type MockIncentiveKeeper struct {
+	ctrl     *gomock.Controller
+	recorder *MockIncentiveKeeperMockRecorder
+}
+
+// MockIncentiveKeeperMockRecorder is the mock recorder for MockIncentiveKeeper.
+type MockIncentiveKeeperMockRecorder struct {
+	mock *MockIncentiveKeeper
+}
+
+// NewMockIncentiveKeeper creates a new mock instance.
+func NewMockIncentiveKeeper(ctrl *gomock.Controller) *MockIncentiveKeeper {
+	mock := &MockIncentiveKeeper{ctrl: ctrl}
+	mock.recorder = &MockIncentiveKeeperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIncentiveKeeper) EXPECT() *MockIncentiveKeeperMockRecorder {
+	return m.recorder
+}
+
+// IndexRefundableMsg mocks base method.
+func (m *MockIncentiveKeeper) IndexRefundableMsg(ctx context.Context, msg types2.Msg) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IndexRefundableMsg", ctx, msg)
+}
+
+// IndexRefundableMsg indicates an expected call of IndexRefundableMsg.
+func (mr *MockIncentiveKeeperMockRecorder) IndexRefundableMsg(ctx, msg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexRefundableMsg", reflect.TypeOf((*MockIncentiveKeeper)(nil).IndexRefundableMsg), ctx, msg)
 }

--- a/x/finality/keeper/msg_server.go
+++ b/x/finality/keeper/msg_server.go
@@ -179,7 +179,7 @@ func (ms msgServer) AddFinalitySig(goCtx context.Context, req *types.MsgAddFinal
 
 	// at this point, the finality signature is 1) valid, 2) over a canonical block,
 	// and 3) not duplicated
-	// Thus, we can safety consider this message as refundable
+	// Thus, we can safely consider this message as refundable
 	ms.IncentiveKeeper.IndexRefundableMsg(ctx, req)
 
 	return &types.MsgAddFinalitySigResponse{}, nil

--- a/x/finality/keeper/msg_server.go
+++ b/x/finality/keeper/msg_server.go
@@ -98,7 +98,7 @@ func (ms msgServer) AddFinalitySig(goCtx context.Context, req *types.MsgAddFinal
 	existingSig, err := ms.GetSig(ctx, req.BlockHeight, fpPK)
 	if err == nil && existingSig.Equals(req.FinalitySig) {
 		ms.Logger(ctx).Debug("Received duplicated finiality vote", "block height", req.BlockHeight, "finality provider", req.FpBtcPk)
-		// exactly same vote alreay exists, return success to the provider
+		// exactly same vote already exists, return success to the provider
 		return &types.MsgAddFinalitySigResponse{}, nil
 	}
 
@@ -178,7 +178,7 @@ func (ms msgServer) AddFinalitySig(goCtx context.Context, req *types.MsgAddFinal
 	}
 
 	// at this point, the finality signature is 1) valid, 2) over a canonical block,
-	// and 3) not duplicated
+	// and 3) not duplicated.
 	// Thus, we can safely consider this message as refundable
 	ms.IncentiveKeeper.IndexRefundableMsg(ctx, req)
 

--- a/x/finality/keeper/msg_server.go
+++ b/x/finality/keeper/msg_server.go
@@ -177,6 +177,11 @@ func (ms msgServer) AddFinalitySig(goCtx context.Context, req *types.MsgAddFinal
 		ms.slashFinalityProvider(ctx, req.FpBtcPk, evidence)
 	}
 
+	// at this point, the finality signature is 1) valid, 2) over a canonical block,
+	// and 3) not duplicated
+	// Thus, we can safety consider this message as refundable
+	ms.IncentiveKeeper.IndexRefundableMsg(ctx, req)
+
 	return &types.MsgAddFinalitySigResponse{}, nil
 }
 

--- a/x/finality/keeper/msg_server_test.go
+++ b/x/finality/keeper/msg_server_test.go
@@ -113,7 +113,9 @@ func FuzzAddFinalitySig(f *testing.F) {
 
 		bsKeeper := types.NewMockBTCStakingKeeper(ctrl)
 		cKeeper := types.NewMockCheckpointingKeeper(ctrl)
-		fKeeper, ctx := keepertest.FinalityKeeper(t, bsKeeper, nil, cKeeper)
+		iKeeper := types.NewMockIncentiveKeeper(ctrl)
+		iKeeper.EXPECT().IndexRefundableMsg(gomock.Any(), gomock.Any()).AnyTimes()
+		fKeeper, ctx := keepertest.FinalityKeeper(t, bsKeeper, iKeeper, cKeeper)
 		ms := keeper.NewMsgServerImpl(*fKeeper)
 
 		// create and register a random finality provider
@@ -310,7 +312,9 @@ func TestVoteForConflictingHashShouldRetrieveEvidenceAndSlash(t *testing.T) {
 	defer ctrl.Finish()
 	bsKeeper := types.NewMockBTCStakingKeeper(ctrl)
 	cKeeper := types.NewMockCheckpointingKeeper(ctrl)
-	fKeeper, ctx := keepertest.FinalityKeeper(t, bsKeeper, nil, cKeeper)
+	iKeeper := types.NewMockIncentiveKeeper(ctrl)
+	iKeeper.EXPECT().IndexRefundableMsg(gomock.Any(), gomock.Any()).AnyTimes()
+	fKeeper, ctx := keepertest.FinalityKeeper(t, bsKeeper, iKeeper, cKeeper)
 	ms := keeper.NewMsgServerImpl(*fKeeper)
 	// create and register a random finality provider
 	btcSK, btcPK, err := datagen.GenRandomBTCKeyPair(r)

--- a/x/finality/types/expected_keepers.go
+++ b/x/finality/types/expected_keepers.go
@@ -6,6 +6,7 @@ import (
 	bbn "github.com/babylonlabs-io/babylon/types"
 	bstypes "github.com/babylonlabs-io/babylon/x/btcstaking/types"
 	etypes "github.com/babylonlabs-io/babylon/x/epoching/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type BTCStakingKeeper interface {
@@ -29,6 +30,7 @@ type CheckpointingKeeper interface {
 // IncentiveKeeper defines the expected interface needed to distribute rewards.
 type IncentiveKeeper interface {
 	RewardBTCStaking(ctx context.Context, height uint64, filteredDc *bstypes.VotingPowerDistCache)
+	IndexRefundableMsg(ctx context.Context, msg sdk.Msg)
 }
 
 type BtcStakingHooks interface {

--- a/x/finality/types/expected_keepers.go
+++ b/x/finality/types/expected_keepers.go
@@ -27,7 +27,8 @@ type CheckpointingKeeper interface {
 	GetLastFinalizedEpoch(ctx context.Context) uint64
 }
 
-// IncentiveKeeper defines the expected interface needed to distribute rewards.
+// IncentiveKeeper defines the expected interface needed for distributing rewards
+// and refund transaction fee for finality signatures
 type IncentiveKeeper interface {
 	RewardBTCStaking(ctx context.Context, height uint64, filteredDc *bstypes.VotingPowerDistCache)
 	IndexRefundableMsg(ctx context.Context, msg sdk.Msg)

--- a/x/finality/types/mocked_keepers.go
+++ b/x/finality/types/mocked_keepers.go
@@ -11,6 +11,7 @@ import (
 	types "github.com/babylonlabs-io/babylon/types"
 	types0 "github.com/babylonlabs-io/babylon/x/btcstaking/types"
 	types1 "github.com/babylonlabs-io/babylon/x/epoching/types"
+	types2 "github.com/cosmos/cosmos-sdk/types"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -250,6 +251,18 @@ func NewMockIncentiveKeeper(ctrl *gomock.Controller) *MockIncentiveKeeper {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIncentiveKeeper) EXPECT() *MockIncentiveKeeperMockRecorder {
 	return m.recorder
+}
+
+// IndexRefundableMsg mocks base method.
+func (m *MockIncentiveKeeper) IndexRefundableMsg(ctx context.Context, msg types2.Msg) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IndexRefundableMsg", ctx, msg)
+}
+
+// IndexRefundableMsg indicates an expected call of IndexRefundableMsg.
+func (mr *MockIncentiveKeeperMockRecorder) IndexRefundableMsg(ctx, msg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexRefundableMsg", reflect.TypeOf((*MockIncentiveKeeper)(nil).IndexRefundableMsg), ctx, msg)
 }
 
 // RewardBTCStaking mocks base method.

--- a/x/incentive/keeper/keeper.go
+++ b/x/incentive/keeper/keeper.go
@@ -16,9 +16,9 @@ type (
 		cdc          codec.BinaryCodec
 		storeService corestoretypes.KVStoreService
 
-		epochingKeeper types.EpochingKeeper
 		bankKeeper     types.BankKeeper
 		accountKeeper  types.AccountKeeper
+		epochingKeeper types.EpochingKeeper
 
 		// RefundableMsgKeySet is the set of hashes of messages that can be refunded
 		// Each key is a hash of the message bytes
@@ -46,15 +46,15 @@ func NewKeeper(
 	return Keeper{
 		cdc:            cdc,
 		storeService:   storeService,
-		epochingKeeper: epochingKeeper,
 		bankKeeper:     bankKeeper,
+		accountKeeper:  accountKeeper,
+		epochingKeeper: epochingKeeper,
 		RefundableMsgKeySet: collections.NewKeySet(
 			sb,
 			types.RefundableMsgKeySetPrefix,
 			"refundable_msg_key_set",
 			collections.BytesKey,
 		),
-		accountKeeper:    accountKeeper,
 		authority:        authority,
 		feeCollectorName: feeCollectorName,
 	}

--- a/x/incentive/keeper/keeper.go
+++ b/x/incentive/keeper/keeper.go
@@ -1,9 +1,10 @@
 package keeper
 
 import (
-	corestoretypes "cosmossdk.io/core/store"
 	"fmt"
 
+	"cosmossdk.io/collections"
+	corestoretypes "cosmossdk.io/core/store"
 	"cosmossdk.io/log"
 	"github.com/babylonlabs-io/babylon/x/incentive/types"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -18,6 +19,11 @@ type (
 		epochingKeeper types.EpochingKeeper
 		bankKeeper     types.BankKeeper
 		accountKeeper  types.AccountKeeper
+
+		// RefundableMsgKeySet is the set of hashes of messages that can be refunded
+		// Each key is a hash of the message bytes
+		RefundableMsgKeySet collections.KeySet[[]byte]
+
 		// the address capable of executing a MsgUpdateParams message. Typically, this
 		// should be the x/gov module account.
 		authority string
@@ -35,11 +41,19 @@ func NewKeeper(
 	authority string,
 	feeCollectorName string,
 ) Keeper {
+	sb := collections.NewSchemaBuilder(storeService)
+
 	return Keeper{
-		cdc:              cdc,
-		storeService:     storeService,
-		epochingKeeper:   epochingKeeper,
-		bankKeeper:       bankKeeper,
+		cdc:            cdc,
+		storeService:   storeService,
+		epochingKeeper: epochingKeeper,
+		bankKeeper:     bankKeeper,
+		RefundableMsgKeySet: collections.NewKeySet(
+			sb,
+			types.RefundableMsgKeySetPrefix,
+			"refundable_msg_key_set",
+			collections.BytesKey,
+		),
 		accountKeeper:    accountKeeper,
 		authority:        authority,
 		feeCollectorName: feeCollectorName,

--- a/x/incentive/keeper/refund_tx_decorator.go
+++ b/x/incentive/keeper/refund_tx_decorator.go
@@ -1,0 +1,63 @@
+package keeper
+
+import (
+	"github.com/babylonlabs-io/babylon/x/incentive/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var _ sdk.PostDecorator = &RefundTxDecorator{}
+
+type RefundTxDecorator struct {
+	k *Keeper
+}
+
+// NewRefundTxDecorator creates a new RefundTxDecorator
+func NewRefundTxDecorator(k *Keeper) *RefundTxDecorator {
+	return &RefundTxDecorator{
+		k: k,
+	}
+}
+
+func (d *RefundTxDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
+	// refund only when finalizing a block or simulating the current tx
+	if ctx.ExecMode() != sdk.ExecModeFinalize && !simulate {
+		return next(ctx, tx, simulate, success)
+	}
+	// ignore unsuccessful tx
+	// NOTE: tx with a misbehaving header will still succeed, but will make the client to be frozen
+	if !success {
+		return next(ctx, tx, simulate, success)
+	}
+	// ignore tx that does not need to pay fee
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return next(ctx, tx, simulate, success)
+	}
+
+	refundableMsgHashList := make([][]byte, 0)
+
+	// iterate over all messages in the tx, and record whether they are refundable
+	for _, msg := range tx.GetMsgs() {
+		msgHash := types.HashMsg(msg)
+		if d.k.HasRefundableMsg(ctx, msgHash) {
+			refundableMsgHashList = append(refundableMsgHashList, msgHash)
+		}
+	}
+
+	// if all messages in the tx are refundable, refund the tx
+	if len(refundableMsgHashList) == len(tx.GetMsgs()) {
+		err := d.k.RefundTx(ctx, feeTx)
+		if err != nil {
+			d.k.Logger(ctx).Error("failed to refund tx", "error", err)
+			return next(ctx, tx, simulate, success)
+		}
+	}
+
+	// remove the refundable messages from the index
+	for _, msgHash := range refundableMsgHashList {
+		d.k.RemoveRefundableMsg(ctx, msgHash)
+	}
+
+	// move to the next PostHandler
+	return next(ctx, tx, simulate, success)
+}

--- a/x/incentive/keeper/refund_tx_decorator.go
+++ b/x/incentive/keeper/refund_tx_decorator.go
@@ -54,8 +54,7 @@ func (d *RefundTxDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, suc
 
 	// remove the refundable messages from the index, regardless whether the tx is refunded or not
 	// NOTE: If the message with same hash shows up again, the refunding rule will
-	// consider it duplicated
-	//   and the tx will not be refunded
+	// consider it duplicated and the tx will not be refunded
 	for _, msgHash := range refundableMsgHashList {
 		d.k.RemoveRefundableMsg(ctx, msgHash)
 	}

--- a/x/incentive/keeper/refundable_msg_index.go
+++ b/x/incentive/keeper/refundable_msg_index.go
@@ -1,12 +1,14 @@
 package keeper
 
 import (
+	"context"
+
 	"github.com/babylonlabs-io/babylon/x/incentive/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // RefundTx refunds the given tx by sending the fee back to the fee payer.
-func (k Keeper) RefundTx(ctx sdk.Context, tx sdk.FeeTx) error {
+func (k Keeper) RefundTx(ctx context.Context, tx sdk.FeeTx) error {
 	txFee := tx.GetFee()
 	txFeePayer := tx.FeePayer()
 
@@ -14,7 +16,7 @@ func (k Keeper) RefundTx(ctx sdk.Context, tx sdk.FeeTx) error {
 }
 
 // IndexRefundableMsg indexes the given refundable message by its hash.
-func (k Keeper) IndexRefundableMsg(ctx sdk.Context, msg sdk.Msg) {
+func (k Keeper) IndexRefundableMsg(ctx context.Context, msg sdk.Msg) {
 	msgHash := types.HashMsg(msg)
 	err := k.RefundableMsgKeySet.Set(ctx, msgHash)
 	if err != nil {
@@ -23,7 +25,7 @@ func (k Keeper) IndexRefundableMsg(ctx sdk.Context, msg sdk.Msg) {
 }
 
 // HasRefundableMsg checks if the message with a given hash is refundable.
-func (k Keeper) HasRefundableMsg(ctx sdk.Context, msgHash []byte) bool {
+func (k Keeper) HasRefundableMsg(ctx context.Context, msgHash []byte) bool {
 	has, err := k.RefundableMsgKeySet.Has(ctx, msgHash)
 	if err != nil {
 		panic(err) // encoding issue; this can only be a programming error
@@ -32,7 +34,7 @@ func (k Keeper) HasRefundableMsg(ctx sdk.Context, msgHash []byte) bool {
 }
 
 // RemoveRefundableMsg removes the given refundable message from the index.
-func (k Keeper) RemoveRefundableMsg(ctx sdk.Context, msgHash []byte) {
+func (k Keeper) RemoveRefundableMsg(ctx context.Context, msgHash []byte) {
 	err := k.RefundableMsgKeySet.Remove(ctx, msgHash)
 	if err != nil {
 		panic(err) // encoding issue; this can only be a programming error

--- a/x/incentive/keeper/refundable_msg_index.go
+++ b/x/incentive/keeper/refundable_msg_index.go
@@ -10,6 +10,11 @@ import (
 // RefundTx refunds the given tx by sending the fee back to the fee payer.
 func (k Keeper) RefundTx(ctx context.Context, tx sdk.FeeTx) error {
 	txFee := tx.GetFee()
+	if txFee.IsZero() {
+		// not possible with the global min gas price mechanism
+		// but having this check for compatibility in the future
+		return nil
+	}
 	txFeePayer := tx.FeePayer()
 
 	return k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.feeCollectorName, txFeePayer, txFee)

--- a/x/incentive/keeper/refundable_msg_index.go
+++ b/x/incentive/keeper/refundable_msg_index.go
@@ -1,0 +1,40 @@
+package keeper
+
+import (
+	"github.com/babylonlabs-io/babylon/x/incentive/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// RefundTx refunds the given tx by sending the fee back to the fee payer.
+func (k Keeper) RefundTx(ctx sdk.Context, tx sdk.FeeTx) error {
+	txFee := tx.GetFee()
+	txFeePayer := tx.FeePayer()
+
+	return k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.feeCollectorName, txFeePayer, txFee)
+}
+
+// IndexRefundableMsg indexes the given refundable message by its hash.
+func (k Keeper) IndexRefundableMsg(ctx sdk.Context, msg sdk.Msg) {
+	msgHash := types.HashMsg(msg)
+	err := k.RefundableMsgKeySet.Set(ctx, msgHash)
+	if err != nil {
+		panic(err) // encoding issue; this can only be a programming error
+	}
+}
+
+// HasRefundableMsg checks if the message with a given hash is refundable.
+func (k Keeper) HasRefundableMsg(ctx sdk.Context, msgHash []byte) bool {
+	has, err := k.RefundableMsgKeySet.Has(ctx, msgHash)
+	if err != nil {
+		panic(err) // encoding issue; this can only be a programming error
+	}
+	return has
+}
+
+// RemoveRefundableMsg removes the given refundable message from the index.
+func (k Keeper) RemoveRefundableMsg(ctx sdk.Context, msgHash []byte) {
+	err := k.RefundableMsgKeySet.Remove(ctx, msgHash)
+	if err != nil {
+		panic(err) // encoding issue; this can only be a programming error
+	}
+}

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+
 	epochingtypes "github.com/babylonlabs-io/babylon/x/epoching/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/x/incentive/types/keys.go
+++ b/x/incentive/types/keys.go
@@ -1,5 +1,7 @@
 package types
 
+import "cosmossdk.io/collections"
+
 const (
 	// ModuleName defines the module name
 	ModuleName = "incentive"
@@ -15,8 +17,9 @@ const (
 )
 
 var (
-	ParamsKey               = []byte{0x01} // key prefix for the parameters
-	BTCStakingGaugeKey      = []byte{0x02} // key prefix for BTC staking gauge at each height
-	BTCTimestampingGaugeKey = []byte{0x03} // key prefix for BTC timestamping gauge at each height
-	RewardGaugeKey          = []byte{0x04} // key prefix for reward gauge for a given stakeholder in a given type
+	ParamsKey                 = []byte{0x01}             // key prefix for the parameters
+	BTCStakingGaugeKey        = []byte{0x02}             // key prefix for BTC staking gauge at each height
+	BTCTimestampingGaugeKey   = []byte{0x03}             // key prefix for BTC timestamping gauge at each height
+	RewardGaugeKey            = []byte{0x04}             // key prefix for reward gauge for a given stakeholder in a given type
+	RefundableMsgKeySetPrefix = collections.NewPrefix(5) // key prefix for refundable msg key set
 )

--- a/x/incentive/types/types.go
+++ b/x/incentive/types/types.go
@@ -1,1 +1,12 @@
 package types
+
+import (
+	"github.com/cometbft/cometbft/crypto/tmhash"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func HashMsg(msg sdk.Msg) []byte {
+	msgBytes := ModuleCdc.MustMarshal(msg)
+	msgHash := tmhash.Sum(msgBytes)
+	return msgHash
+}


### PR DESCRIPTION
Resolves https://github.com/babylonlabs-io/pm/issues/64

This PR introduces the functionality of refunding fee for certain txs, including BTC headers/checkpoints in BTC timestamping protocol, and finality signature, BTC delegation inclusion proof, covenant signatures, undelegation, selective slashing evidence in BTC staking protocol.

The implementation leverages a new key-only KV store in the incentive module for storing refundable messages, and a new PostHandler for refunding a tx if all msgs in it are refundable.

Along the way, this PR also adds dependency from BTC light client / BTC staking modules to the incentive module, and adds relevant e2e tests to ensure that the tx fee refunding indeed works.

- RFC: https://github.com/babylonlabs-io/pm/blob/main/rfc/rfc-010-transaction-fee-refund-protocol.md
- ADR: https://github.com/babylonlabs-io/pm/blob/main/adr/adr-028-transaction-fee-refund-protocol.md