### PR TITLE
chore: Fix flunky TestValidateParsedMessageAgainstTheParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#252](https://github.com/babylonlabs-io/babylon/pull/252) Fix
+flunky TestValidateParsedMessageAgainstTheParams
 * [#229](https://github.com/babylonlabs-io/babylon/pull/229) Remove babylond
 e2e before upgrade
 * [#250](https://github.com/babylonlabs-io/babylon/pull/250) Add tests for

--- a/x/btcstaking/types/validate_parsed_message_test.go
+++ b/x/btcstaking/types/validate_parsed_message_test.go
@@ -43,7 +43,7 @@ func testStakingParams(
 		MinStakingValueSat:     100000,
 		MaxStakingValueSat:     int64(4 * 10e8),
 		MinStakingTimeBlocks:   1000,
-		MaxStakingTimeBlocks:   100000,
+		MaxStakingTimeBlocks:   10000,
 		SlashingPkScript:       slashingPkScript,
 		MinSlashingTxFeeSat:    1000,
 		MinCommissionRate:      sdkmath.LegacyMustNewDecFromStr("0.01"),


### PR DESCRIPTION
Closes #251. The flunky is caused due to the fact that the test uses `uint16` type for the `stakingTimeBlocks` which is generated in a range of min and max staking time (0, 100000). However, the max value of `uint16` is 65535. This PR changes the value of max staking time to 10000 to avoid overflow.