### PR TITLE
ci: add Github actions for changelog reminder and goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.6.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
     secrets: inherit
     with:
      run-unit-tests: true
@@ -19,11 +19,11 @@ jobs:
      run-lint: true
     
   changelog_reminder:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@main
+    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@v0.7.0
     secrets: inherit
 
   docker_pipeline:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.6.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
     secrets: inherit
     with:
      publish: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,19 @@ concurrency:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.5.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.6.0
     secrets: inherit
     with:
      run-unit-tests: true
      run-integration-tests: false
      run-lint: true
+    
+  changelog_reminder:
+    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@main
+    secrets: inherit
 
   docker_pipeline:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.5.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.6.0
     secrets: inherit
     with:
      publish: false

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,3 +1,5 @@
+name: goreleaser
+
 on:
   push:
     tags:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,9 @@
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@main
+    secrets: inherit

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,5 +5,5 @@ on:
 
 jobs:
   release:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@main
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.5.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
     secrets: inherit
     with:
       run-unit-tests: true
@@ -18,7 +18,7 @@ jobs:
       run-lint: true
 
   docker_pipeline:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.5.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
     needs: ["lint_test"]
     secrets: inherit
     with:


### PR DESCRIPTION
Resolves #110 

This PR adds Github actions for changelog reminder and goreleaser. Also this PR bumps the dependency of babylonlabs-io/.github to v0.7.0

TODOs before merging:

- [x] wait until v0.7.0 tag of https://github.com/babylonlabs-io/.github
- [x] apply v0.7.0 to all reusable workflows