### PR TITLE
fix: docs link to old file in x/finality/README.md

### DIFF
--- a/x/finality/README.md
+++ b/x/finality/README.md
@@ -141,7 +141,7 @@ message Params {
 
 ### Voting power table
 
-The [voting power table management](./keeper/voting_power_table.go) maintains
+The [voting power table management](./keeper/power_table.go) maintains
 the voting power table of all finality providers at each height of the Babylon
 chain. The key is the block height concatenated with the finality provider's
 Bitcoin secp256k1 public key in BIP-340 format, and the value is the finality


### PR DESCRIPTION
## Summary

The [Voting power table paragraph](https://github.com/babylonlabs-io/babylon/blob/main/x/finality/README.md#voting-power-table) was added but it links to [the old file before the refactor](https://github.com/babylonlabs-io/babylon/pull/217/files#diff-5ef6b9375392fd87cb13832d73f0e1ff248e412afc8c5b6eba8d2e4e4f7df1ac), which leads to 404.

