### PR TITLE
chore: change IAVL size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Improvements
 
 - [#316](https://github.com/babylonlabs-io/babylon/pull/316) Add testnet upgrade data
+- [#334](https://github.com/babylonlabs-io/babylon/pull/334) Default IAVL cache size
 
 ### Bug fixes
 

--- a/cmd/babylond/cmd/testnet.go
+++ b/cmd/babylond/cmd/testnet.go
@@ -196,10 +196,9 @@ func InitTestnet(
 	babylonConfig.GRPC.Enable = true
 	babylonConfig.GRPC.Address = "0.0.0.0:9090"
 
-	// Disable IAVL cache by default as Babylon leaf nodes can be large, and in case
-	// of big cache values, Babylon node can run out of memory.
-	babylonConfig.IAVLCacheSize = 0
-	babylonConfig.IAVLDisableFastNode = true
+	// IAVLCacheSize of 5000 shouldn't exceed memory usage of 3GB
+	babylonConfig.IAVLCacheSize = 5000
+	babylonConfig.IAVLDisableFastNode = false
 
 	var (
 		genAccounts []authtypes.GenesisAccount


### PR DESCRIPTION
Based on benchmark measurements recommended default size of IAVL cache will be 5000, with fastnode enabled.

![image](https://github.com/user-attachments/assets/b6a51a4c-9c4f-4716-9431-f09946fd7822)

More context in [confluence](https://babylonlabs.atlassian.net/wiki/spaces/BABYLON/pages/83460126/Babylon+node+benchmark+analysis). 