### PR TITLE
ci: add goreleaser setup and move out changelog reminder

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -1,0 +1,11 @@
+name: Changelog Reminder
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+jobs:
+  changelog_reminder:
+    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@v0.7.0
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   changelog_reminder:
     uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@v0.7.0
     secrets: inherit
+    if: github.ref != 'refs/heads/main'
 
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,6 @@ jobs:
      run-integration-tests: false
      run-lint: true
     
-  changelog_reminder:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@v0.7.0
-    secrets: inherit
-    if: github.ref != 'refs/heads/main'
-
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,4 @@ docs/diagrams/plantuml.jar
 .testnet/
 mytestnet/
 output/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,94 @@
+project_name: babylon
+
+builds:
+  - id: babylond-darwin-amd64
+    main: ./cmd/babylond/main.go
+    binary: babylond
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+    env:
+      - CC=o64-clang
+      - CGO_LDFLAGS=-L/lib
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=babylond
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
+      - -w -s
+      - -linkmode=external
+    tags:
+      - netgo
+      - ledger
+      - static_wasm
+
+  - id: babylond-linux-amd64
+    main: ./cmd/babylond/main.go
+    binary: babylond
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CC=x86_64-linux-gnu-gcc
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=babylond
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,muslc,osusergo
+      - -w -s
+      - -linkmode=external
+      - -extldflags '-Wl,-z,muldefs -static -lm'
+    tags:
+      - netgo
+      - ledger
+      - muslc
+      - osusergo
+
+archives:
+  - id: zipped
+    builds:
+      - babylond-darwin-amd64
+      - babylond-linux-amd64
+    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: tar.gz
+    files:
+      - none*
+  - id: binaries
+    builds:
+      - babylond-darwin-amd64
+      - babylond-linux-amd64
+    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: binary
+    files:
+      - none*
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+
+release:
+  github:
+    owner: babylonlabs-io
+    name: babylon
+
+# Docs: https://goreleaser.com/customization/changelog/
+changelog:
+  disable: true
+
+dist: dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,59 +1,29 @@
 project_name: babylon
 
 builds:
-  - id: babylond-darwin-amd64
-    main: ./cmd/babylond/main.go
-    binary: babylond
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
-    env:
-      - CC=o64-clang
-      - CGO_LDFLAGS=-L/lib
-    goos:
-      - darwin
-    goarch:
-      - amd64
-    flags:
-      - -mod=readonly
-      - -trimpath
-    ldflags:
-      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
-      - -X github.com/cosmos/cosmos-sdk/version.AppName=babylond
-      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
-      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
-      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
-      - -w -s
-      - -linkmode=external
-    tags:
-      - netgo
-      - ledger
-      - static_wasm
-
   - id: babylond-linux-amd64
     main: ./cmd/babylond/main.go
     binary: babylond
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm.x86_64.so -O /lib/libwasmvm_muslc.x86_64.so
     goos:
       - linux
     goarch:
       - amd64
     env:
-      - CC=x86_64-linux-gnu-gcc
+      - GO111MODULE=on
     flags:
       - -mod=readonly
       - -trimpath
     ldflags:
-      - -X github.com/cosmos/cosmos-sdk/version.Name=osmosis
+      - -X github.com/cosmos/cosmos-sdk/version.Name=babylon
       - -X github.com/cosmos/cosmos-sdk/version.AppName=babylond
       - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
       - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
       - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,muslc,osusergo
       - -w -s
       - -linkmode=external
-      - -extldflags '-Wl,-z,muldefs -static -lm'
     tags:
       - netgo
       - ledger
@@ -63,7 +33,6 @@ builds:
 archives:
   - id: zipped
     builds:
-      - babylond-darwin-amd64
       - babylond-linux-amd64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
@@ -71,7 +40,6 @@ archives:
       - none*
   - id: binaries
     builds:
-      - babylond-darwin-amd64
       - babylond-linux-amd64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Misc Improvements
 
+* [#170](https://github.com/babylonlabs-io/babylon/pull/170) Go releaser setup
 * [#168](https://github.com/babylonlabs-io/babylon/pull/168) Remove devdoc from
   Makefile and remove unnecessary gin replace.
 

--- a/Makefile
+++ b/Makefile
@@ -491,3 +491,54 @@ diagrams: ## Generate diagrams for documentation
 update-changelog: ## Update the project changelog
 	@echo ./scripts/update_changelog.sh $(since_tag) $(upcoming_tag)
 	./scripts/update_changelog.sh $(since_tag) $(upcoming_tag)
+
+###############################################################################
+###                                Release                                  ###
+###############################################################################
+
+GO_VERSION := $(shell grep -E '^go [0-9]+\.[0-9]+' go.mod | awk '{print $$2}')
+GORELEASER_IMAGE := ghcr.io/goreleaser/goreleaser-cross:v$(GO_VERSION)
+COSMWASM_VERSION := $(shell go list -m github.com/CosmWasm/wasmvm/v2 | sed 's/.* //')
+
+release-dry-run:
+	docker run \
+		--rm \
+		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/babylon \
+		-w /go/src/babylon \
+		$(GORELEASER_IMAGE) \
+		release \
+		--clean \
+		--skip-publish
+
+release-snapshot:
+	docker run \
+		--rm \
+		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/babylon \
+		-w /go/src/babylon \
+		$(GORELEASER_IMAGE) \
+		release \
+		--clean \
+		--snapshot \
+		--skip-validate \
+		--skip-publish
+
+ifdef GITHUB_TOKEN
+release:
+	docker run \
+		--rm \
+		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \
+		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/babylon \
+		-w /go/src/babylon \
+		$(GORELEASER_IMAGE) \
+		release \
+		--clean
+else
+release:
+	@echo "Error: GITHUB_TOKEN is not defined. Please define it before running 'make release'."
+endif

--- a/Makefile
+++ b/Makefile
@@ -496,6 +496,7 @@ update-changelog: ## Update the project changelog
 ###                                Release                                  ###
 ###############################################################################
 
+# Below is adapted from https://github.com/osmosis-labs/osmosis/blob/main/Makefile
 GO_VERSION := $(shell grep -E '^go [0-9]+\.[0-9]+' go.mod | awk '{print $$2}')
 GORELEASER_IMAGE := ghcr.io/goreleaser/goreleaser-cross:v$(GO_VERSION)
 COSMWASM_VERSION := $(shell go list -m github.com/CosmWasm/wasmvm/v2 | sed 's/.* //')
@@ -526,6 +527,8 @@ release-snapshot:
 		--skip-validate \
 		--skip-publish
 
+# NOTE: By default, the CI will handle the release process.
+# this is for manually releasing.
 ifdef GITHUB_TOKEN
 release:
 	docker run \

--- a/Makefile
+++ b/Makefile
@@ -501,6 +501,7 @@ GO_VERSION := $(shell grep -E '^go [0-9]+\.[0-9]+' go.mod | awk '{print $$2}')
 GORELEASER_IMAGE := ghcr.io/goreleaser/goreleaser-cross:v$(GO_VERSION)
 COSMWASM_VERSION := $(shell go list -m github.com/CosmWasm/wasmvm/v2 | sed 's/.* //')
 
+.PHONY: release-dry-run release-snapshot release
 release-dry-run:
 	docker run \
 		--rm \

--- a/Makefile
+++ b/Makefile
@@ -512,7 +512,7 @@ release-dry-run:
 		$(GORELEASER_IMAGE) \
 		release \
 		--clean \
-		--skip-publish
+		--skip=publish
 
 release-snapshot:
 	docker run \
@@ -525,8 +525,7 @@ release-snapshot:
 		release \
 		--clean \
 		--snapshot \
-		--skip-validate \
-		--skip-publish
+		--skip=publish,validate
 
 # NOTE: By default, the CI will handle the release process.
 # this is for manually releasing.

--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ update-changelog: ## Update the project changelog
 ###                                Release                                  ###
 ###############################################################################
 
-# Below is adapted from https://github.com/osmosis-labs/osmosis/blob/main/Makefile
+# The below is adapted from https://github.com/osmosis-labs/osmosis/blob/main/Makefile
 GO_VERSION := $(shell grep -E '^go [0-9]+\.[0-9]+' go.mod | awk '{print $$2}')
 GORELEASER_IMAGE := ghcr.io/goreleaser/goreleaser-cross:v$(GO_VERSION)
 COSMWASM_VERSION := $(shell go list -m github.com/CosmWasm/wasmvm/v2 | sed 's/.* //')

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -110,6 +110,10 @@ git pull --tags
 
 git tag -s -a v0.10.0-rc.0 -m "Version v0.10.0-rc.0"
 ```
+
+With every tag, the Github action will use the `goreleaser` tool to create a
+release, including artifacts and their checksums.
+
 ## Patch Release Procedure
 
 A _patch release_ is an increment of the patch number (eg: `v10.0.0` → `v10.0.1`).


### PR DESCRIPTION
This PR 

- sets up Go releaser for Babylon. Currently it only supports linux amd64. Other targets will be supported in the future. To test locally, run `make release-snapshot`
- moves changelog reminder out from the CI flow
