### PR TITLE
[backport] fix: non-determinism while jailing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,13 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug fixes
 
-- [#324](https://github.com/babylonlabs-io/babylon/pull/324) Fix decrementing
-jailed fp counter
-
-### Improvements
-
-- [#326](https://github.com/babylonlabs-io/babylon/pull/326) docs: btcstaking:
-Update btcstaking module docs to include EOI
+- [#342](https://github.com/babylonlabs-io/babylon/pull/342) Fix non-determinism while jailing
 
 ## v0.18.1
 

--- a/testutil/btcstaking-helper/keeper.go
+++ b/testutil/btcstaking-helper/keeper.go
@@ -578,3 +578,14 @@ func (h *Helper) CommitPubRandList(
 
 	return randListInfo
 }
+
+func (h *Helper) AddFinalityProvider(fp *types.FinalityProvider) {
+	err := h.BTCStakingKeeper.AddFinalityProvider(h.Ctx, &types.MsgCreateFinalityProvider{
+		Addr:        fp.Addr,
+		Description: fp.Description,
+		Commission:  fp.Commission,
+		BtcPk:       fp.BtcPk,
+		Pop:         fp.Pop,
+	})
+	h.NoError(err)
+}

--- a/x/finality/keeper/liveness_test.go
+++ b/x/finality/keeper/liveness_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	testutil "github.com/babylonlabs-io/babylon/testutil/btcstaking-helper"
 	"github.com/babylonlabs-io/babylon/testutil/datagen"
 	keepertest "github.com/babylonlabs-io/babylon/testutil/keeper"
+	btclctypes "github.com/babylonlabs-io/babylon/x/btclightclient/types"
 	bstypes "github.com/babylonlabs-io/babylon/x/btcstaking/types"
 	"github.com/babylonlabs-io/babylon/x/finality/types"
 )
@@ -76,5 +78,133 @@ func FuzzHandleLiveness(f *testing.F) {
 		require.NoError(t, err)
 		require.Equal(t, blockTime.Add(params.JailDuration).Unix(), signingInfo.JailedUntil.Unix())
 		require.Equal(t, int64(0), signingInfo.MissedBlocksCounter)
+	})
+}
+
+// FuzzHandleLivenessDeterminism tests the property of determinism of
+// HandleLiveness by creating two helpers with the same steps to jailing
+// and asserting the jailing events should be with the same order
+func FuzzHandleLivenessDeterminism(f *testing.F) {
+	datagen.AddRandomSeedsToFuzzer(f, 10)
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// mock BTC light client and BTC checkpoint modules
+		btclcKeeper := bstypes.NewMockBTCLightClientKeeper(ctrl)
+		btccKeeper := bstypes.NewMockBtcCheckpointKeeper(ctrl)
+		h1 := testutil.NewHelper(t, btclcKeeper, btccKeeper)
+		h2 := testutil.NewHelper(t, btclcKeeper, btccKeeper)
+
+		// set all parameters
+		covenantSKs, _ := h1.GenAndApplyParams(r)
+		params := h1.BTCStakingKeeper.GetParams(h1.Ctx)
+		err := h2.BTCStakingKeeper.SetParams(h2.Ctx, params)
+		require.NoError(t, err)
+		changeAddress, err := datagen.GenRandomBTCAddress(r, h1.Net)
+		require.NoError(t, err)
+
+		// Generate multiple finality providers
+		numFPs := 5 // Can be adjusted or randomized
+		fps := make([]*bstypes.FinalityProvider, numFPs)
+		for i := 0; i < numFPs; i++ {
+			fpSK, fpPK, fp := h1.CreateFinalityProvider(r)
+			require.NoError(t, err)
+			h2.AddFinalityProvider(fp)
+			h1.CommitPubRandList(r, fpSK, fp, 1, 1000, true)
+			h2.CommitPubRandList(r, fpSK, fp, 1, 1000, true)
+			fps[i] = fp
+
+			// Create delegation for each FP
+			stakingValue := int64(2 * 10e8)
+			delSK, _, err := datagen.GenRandomBTCKeyPair(r)
+			require.NoError(t, err)
+			stakingTxHash, msgCreateBTCDel, actualDel, btcHeaderInfo, inclusionProof, _, err := h1.CreateDelegationWithBtcBlockHeight(
+				r,
+				delSK,
+				fpPK,
+				changeAddress.EncodeAddress(),
+				stakingValue,
+				1000,
+				0,
+				0,
+				true,
+				false,
+				10,
+				10,
+			)
+			require.NoError(t, err)
+			stakingTxHash2, msgCreateBTCDel2, actualDel2, btcHeaderInfo2, inclusionProof2, _, err := h2.CreateDelegationWithBtcBlockHeight(
+				r,
+				delSK,
+				fpPK,
+				changeAddress.EncodeAddress(),
+				stakingValue,
+				1000,
+				0,
+				0,
+				true,
+				false,
+				10,
+				10,
+			)
+			require.NoError(t, err)
+			// generate and insert new covenant signatures
+			h1.CreateCovenantSigs(r, covenantSKs, msgCreateBTCDel, actualDel, 10)
+			h2.CreateCovenantSigs(r, covenantSKs, msgCreateBTCDel2, actualDel2, 10)
+			// activate BTC delegation
+			// after that, all BTC delegations will have voting power
+			h1.AddInclusionProof(stakingTxHash, btcHeaderInfo, inclusionProof, 30)
+			h2.AddInclusionProof(stakingTxHash2, btcHeaderInfo2, inclusionProof2, 30)
+		}
+
+		fParams := h1.FinalityKeeper.GetParams(h1.Ctx)
+		minSignedPerWindow := fParams.MinSignedPerWindowInt()
+		maxMissed := fParams.SignedBlocksWindow - minSignedPerWindow
+
+		nextHeight := datagen.RandomInt(r, 10) + 2 + uint64(minSignedPerWindow)
+
+		btcTip := &btclctypes.BTCHeaderInfo{Height: 30}
+		// for blocks up to the inactivity boundary, mark the finality provider as having not signed
+		sluggishDetectedHeight := nextHeight + uint64(maxMissed)
+		for ; nextHeight < sluggishDetectedHeight; nextHeight++ {
+			h1.SetCtxHeight(nextHeight)
+			h1.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h1.Ctx)).Return(btcTip).AnyTimes()
+			h1.BeginBlocker()
+			h1.FinalityKeeper.HandleLiveness(h1.Ctx, int64(nextHeight))
+
+			h2.SetCtxHeight(nextHeight)
+			h2.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h2.Ctx)).Return(btcTip).AnyTimes()
+			h2.BeginBlocker()
+			h2.FinalityKeeper.HandleLiveness(h2.Ctx, int64(nextHeight))
+		}
+
+		// after next height, the fp will be jailed
+		h1.SetCtxHeight(nextHeight)
+		h1.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h1.Ctx)).Return(btcTip).AnyTimes()
+		h1.BeginBlocker()
+
+		h1.FinalityKeeper.HandleLiveness(h1.Ctx, int64(nextHeight))
+		events := h1.BTCStakingKeeper.GetAllPowerDistUpdateEvents(h1.Ctx, btcTip.Height, btcTip.Height)
+		require.Equal(t, numFPs, len(events))
+
+		h2.SetCtxHeight(nextHeight)
+		h2.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h2.Ctx)).Return(btcTip).AnyTimes()
+		h2.BeginBlocker()
+
+		h2.FinalityKeeper.HandleLiveness(h2.Ctx, int64(nextHeight))
+		events2 := h2.BTCStakingKeeper.GetAllPowerDistUpdateEvents(h2.Ctx, btcTip.Height, btcTip.Height)
+		require.Equal(t, numFPs, len(events))
+
+		// ensure the jailing events are in the same order in two different runs
+		for i, e := range events {
+			e1, ok := e.Ev.(*bstypes.EventPowerDistUpdate_JailedFp)
+			require.True(t, ok)
+			e2, ok := events2[i].Ev.(*bstypes.EventPowerDistUpdate_JailedFp)
+			require.True(t, ok)
+			require.Equal(t, e1.JailedFp.Pk.MarshalHex(), e2.JailedFp.Pk.MarshalHex())
+		}
 	})
 }

--- a/x/finality/keeper/liveness_test.go
+++ b/x/finality/keeper/liveness_test.go
@@ -133,7 +133,6 @@ func FuzzHandleLivenessDeterminism(f *testing.F) {
 				true,
 				false,
 				10,
-				10,
 			)
 			require.NoError(t, err)
 			stakingTxHash2, msgCreateBTCDel2, actualDel2, btcHeaderInfo2, inclusionProof2, _, err := h2.CreateDelegationWithBtcBlockHeight(
@@ -148,16 +147,15 @@ func FuzzHandleLivenessDeterminism(f *testing.F) {
 				true,
 				false,
 				10,
-				10,
 			)
 			require.NoError(t, err)
 			// generate and insert new covenant signatures
-			h1.CreateCovenantSigs(r, covenantSKs, msgCreateBTCDel, actualDel, 10)
-			h2.CreateCovenantSigs(r, covenantSKs, msgCreateBTCDel2, actualDel2, 10)
+			h1.CreateCovenantSigs(r, covenantSKs, msgCreateBTCDel, actualDel)
+			h2.CreateCovenantSigs(r, covenantSKs, msgCreateBTCDel2, actualDel2)
 			// activate BTC delegation
 			// after that, all BTC delegations will have voting power
-			h1.AddInclusionProof(stakingTxHash, btcHeaderInfo, inclusionProof, 30)
-			h2.AddInclusionProof(stakingTxHash2, btcHeaderInfo2, inclusionProof2, 30)
+			h1.AddInclusionProof(stakingTxHash, btcHeaderInfo, inclusionProof)
+			h2.AddInclusionProof(stakingTxHash2, btcHeaderInfo2, inclusionProof2)
 		}
 
 		fParams := h1.FinalityKeeper.GetParams(h1.Ctx)


### PR DESCRIPTION
The voting power table is a map which causes random order of processing jailing events. If more than one fps jailed at one block, non-determinism could happen. The PR fixed this by introducing ordered voting power table which retains the order from interating the `votingPowerBbnBlockHeightStore`