### PR TITLE
feat: fix go releaser and hook by github action

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,9 +1,8 @@
 name: goreleaser
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 permissions:
   contents: write

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,10 @@
+version: 2
 project_name: babylon
 
 builds:
   - id: babylond-linux-amd64
     main: ./cmd/babylond/main.go
     binary: babylond
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm.x86_64.so -O /lib/libwasmvm_muslc.x86_64.so
     goos:
       - linux
     goarch:
@@ -21,14 +19,11 @@ builds:
       - -X github.com/cosmos/cosmos-sdk/version.AppName=babylond
       - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
       - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
-      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,muslc,osusergo
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger
       - -w -s
-      - -linkmode=external
     tags:
       - netgo
       - ledger
-      - muslc
-      - osusergo
 
 archives:
   - id: zipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#258](https://github.com/babylonlabs-io/babylon/pull/258) fix go releaser
+and trigger by github action
 * [#252](https://github.com/babylonlabs-io/babylon/pull/252) Fix
 flunky TestValidateParsedMessageAgainstTheParams
 * [#229](https://github.com/babylonlabs-io/babylon/pull/229) Remove babylond


### PR DESCRIPTION
Make github action actually make a go release package and added into release note to be able download by all the audience. Remove libwasmvm for github action using whatever is defined in the go mod file library.