### PR TITLE
fix error handling in checkpointing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ unbonding output
 * [#253](https://github.com/babylonlabs-io/babylon/pull/253) Upgrade cometbft dependency
 * [#256](https://github.com/babylonlabs-io/babylon/pull/256) Removes retry library
 from core Babylon repository
+* [#257](https://github.com/babylonlabs-io/babylon/pull/257) Fix error handling
+in checkpointing module
 
 ### State Machine Breaking
 


### PR DESCRIPTION
Fix error handling in checkpointing module:
- the line `err = types.ErrInvalidCkptStatus.Wrapf("the status of the checkpoint should be %s", from.String())` was just allocating error and not doing anything with it
- error from `ckptWithMeta, err := k.GetRawCheckpoint(ctx, epoch)` was just getting swallowed