### PR TITLE
chore: gh sync workflow from main to base

### DIFF
--- a/.github/workflows/sync_pr_main_to_base.yml
+++ b/.github/workflows/sync_pr_main_to_base.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   call_sync_branch:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_sync_branch.yml@v0.2.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_sync_branch.yml@v0.7.0
     with:
       base_branch: "main"
       target_branch: "base/consumer-chain-support"


### PR DESCRIPTION
Creates a cron scheduled gh workflow to open a sync pr from main -> base/consumer branch. 

Taken from https://github.com/babylonlabs-io/simple-staking/blob/dev/.github/workflows/sync_pr_dev_to_main.yml