### PR TITLE
chore: add print bip 340 to debug pubkey-raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#338](https://github.com/babylonlabs-io/babylon/pull/338) Add print BIP-340 in
+`debug pubkey-raw` subcommand
 - [#316](https://github.com/babylonlabs-io/babylon/pull/316) Add testnet upgrade data
 
 ### Bug fixes

--- a/cmd/babylond/cmd/debug.go
+++ b/cmd/babylond/cmd/debug.go
@@ -7,12 +7,14 @@ import (
 	"strings"
 
 	"github.com/babylonlabs-io/babylon/types"
+	"github.com/cosmos/cosmos-sdk/client/debug"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 
-	"github.com/cosmos/cosmos-sdk/client/debug"
-	legacybech32 "github.com/cosmos/cosmos-sdk/types/bech32/legacybech32" //nolint:staticcheck // we do old keys, they're keys after all.
+	// this pkg was deprecated but still needs support
+	bech32 "github.com/cosmos/cosmos-sdk/types/bech32/legacybech32" //nolint:staticcheck
+
 	"github.com/spf13/cobra"
 )
 
@@ -97,17 +99,17 @@ func getPubKeyFromRawString(pkstr, keytype string) (cryptotypes.PubKey, error) {
 		}
 	}
 
-	pk, err := legacybech32.UnmarshalPubKey(legacybech32.AccPK, pkstr) //nolint:staticcheck // we do old keys, they're keys after all.
+	pk, err := bech32.UnmarshalPubKey(bech32.AccPK, pkstr) //nolint:staticcheck
 	if err == nil {
 		return pk, nil
 	}
 
-	pk, err = legacybech32.UnmarshalPubKey(legacybech32.ValPK, pkstr) //nolint:staticcheck // we do old keys, they're keys after all.
+	pk, err = bech32.UnmarshalPubKey(bech32.ValPK, pkstr) //nolint:staticcheck
 	if err == nil {
 		return pk, nil
 	}
 
-	pk, err = legacybech32.UnmarshalPubKey(legacybech32.ConsPK, pkstr) //nolint:staticcheck // we do old keys, they're keys after all.
+	pk, err = bech32.UnmarshalPubKey(bech32.ConsPK, pkstr) //nolint:staticcheck
 	if err == nil {
 		return pk, nil
 	}

--- a/cmd/babylond/cmd/debug.go
+++ b/cmd/babylond/cmd/debug.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/babylonlabs-io/babylon/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+
+	"github.com/cosmos/cosmos-sdk/client/debug"
+	legacybech32 "github.com/cosmos/cosmos-sdk/types/bech32/legacybech32" //nolint:staticcheck // we do old keys, they're keys after all.
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagPubkeyType = "type"
+	ed             = "ed25519"
+)
+
+// DebugCmd creates a main CLI command
+func DebugCmd() *cobra.Command {
+	debugCmd := debug.Cmd()
+
+	pubKeyRawCmd := GetSubCommand(debugCmd, "pubkey-raw")
+	if pubKeyRawCmd == nil {
+		panic("failed to find keys pubkey-raw")
+	}
+
+	oldRun := pubKeyRawCmd.RunE
+	pubKeyRawCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		// Run the original command
+		err := oldRun(cmd, args)
+		if err != nil {
+			return err
+		}
+
+		return PrintBip340(cmd, args)
+	}
+	return debugCmd
+}
+
+// PrintBip340 prints the BIP340 hex from the public key if possible
+func PrintBip340(cmd *cobra.Command, args []string) error {
+	pubkeyType, err := cmd.Flags().GetString(flagPubkeyType)
+	if err != nil {
+		return err
+	}
+
+	pk, err := getPubKeyFromRawString(args[0], pubkeyType)
+	if err != nil {
+		return err
+	}
+
+	bip340Key := types.BIP340PubKey(pk.Bytes())
+	if err != nil {
+		return err
+	}
+
+	cmd.Println("BIP340 Hex:", bip340Key.MarshalHex())
+	return nil
+}
+
+// GetSubCommand returns the command if it finds, otherwise it returns nil
+func GetSubCommand(cmd *cobra.Command, commandName string) *cobra.Command {
+	for _, c := range cmd.Commands() {
+		if !strings.EqualFold(c.Name(), commandName) {
+			continue
+		}
+		return c
+	}
+	return nil
+}
+
+// getPubKeyFromRawString returns a PubKey (PubKeyEd25519 or PubKeySecp256k1) by attempting
+// to decode the pubkey string from hex, base64, and finally bech32. If all
+// encodings fail, an error is returned.
+// copy from https://github.com/cosmos/cosmos-sdk/blob/08fdfec9543b02ad2a72c5300ad3394916af9e02/client/debug/main.go#L142
+func getPubKeyFromRawString(pkstr, keytype string) (cryptotypes.PubKey, error) {
+	// Try hex decoding
+	bz, err := hex.DecodeString(pkstr)
+	if err == nil {
+		pk, ok := bytesToPubkey(bz, keytype)
+		if ok {
+			return pk, nil
+		}
+	}
+
+	bz, err = base64.StdEncoding.DecodeString(pkstr)
+	if err == nil {
+		pk, ok := bytesToPubkey(bz, keytype)
+		if ok {
+			return pk, nil
+		}
+	}
+
+	pk, err := legacybech32.UnmarshalPubKey(legacybech32.AccPK, pkstr) //nolint:staticcheck // we do old keys, they're keys after all.
+	if err == nil {
+		return pk, nil
+	}
+
+	pk, err = legacybech32.UnmarshalPubKey(legacybech32.ValPK, pkstr) //nolint:staticcheck // we do old keys, they're keys after all.
+	if err == nil {
+		return pk, nil
+	}
+
+	pk, err = legacybech32.UnmarshalPubKey(legacybech32.ConsPK, pkstr) //nolint:staticcheck // we do old keys, they're keys after all.
+	if err == nil {
+		return pk, nil
+	}
+
+	return nil, fmt.Errorf("pubkey '%s' invalid; expected hex, base64, or bech32 of correct size", pkstr)
+}
+
+// copy from https://github.com/cosmos/cosmos-sdk/blob/08fdfec9543b02ad2a72c5300ad3394916af9e02/client/debug/main.go#L126
+func bytesToPubkey(bz []byte, keytype string) (cryptotypes.PubKey, bool) {
+	if keytype == ed {
+		if len(bz) == ed25519.PubKeySize {
+			return &ed25519.PubKey{Key: bz}, true
+		}
+	}
+
+	if len(bz) == secp256k1.PubKeySize {
+		return &secp256k1.PubKey{Key: bz}, true
+	}
+	return nil, false
+}

--- a/cmd/babylond/cmd/root.go
+++ b/cmd/babylond/cmd/root.go
@@ -23,7 +23,6 @@ import (
 
 	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/debug"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
@@ -177,7 +176,7 @@ func initRootCmd(rootCmd *cobra.Command, txConfig client.TxEncodingConfig, basic
 		genhelpers.CmdGenHelpers(gentxModule.GenTxValidator),
 		CreateBlsKeyCmd(),
 		ModuleSizeCmd(),
-		debug.Cmd(),
+		DebugCmd(),
 		confixcmd.ConfigCommand(),
 	)
 


### PR DESCRIPTION
- Helps to convert keys from pub key 

```shell
babylond debug pubkey-raw "A2h06lj/GAPW1RvJE3HU9yetMGCR9K7a+tcwwTYT8t7z"
Parsed key as secp256k1
Address: 3565AEBC1D0CF089A4C2B04500EFE5007701604E
JSON (base64): {"type":"tendermint/PubKeySecp256k1","value":"A2h06lj/GAPW1RvJE3HU9yetMGCR9K7a+tcwwTYT8t7z"}
Bech32 Acc: bbnpub1addwnpepqd58f6jcluvq84k4r0y3xuw57un66vrqj862akh66ucvzdsn7t00x5n57a8
Bech32 Validator Operator: bbnvaloperpub1addwnpepqd58f6jcluvq84k4r0y3xuw57un66vrqj862akh66ucvzdsn7t00x4p4spq
Bech32 Validator Consensus: 
BIP340 Hex: 036874ea58ff1803d6d51bc91371d4f727ad306091f4aedafad730c13613f2def3
```