### PR TITLE
fix: Decrementing jailed fp counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Bug fixes
+
+- [#324](https://github.com/babylonlabs-io/babylon/pull/324) Fix decrementing
+jailed fp counter
+
 ## v0.18.0
 
 ### Improvements

--- a/x/finality/keeper/msg_server.go
+++ b/x/finality/keeper/msg_server.go
@@ -316,7 +316,7 @@ func (ms msgServer) UnjailFinalityProvider(ctx context.Context, req *types.MsgUn
 		return nil, fmt.Errorf("failed to unjail finality provider %s: %w", fpPk.MarshalHex(), err)
 	}
 
-	types.DecrementJailedFinalityProviderCounter()
+	types.IncrementUnjailedFinalityProviderCounter()
 
 	return &types.MsgUnjailFinalityProviderResponse{}, nil
 }

--- a/x/finality/types/metrics.go
+++ b/x/finality/types/metrics.go
@@ -24,9 +24,14 @@ const (
 
 	/* Metrics for monitoring finality provider liveness */
 
-	// MetricsKeyJailedFinalityProviderCounter is the number of finality providers
-	// that are being labeled as jailed
+	// MetricsKeyJailedFinalityProviderCounter is the total number of finality providers
+	// that are labeled as jailed
 	MetricsKeyJailedFinalityProviderCounter = "jailed_finality_provider_counter"
+	// MetricsKeyUnjailedFinalityProviderCounter is the total number of finality providers
+	// that are unjailed
+	// the number of finality providers that are being jailed can be calculated by
+	// jailed_finality_provider_counter - unjailed_finality_provider_counter
+	MetricsKeyUnjailedFinalityProviderCounter = "unjailed_finality_provider_counter"
 )
 
 // RecordLastHeight records the last height. It is triggered upon `IndexBlock`
@@ -64,14 +69,14 @@ func IncrementJailedFinalityProviderCounter() {
 	)
 }
 
-// DecrementJailedFinalityProviderCounter decrements the counter for the jailed
+// IncrementUnjailedFinalityProviderCounter increments the counter for the unjailed
 // finality providers
-func DecrementJailedFinalityProviderCounter() {
-	keys := []string{MetricsKeyJailedFinalityProviderCounter}
+func IncrementUnjailedFinalityProviderCounter() {
+	keys := []string{MetricsKeyUnjailedFinalityProviderCounter}
 	labels := []metrics.Label{telemetry.NewLabel(telemetry.MetricLabelNameModule, ModuleName)}
 	telemetry.IncrCounterWithLabels(
 		keys,
-		-1,
+		1,
 		labels,
 	)
 }


### PR DESCRIPTION
Closes #259. Using gauge is not easy to fix the issue as we don't know the number of fps being jailed. Therefore, this PR fixed the issue by adding a separate counter for unjailed fps.