### PR TITLE
chore: gh sync workflow from main to base/consumer branch

### DIFF
--- a/.github/workflows/sync_pr_main_to_base.yml
+++ b/.github/workflows/sync_pr_main_to_base.yml
@@ -1,0 +1,17 @@
+name: Create Sync PR from main to base/consumer-chain-support
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  call_sync_branch:
+    uses: babylonlabs-io/.github/.github/workflows/reusable_sync_branch.yml@v0.7.0
+    with:
+      base_branch: "main"
+      target_branch: "base/consumer-chain-support"
+      reviewers: "SebastianElvis,maurolacy,gusin13"
+    secrets: inherit


### PR DESCRIPTION
Sometime ago we merged a gh workflow in base/consumer branch which auto syncs changes from main-> base/consumer branch. But smh the workflow is not triggering and @babylon-devops suggested this might be b/c it's not merged in default branch(main)