### PR TITLE
chore: Allow unbonding time to be min unbonding value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### State Breaking
+
+- [278](https://github.com/babylonlabs-io/babylon/pull/278) Allow unbonding time to be min unbonding value
 
 ### Bug fixes
 

--- a/test/e2e/btc_staking_e2e_test.go
+++ b/test/e2e/btc_staking_e2e_test.go
@@ -17,8 +17,9 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 	feegrantcli "cosmossdk.io/x/feegrant/client/cli"
-	appparams "github.com/babylonlabs-io/babylon/app/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	appparams "github.com/babylonlabs-io/babylon/app/params"
 
 	"github.com/babylonlabs-io/babylon/crypto/eots"
 	"github.com/babylonlabs-io/babylon/test/e2e/configurer"
@@ -93,7 +94,7 @@ func (s *BTCStakingTestSuite) Test1CreateFinalityProviderAndDelegation() {
 	params := nonValidatorNode.QueryBTCStakingParams()
 
 	// minimal required unbonding time
-	unbondingTime := uint16(initialization.BabylonBtcFinalizationPeriod) + 1
+	unbondingTime := params.MinUnbondingTimeBlocks
 
 	// NOTE: we use the node's address for the BTC delegation
 	stakerAddr := sdk.MustAccAddressFromBech32(nonValidatorNode.PublicAddress)
@@ -508,7 +509,7 @@ func (s *BTCStakingTestSuite) Test6MultisigBTCDelegation() {
 	params := nonValidatorNode.QueryBTCStakingParams()
 
 	// minimal required unbonding time
-	unbondingTime := uint16(initialization.BabylonBtcFinalizationPeriod) + 1
+	unbondingTime := params.MinUnbondingTimeBlocks
 
 	// NOTE: we use the multisig address for the BTC delegation
 	multisigStakerAddr := sdk.MustAccAddressFromBech32(multisigAddr)
@@ -579,7 +580,7 @@ func (s *BTCStakingTestSuite) Test7BTCDelegationFeeGrant() {
 	btcStkParams := nonValidatorNode.QueryBTCStakingParams()
 
 	// minimal required unbonding time
-	unbondingTime := uint16(initialization.BabylonBtcFinalizationPeriod) + 1
+	unbondingTime := btcStkParams.MinUnbondingTimeBlocks
 
 	// NOTE: we use the grantee staker address for the BTC delegation PoP
 	pop, err := bstypes.NewPoPBTC(granteeStakerAddr, s.delBTCSK)
@@ -670,7 +671,7 @@ func (s *BTCStakingTestSuite) Test8BTCDelegationFeeGrantTyped() {
 	btcStkParams := node.QueryBTCStakingParams()
 
 	// minimal required unbonding time
-	unbondingTime := uint16(initialization.BabylonBtcFinalizationPeriod) + 1
+	unbondingTime := btcStkParams.MinUnbondingTimeBlocks
 
 	// NOTE: we use the grantee staker address for the BTC delegation PoP
 	pop, err := bstypes.NewPoPBTC(granteeStakerAddr, s.delBTCSK)
@@ -936,7 +937,7 @@ func (s *BTCStakingTestSuite) BTCStakingUnbondSlashInfo(
 ) {
 	covenantBTCPKs := CovenantBTCPKs(params)
 	// minimal required unbonding time
-	unbondingTime := uint16(initialization.BabylonBtcFinalizationPeriod) + 1
+	unbondingTime := params.MinUnbondingTimeBlocks
 
 	testStakingInfo = datagen.GenBTCStakingSlashingInfo(
 		s.r,
@@ -950,7 +951,7 @@ func (s *BTCStakingTestSuite) BTCStakingUnbondSlashInfo(
 		s.stakingValue,
 		params.SlashingPkScript,
 		params.SlashingRate,
-		unbondingTime,
+		uint16(unbondingTime),
 	)
 
 	// submit staking tx to Bitcoin and get inclusion proof
@@ -985,7 +986,7 @@ func (s *BTCStakingTestSuite) BTCStakingUnbondSlashInfo(
 		unbondingValue,
 		params.SlashingPkScript,
 		params.SlashingRate,
-		unbondingTime,
+		uint16(unbondingTime),
 	)
 
 	stakingSlashingPathInfo, err := testStakingInfo.StakingInfo.SlashingPathSpendInfo()

--- a/test/e2e/btc_staking_pre_approval_e2e_test.go
+++ b/test/e2e/btc_staking_pre_approval_e2e_test.go
@@ -92,7 +92,7 @@ func (s *BTCStakingPreApprovalTestSuite) Test1CreateFinalityProviderAndDelegatio
 	params := nonValidatorNode.QueryBTCStakingParams()
 
 	// minimal required unbonding time
-	unbondingTime := uint16(initialization.BabylonBtcFinalizationPeriod) + 1
+	unbondingTime := params.MinUnbondingTimeBlocks
 
 	// NOTE: we use the node's address for the BTC delegation
 	stakerAddr := sdk.MustAccAddressFromBech32(nonValidatorNode.PublicAddress)
@@ -535,7 +535,7 @@ func (s *BTCStakingPreApprovalTestSuite) BTCStakingUnbondSlashInfo(
 ) {
 	covenantBTCPKs := CovenantBTCPKs(params)
 	// minimal required unbonding time
-	unbondingTime := uint16(initialization.BabylonBtcFinalizationPeriod) + 1
+	unbondingTime := params.MinUnbondingTimeBlocks
 
 	testStakingInfo = datagen.GenBTCStakingSlashingInfo(
 		s.r,
@@ -549,7 +549,7 @@ func (s *BTCStakingPreApprovalTestSuite) BTCStakingUnbondSlashInfo(
 		s.stakingValue,
 		params.SlashingPkScript,
 		params.SlashingRate,
-		unbondingTime,
+		uint16(unbondingTime),
 	)
 
 	// submit staking tx to Bitcoin and get inclusion proof
@@ -584,7 +584,7 @@ func (s *BTCStakingPreApprovalTestSuite) BTCStakingUnbondSlashInfo(
 		unbondingValue,
 		params.SlashingPkScript,
 		params.SlashingRate,
-		unbondingTime,
+		uint16(unbondingTime),
 	)
 
 	stakingSlashingPathInfo, err := testStakingInfo.StakingInfo.SlashingPathSpendInfo()

--- a/testutil/btcstaking-helper/keeper.go
+++ b/testutil/btcstaking-helper/keeper.go
@@ -124,7 +124,8 @@ func (h *Helper) BeginBlocker() {
 }
 
 func (h *Helper) GenAndApplyParams(r *rand.Rand) ([]*btcec.PrivateKey, []*btcec.PublicKey) {
-	return h.GenAndApplyCustomParams(r, 100, 0, 0)
+	// ensure that minUnbondingTime is larger than finalizationTimeout
+	return h.GenAndApplyCustomParams(r, 100, 200, 0)
 }
 
 func (h *Helper) SetCtxHeight(height uint64) {
@@ -228,7 +229,7 @@ func (h *Helper) CreateDelegation(
 	if unbondingValue == 0 {
 		unbondingValue = defaultUnbondingValue
 	}
-	defaultUnbondingTime := types.MinimumUnbondingTime(&bsParams, &bcParams) + 1
+	defaultUnbondingTime := bsParams.MinUnbondingTimeBlocks
 	if unbondingTime == 0 {
 		unbondingTime = uint16(defaultUnbondingTime)
 	}

--- a/x/btccheckpoint/keeper/msg_server.go
+++ b/x/btccheckpoint/keeper/msg_server.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	errorsmod "cosmossdk.io/errors"
-	"github.com/babylonlabs-io/babylon/x/btccheckpoint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/babylonlabs-io/babylon/x/btccheckpoint/types"
 )
 
 var _ types.MsgServer = msgServer{}
@@ -110,6 +111,10 @@ func (ms msgServer) UpdateParams(goCtx context.Context, req *types.MsgUpdatePara
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	if req.Params.CheckpointFinalizationTimeout != ms.k.GetParams(ctx).CheckpointFinalizationTimeout {
+		return nil, govtypes.ErrInvalidProposalMsg.Wrapf("the checkpoint finalization timeout cannot be changed")
+	}
+
 	if err := ms.k.SetParams(ctx, req.Params); err != nil {
 		return nil, err
 	}

--- a/x/btccheckpoint/keeper/msg_server.go
+++ b/x/btccheckpoint/keeper/msg_server.go
@@ -110,6 +110,8 @@ func (ms msgServer) UpdateParams(goCtx context.Context, req *types.MsgUpdatePara
 		return nil, govtypes.ErrInvalidProposalMsg.Wrapf("invalid parameter: %v", err)
 	}
 
+	// CheckpointFinalizationTimeout must remain immutable as changing it
+	// breaks a lot of system assumption
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	if req.Params.CheckpointFinalizationTimeout != ms.k.GetParams(ctx).CheckpointFinalizationTimeout {
 		return nil, govtypes.ErrInvalidProposalMsg.Wrapf("the checkpoint finalization timeout cannot be changed")

--- a/x/btcstaking/keeper/btc_delegations.go
+++ b/x/btcstaking/keeper/btc_delegations.go
@@ -79,7 +79,7 @@ func (k Keeper) AddBTCDelegation(
 			NewState:      types.BTCDelegationStatus_UNBONDED,
 		})
 
-		// NOTE: we should have verified that EndHeight > btcTip.Height + max(w, min_unbonding_time)
+		// NOTE: we should have verified that EndHeight > btcTip.Height + min_unbonding_time
 		k.addPowerDistUpdateEvent(ctx, btcDel.EndHeight-minUnbondingTime, unbondedEvent)
 	}
 

--- a/x/btcstaking/keeper/genesis_test.go
+++ b/x/btcstaking/keeper/genesis_test.go
@@ -6,23 +6,23 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/babylonlabs-io/babylon/testutil/datagen"
 	"github.com/babylonlabs-io/babylon/testutil/helper"
 	btclightclientt "github.com/babylonlabs-io/babylon/x/btclightclient/types"
 	"github.com/babylonlabs-io/babylon/x/btcstaking/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExportGenesis(t *testing.T) {
 	r, h := rand.New(rand.NewSource(11)), helper.NewHelper(t)
-	k, btclcK, btcCheckK, ctx := h.App.BTCStakingKeeper, h.App.BTCLightClientKeeper, h.App.BtcCheckpointKeeper, h.Ctx
+	k, btclcK, ctx := h.App.BTCStakingKeeper, h.App.BTCLightClientKeeper, h.Ctx
 	numFps := 3
 
 	fps := datagen.CreateNFinalityProviders(r, t, numFps)
 	params := k.GetParams(ctx)
-	btcckptParams := btcCheckK.GetParams(ctx)
 
-	minUnbondingTime := types.MinimumUnbondingTime(&params, &btcckptParams)
+	minUnbondingTime := params.MinUnbondingTimeBlocks
 
 	chainsHeight := make([]*types.BlockHeightBbnToBtc, 0)
 	// creates the first as it starts already with an chain height from the helper.

--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -215,7 +215,7 @@ func (ms msgServer) CreateBTCDelegation(goCtx context.Context, req *types.MsgCre
 			btcutil.NewTx(parsedMsg.StakingTx.Transaction),
 			btccParams.BtcConfirmationDepth,
 			uint32(parsedMsg.StakingTime),
-			paramsValidationResult.MinUnbondingTime,
+			vp.Params.MinStakingTimeBlocks,
 			parsedMsg.StakingTxProofOfInclusion)
 		if err != nil {
 			return nil, fmt.Errorf("invalid inclusion proof: %w", err)
@@ -259,7 +259,7 @@ func (ms msgServer) CreateBTCDelegation(goCtx context.Context, req *types.MsgCre
 	}
 
 	// add this BTC delegation, and emit corresponding events
-	if err := ms.AddBTCDelegation(ctx, newBTCDel, paramsValidationResult.MinUnbondingTime); err != nil {
+	if err := ms.AddBTCDelegation(ctx, newBTCDel, vp.Params.MinUnbondingTimeBlocks); err != nil {
 		panic(fmt.Errorf("failed to add BTC delegation that has passed verification: %w", err))
 	}
 

--- a/x/btcstaking/keeper/msg_server_test.go
+++ b/x/btcstaking/keeper/msg_server_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -26,6 +28,43 @@ import (
 	btcctypes "github.com/babylonlabs-io/babylon/x/btccheckpoint/types"
 	"github.com/babylonlabs-io/babylon/x/btcstaking/types"
 )
+
+func FuzzMsgServer_UpdateParams(f *testing.F) {
+	datagen.AddRandomSeedsToFuzzer(f, 500)
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// mock BTC light client and BTC checkpoint modules
+		btclcKeeper := types.NewMockBTCLightClientKeeper(ctrl)
+		btccKeeper := types.NewMockBtcCheckpointKeeper(ctrl)
+		h := testutil.NewHelper(t, btclcKeeper, btccKeeper)
+
+		// set all parameters
+		h.GenAndApplyParams(r)
+
+		params := h.BTCStakingKeeper.GetParams(h.Ctx)
+		ckptFinalizationTimeout := btccKeeper.GetParams(h.Ctx).CheckpointFinalizationTimeout
+		params.MinUnbondingTimeBlocks = uint32(r.Intn(int(ckptFinalizationTimeout))) + 1
+
+		// Try to update params with minUnbondingTime less than or equal to checkpointFinalizationTimeout
+		msg := &types.MsgUpdateParams{
+			Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+			Params:    params,
+		}
+
+		_, err := h.MsgServer.UpdateParams(h.Ctx, msg)
+		require.ErrorIs(t, err, govtypes.ErrInvalidProposalMsg,
+			"should not set minUnbondingTime to be less than checkpointFinalizationTimeout")
+
+		// Try to update params with minUnbondingTime larger than checkpointFinalizationTimeout
+		msg.Params.MinUnbondingTimeBlocks = uint32(r.Intn(1000)) + ckptFinalizationTimeout + 1
+		_, err = h.MsgServer.UpdateParams(h.Ctx, msg)
+		require.NoError(t, err)
+	})
+}
 
 func FuzzMsgCreateFinalityProvider(f *testing.F) {
 	datagen.AddRandomSeedsToFuzzer(f, 10)

--- a/x/btcstaking/keeper/params.go
+++ b/x/btcstaking/keeper/params.go
@@ -7,8 +7,9 @@ import (
 
 	"cosmossdk.io/math"
 	"cosmossdk.io/store/prefix"
-	"github.com/babylonlabs-io/babylon/x/btcstaking/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
+
+	"github.com/babylonlabs-io/babylon/x/btcstaking/types"
 )
 
 // cosmos-sdk does not have utils for uint32

--- a/x/btcstaking/types/btcstaking.go
+++ b/x/btcstaking/types/btcstaking.go
@@ -3,13 +3,10 @@ package types
 import (
 	"fmt"
 
-	"cosmossdk.io/math"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	asig "github.com/babylonlabs-io/babylon/crypto/schnorr-adaptor-signature"
 	bbn "github.com/babylonlabs-io/babylon/types"
-	btcctypes "github.com/babylonlabs-io/babylon/x/btccheckpoint/types"
 )
 
 func (fp *FinalityProvider) IsSlashed() bool {
@@ -104,16 +101,4 @@ func GetOrderedCovenantSignatures(fpIdx int, covSigsList []*CovenantAdaptorSigna
 	}
 
 	return orderedCovSigs, nil
-}
-
-// MinimumUnbondingTime returns the minimum unbonding time. It is the bigger value from:
-// - MinUnbondingTime
-// - CheckpointFinalizationTimeout
-func MinimumUnbondingTime(
-	stakingParams *Params,
-	checkpointingParams *btcctypes.Params) uint32 {
-	return math.Max[uint32](
-		stakingParams.MinUnbondingTimeBlocks,
-		checkpointingParams.CheckpointFinalizationTimeout,
-	)
 }

--- a/x/btcstaking/types/params.go
+++ b/x/btcstaking/types/params.go
@@ -72,9 +72,8 @@ func DefaultParams() Params {
 		MinCommissionRate:    sdkmath.LegacyZeroDec(),
 		// The Default slashing rate is 0.1 i.e., 10% of the total staked BTC will be burned.
 		SlashingRate: sdkmath.LegacyNewDecWithPrec(1, 1), // 1 * 10^{-1} = 0.1
-		// The default minimum unbonding time is 0, which effectively defaults to checkpoint
-		// finalization timeout.
-		MinUnbondingTimeBlocks:       0,
+		// min unbonding time should be always larger than the checkpoint finalization timeout
+		MinUnbondingTimeBlocks:       200,
 		UnbondingFeeSat:              1000,
 		DelegationCreationBaseGasFee: defaultDelegationCreationBaseGasFee,
 		// The default allow list expiration height is 0, which effectively disables the allow list.

--- a/x/btcstaking/types/validate_parsed_message.go
+++ b/x/btcstaking/types/validate_parsed_message.go
@@ -13,7 +13,6 @@ import (
 type ParamsValidationResult struct {
 	StakingOutputIdx   uint32
 	UnbondingOutputIdx uint32
-	MinUnbondingTime   uint32
 }
 
 // ValidateParsedMessageAgainstTheParams validates parsed message against parameters
@@ -201,6 +200,5 @@ func ValidateParsedMessageAgainstTheParams(
 	return &ParamsValidationResult{
 		StakingOutputIdx:   stakingOutputIdx,
 		UnbondingOutputIdx: 0, // unbonding output always has only 1 output
-		MinUnbondingTime:   parameters.MinUnbondingTimeBlocks,
 	}, nil
 }

--- a/x/btcstaking/types/validate_parsed_message_test.go
+++ b/x/btcstaking/types/validate_parsed_message_test.go
@@ -153,7 +153,7 @@ func createMsgDelegationForParams(
 	stakingValue := int64(randRange(r, int(p.MinStakingValueSat), int(p.MaxStakingValueSat)))
 
 	// always chose minimum unbonding time possible
-	unbondingTime := uint16(types.MinimumUnbondingTime(p, cp)) + 1
+	unbondingTime := p.MinUnbondingTimeBlocks
 
 	testStakingInfo := datagen.GenBTCStakingSlashingInfo(
 		r,
@@ -167,7 +167,7 @@ func createMsgDelegationForParams(
 		stakingValue,
 		p.SlashingPkScript,
 		p.SlashingRate,
-		unbondingTime,
+		uint16(unbondingTime),
 	)
 
 	slashingSpendInfo, err := testStakingInfo.StakingInfo.SlashingPathSpendInfo()
@@ -205,7 +205,7 @@ func createMsgDelegationForParams(
 		fpPk,
 		stkTxHash,
 		stkOutputIdx,
-		unbondingTime,
+		uint16(unbondingTime),
 		unbondingValue,
 		p,
 	)
@@ -871,7 +871,7 @@ func TestValidateParsedMessageAgainstTheParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := rand.New(rand.NewSource(time.Now().Unix()))
 
-			msg, params, checkpointParams := tt.fn(r, t)
+			msg, params, _ := tt.fn(r, t)
 
 			parsed, err := types.ParseCreateDelegationMessage(msg)
 
@@ -885,7 +885,6 @@ func TestValidateParsedMessageAgainstTheParams(t *testing.T) {
 			got, err := types.ValidateParsedMessageAgainstTheParams(
 				parsed,
 				params,
-				checkpointParams,
 				&chaincfg.MainNetParams,
 			)
 
@@ -895,9 +894,7 @@ func TestValidateParsedMessageAgainstTheParams(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, got)
-
-				minUnbondingTime := types.MinimumUnbondingTime(params, checkpointParams)
-				require.Equal(t, minUnbondingTime, got.MinUnbondingTime)
+				require.Equal(t, params.MinUnbondingTimeBlocks, got.MinUnbondingTime)
 			}
 
 		})

--- a/x/btcstaking/types/validate_parsed_message_test.go
+++ b/x/btcstaking/types/validate_parsed_message_test.go
@@ -894,9 +894,7 @@ func TestValidateParsedMessageAgainstTheParams(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, got)
-				require.Equal(t, params.MinUnbondingTimeBlocks, got.MinUnbondingTime)
 			}
-
 		})
 	}
 }

--- a/x/finality/keeper/power_dist_change_test.go
+++ b/x/finality/keeper/power_dist_change_test.go
@@ -686,7 +686,7 @@ func TestDoNotGenerateDuplicateEventsAfterHavingCovenantQuorum(t *testing.T) {
 	h.NoError(err)
 	/*
 		at this point, there should be 1 event that BTC delegation
-		will become expired at end height - w
+		will become expired at end height - min_unbonding_time
 	*/
 	// there exists no event at the current BTC tip
 	btcTip := btclcKeeper.GetTipInfo(h.Ctx)

--- a/x/finality/keeper/power_dist_change_test.go
+++ b/x/finality/keeper/power_dist_change_test.go
@@ -441,7 +441,7 @@ func FuzzBTCDelegationEvents_NoPreApproval(f *testing.F) {
 			stakingValue,
 			1000,
 			0,
-			uint16(stakingParams.MinUnbondingTimeBlocks),
+			0,
 			false,
 			false,
 		)
@@ -679,7 +679,7 @@ func TestDoNotGenerateDuplicateEventsAfterHavingCovenantQuorum(t *testing.T) {
 		stakingValue,
 		1000,
 		0,
-		uint16(stakingParams.MinUnbondingTimeBlocks),
+		0,
 		false,
 		false,
 	)


### PR DESCRIPTION
Closes #263. In particular,
- ensure `checkpointFinalizationTimeout` can never be changed in the update params handler of the btccheckpoint module
- ensure `minUnbondingTime` can not be set to a value less than or equal to `checkpointFinalizationTimeout` in the update params handler of the btcstaking module
- allows `unbondingTime` of a delegation to be set to a value equals to `minUnbondingTime`