### PR TITLE
fix: remove unused deps in `.proto` files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,15 @@ jobs:
      run-integration-tests: false
      run-lint: true
 
+  proto_lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run proto lint
+        run: |
+          make proto-lint
+
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,7 @@ protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(pro
 
 proto-all: proto-gen proto-swagger-gen ## Generate all protobuf related files
 
-proto-gen: ## Generate protobuf files
+proto-gen: proto-lint ## Generate protobuf files
 	@echo "Generating Protobuf files"
 	@$(protoImage) sh ./proto/scripts/protocgen.sh
 
@@ -433,7 +433,7 @@ proto-format: ## Format protobuf files
 proto-lint: ## Lint protobuf files
 	@$(protoImage) buf lint --error-format=json
 
-.PHONY: proto-gen proto-swagger-gen proto-format prot-lint
+.PHONY: proto-gen proto-swagger-gen proto-format proto-lint
 
 ###############################################################################
 ###                                Docker                                   ###

--- a/proto/babylon/btcstaking/v1/events.proto
+++ b/proto/babylon/btcstaking/v1/events.proto
@@ -2,13 +2,12 @@ syntax = "proto3";
 package babylon.btcstaking.v1;
 
 import "gogoproto/gogo.proto";
-import "cosmos/staking/v1beta1/staking.proto";
 import "babylon/btcstaking/v1/btcstaking.proto";
-import "cosmos_proto/cosmos.proto";
 import "amino/amino.proto";
 
 option go_package = "github.com/babylonlabs-io/babylon/x/btcstaking/types";
 
+// EventNewFinalityProvider is the event emitted when new finality provider is created
 message EventNewFinalityProvider {
   FinalityProvider fp = 1;
 }

--- a/proto/babylon/btcstkconsumer/v1/btcstkconsumer.proto
+++ b/proto/babylon/btcstkconsumer/v1/btcstkconsumer.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package babylon.btcstkconsumer.v1;
 
-import "gogoproto/gogo.proto";
 import "cosmos_proto/cosmos.proto";
 
 option go_package = "github.com/babylonlabs-io/babylon/x/btcstkconsumer/types";

--- a/proto/babylon/checkpointing/v1/query.proto
+++ b/proto/babylon/checkpointing/v1/query.proto
@@ -4,7 +4,6 @@ package babylon.checkpointing.v1;
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
-import "babylon/checkpointing/v1/bls_key.proto";
 import "babylon/checkpointing/v1/checkpoint.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 

--- a/proto/babylon/finality/v1/tx.proto
+++ b/proto/babylon/finality/v1/tx.proto
@@ -8,7 +8,6 @@ import "tendermint/crypto/proof.proto";
 import "cosmos_proto/cosmos.proto";
 import "cosmos/msg/v1/msg.proto";
 import "babylon/finality/v1/params.proto";
-import "babylon/finality/v1/finality.proto";
 
 // Msg defines the Msg service.
 service Msg {

--- a/proto/babylon/incentive/query.proto
+++ b/proto/babylon/incentive/query.proto
@@ -4,7 +4,6 @@ package babylon.incentive;
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "babylon/incentive/params.proto";
-import "babylon/incentive/incentive.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
 option go_package = "github.com/babylonlabs-io/babylon/x/incentive/types";

--- a/proto/babylon/mint/v1/query.proto
+++ b/proto/babylon/mint/v1/query.proto
@@ -3,7 +3,6 @@ package babylon.mint.v1;
 
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
-import "babylon/mint/v1/mint.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/babylonlabs-io/babylon/x/mint/types";


### PR DESCRIPTION
## Summary

This PR removes unused dependencies in `.proto` files, addressing the protobuf generation issue outlined in [babylon-contract/issues/101](https://github.com/babylonlabs-io/babylon-contract/issues/101).


## Test Plan

```
make proto-lint
```