### PR TITLE
fix getStatus call on BTCDelegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [#310](https://github.com/babylonlabs-io/babylon/pull/310) implement adr-37 -
 making params valid for btc light client ranges
 
+### Bug fixes
+
+- [#318](https://github.com/babylonlabs-io/babylon/pull/318) Fix BTC delegation status check
+to relay on UnbondingTime in delegation
+
 ## v0.17.2
 
 ### Improvements

--- a/x/btcstaking/keeper/msg_server_test.go
+++ b/x/btcstaking/keeper/msg_server_test.go
@@ -458,10 +458,9 @@ func FuzzAddCovenantSigs(f *testing.F) {
 		require.True(h.T(), actualDel.BtcUndelegation.HasCovenantQuorums(h.BTCStakingKeeper.GetParams(h.Ctx).CovenantQuorum))
 
 		tipHeight := h.BTCLightClientKeeper.GetTipInfo(h.Ctx).Height
-		checkpointTimeout := h.BTCCheckpointKeeper.GetParams(h.Ctx).CheckpointFinalizationTimeout
 		covenantQuorum := h.BTCStakingKeeper.GetParams(h.Ctx).CovenantQuorum
-		status := actualDel.GetStatus(tipHeight, checkpointTimeout, covenantQuorum)
-		votingPower := actualDel.VotingPower(tipHeight, checkpointTimeout, covenantQuorum)
+		status := actualDel.GetStatus(tipHeight, covenantQuorum)
+		votingPower := actualDel.VotingPower(tipHeight, covenantQuorum)
 
 		if usePreApproval {
 			require.Equal(t, status, types.BTCDelegationStatus_VERIFIED)
@@ -520,10 +519,9 @@ func FuzzAddBTCDelegationInclusionProof(f *testing.F) {
 
 		// ensure the BTC delegation is now verified and does not have voting power
 		tipHeight := h.BTCLightClientKeeper.GetTipInfo(h.Ctx).Height
-		checkpointTimeout := h.BTCCheckpointKeeper.GetParams(h.Ctx).CheckpointFinalizationTimeout
 		covenantQuorum := h.BTCStakingKeeper.GetParams(h.Ctx).CovenantQuorum
-		status := actualDel.GetStatus(tipHeight, checkpointTimeout, covenantQuorum)
-		votingPower := actualDel.VotingPower(tipHeight, checkpointTimeout, covenantQuorum)
+		status := actualDel.GetStatus(tipHeight, covenantQuorum)
+		votingPower := actualDel.VotingPower(tipHeight, covenantQuorum)
 
 		require.Equal(t, status, types.BTCDelegationStatus_VERIFIED)
 		require.Zero(t, votingPower)
@@ -534,8 +532,8 @@ func FuzzAddBTCDelegationInclusionProof(f *testing.F) {
 
 		actualDel, err = h.BTCStakingKeeper.GetBTCDelegation(h.Ctx, stakingTxHash)
 		h.NoError(err)
-		status = actualDel.GetStatus(tipHeight, checkpointTimeout, covenantQuorum)
-		votingPower = actualDel.VotingPower(tipHeight, checkpointTimeout, covenantQuorum)
+		status = actualDel.GetStatus(tipHeight, covenantQuorum)
+		votingPower = actualDel.VotingPower(tipHeight, covenantQuorum)
 
 		require.Equal(t, status, types.BTCDelegationStatus_ACTIVE)
 		require.Equal(t, uint64(stakingValue), votingPower)
@@ -559,7 +557,6 @@ func FuzzBTCUndelegate(f *testing.F) {
 		covenantSKs, _ := h.GenAndApplyParams(r)
 
 		bsParams := h.BTCStakingKeeper.GetParams(h.Ctx)
-		wValue := h.BTCCheckpointKeeper.GetParams(h.Ctx).CheckpointFinalizationTimeout
 
 		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
 		require.NoError(t, err)
@@ -594,7 +591,7 @@ func FuzzBTCUndelegate(f *testing.F) {
 		actualDel, err = h.BTCStakingKeeper.GetBTCDelegation(h.Ctx, stakingTxHash)
 		h.NoError(err)
 		btcTip := h.BTCLightClientKeeper.GetTipInfo(h.Ctx).Height
-		status := actualDel.GetStatus(btcTip, wValue, bsParams.CovenantQuorum)
+		status := actualDel.GetStatus(btcTip, bsParams.CovenantQuorum)
 		require.Equal(t, types.BTCDelegationStatus_ACTIVE, status)
 
 		msg := &types.MsgBTCUndelegate{
@@ -617,7 +614,7 @@ func FuzzBTCUndelegate(f *testing.F) {
 		// ensure the BTC delegation is unbonded
 		actualDel, err = h.BTCStakingKeeper.GetBTCDelegation(h.Ctx, stakingTxHash)
 		h.NoError(err)
-		status = actualDel.GetStatus(btcTip, wValue, bsParams.CovenantQuorum)
+		status = actualDel.GetStatus(btcTip, bsParams.CovenantQuorum)
 		require.Equal(t, types.BTCDelegationStatus_UNBONDED, status)
 	})
 }

--- a/x/btcstaking/types/btc_delegation_test.go
+++ b/x/btcstaking/types/btc_delegation_test.go
@@ -23,12 +23,12 @@ func FuzzBTCDelegation(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, seed int64) {
 		r := rand.New(rand.NewSource(seed))
-
+		unbondingTime := uint32(datagen.RandomInt(r, 50))
 		btcDel := &types.BTCDelegation{}
 		// randomise voting power
 		btcDel.TotalSat = datagen.RandomInt(r, 100000)
 		btcDel.BtcUndelegation = &types.BTCUndelegation{}
-
+		btcDel.UnbondingTime = unbondingTime
 		// randomise covenant sig
 		hasCovenantSig := datagen.RandomInt(r, 2) == 0
 		if hasCovenantSig {
@@ -56,11 +56,10 @@ func FuzzBTCDelegation(f *testing.F) {
 
 		// randomise BTC tip and w
 		btcHeight := btcDel.StartHeight + uint32(datagen.RandomInt(r, 50))
-		w := uint32(datagen.RandomInt(r, 50))
 
 		// test expected voting power
-		hasVotingPower := hasCovenantSig && btcDel.StartHeight <= btcHeight && btcHeight+w <= btcDel.EndHeight
-		actualVotingPower := btcDel.VotingPower(btcHeight, w, 1)
+		hasVotingPower := hasCovenantSig && btcDel.StartHeight <= btcHeight && btcHeight+unbondingTime <= btcDel.EndHeight
+		actualVotingPower := btcDel.VotingPower(btcHeight, 1)
 		if hasVotingPower {
 			require.Equal(t, btcDel.TotalSat, actualVotingPower)
 		} else {


### PR DESCRIPTION
With recent changes:
- enforcing that `min_unbonding_time` is always larger than `checkpoint_finalization_timeout`
- changing `min_unbonding_time` to exact `unbonding_time`

`GetStatus` can now rely on `UnbondingTime` in delegation instead of `checkpoint_finalization_timeout`
