### PR TITLE
Do not panic on nil proof when handling votes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
-### State Machine Breaking 
+### State Machine Breaking
 
 * [#181](https://github.com/babylonlabs-io/babylon/pull/181) Modify BTC heights
   and depths to be of uint32 type instead of uint64.
@@ -47,6 +47,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#180](https://github.com/babylonlabs-io/babylon/pull/180) Non-determinism in
   sorting finality providers in the voting power table
 * [#154](https://github.com/babylonlabs-io/babylon/pull/154) Fix "edit-finality-provider" cmd argument index
+* [#186](https://github.com/babylonlabs-io/babylon/pull/186) Do not panic on `nil`
+Proof when handling finality votes
 
 ### Improvements
 

--- a/x/finality/types/msg.go
+++ b/x/finality/types/msg.go
@@ -4,6 +4,7 @@ import (
 	fmt "fmt"
 
 	"github.com/babylonlabs-io/babylon/crypto/eots"
+	bbn "github.com/babylonlabs-io/babylon/types"
 	"github.com/cometbft/cometbft/crypto/merkle"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -21,20 +22,20 @@ func (m *MsgAddFinalitySig) MsgToSign() []byte {
 }
 
 func (m *MsgAddFinalitySig) ValidateBasic() error {
-	if m.FpBtcPk == nil {
-		return ErrInvalidFinalitySig.Wrap("empty finality provider BTC public key")
+	if m.FpBtcPk.Size() != bbn.BIP340PubKeyLen {
+		return ErrInvalidFinalitySig.Wrapf("invalid finality provider BTC public key length: got %d, want %d", m.FpBtcPk.Size(), bbn.BIP340PubKeyLen)
 	}
 
-	if m.PubRand == nil {
-		return ErrInvalidFinalitySig.Wrap("empty public randomness")
+	if m.PubRand.Size() != bbn.SchnorrPubRandLen {
+		return ErrInvalidFinalitySig.Wrapf("invalind public randomness length: got %d, want %d", m.PubRand.Size(), bbn.SchnorrPubRandLen)
 	}
 
 	if m.Proof == nil {
 		return ErrInvalidFinalitySig.Wrap("empty inclusion proof")
 	}
 
-	if m.FinalitySig == nil {
-		return ErrInvalidFinalitySig.Wrap("empty finality signature")
+	if m.FinalitySig.Size() != bbn.SchnorrEOTSSigLen {
+		return ErrInvalidFinalitySig.Wrapf("invalid finality signature length: got %d, want %d", m.FinalitySig.Size(), bbn.BIP340SignatureLen)
 	}
 
 	if len(m.BlockAppHash) != tmhash.Size {

--- a/x/finality/types/msg.go
+++ b/x/finality/types/msg.go
@@ -20,6 +20,30 @@ func (m *MsgAddFinalitySig) MsgToSign() []byte {
 	return msgToSignForVote(m.BlockHeight, m.BlockAppHash)
 }
 
+func (m *MsgAddFinalitySig) ValidateBasic() error {
+	if m.FpBtcPk == nil {
+		return ErrInvalidFinalitySig.Wrap("empty finality provider BTC public key")
+	}
+
+	if m.PubRand == nil {
+		return ErrInvalidFinalitySig.Wrap("empty public randomness")
+	}
+
+	if m.Proof == nil {
+		return ErrInvalidFinalitySig.Wrap("empty inclusion proof")
+	}
+
+	if m.FinalitySig == nil {
+		return ErrInvalidFinalitySig.Wrap("empty finality signature")
+	}
+
+	if len(m.BlockAppHash) != tmhash.Size {
+		return ErrInvalidFinalitySig.Wrapf("invalid block app hash length: got %d, want %d", len(m.BlockAppHash), tmhash.Size)
+	}
+
+	return nil
+}
+
 // VerifyFinalitySig verifies the finality signature message w.r.t. the
 // public randomness commitment. The verification includes
 // - verifying the proof of inclusion of the given public randomness


### PR DESCRIPTION
If not would receive finality vote with `nil` Proof, it would panic. 

Pr:
- fixes that
- add test case 

Fixes: https://github.com/babylonlabs-io/babylon/issues/174