### PR TITLE
refactor(btccheckpoint): remove unnecessary index boundary check

### DIFF
--- a/x/btccheckpoint/types/msgs.go
+++ b/x/btccheckpoint/types/msgs.go
@@ -53,9 +53,6 @@ func ParseTwoProofs(
 	var checkpointData [][]byte
 
 	for i, proof := range parsedProofs {
-		if i > math.MaxUint8 || i < 0 {
-			return nil, fmt.Errorf("expected at most 255 proofs but got %d", len(parsedProofs))
-		}
 		partIdxUint8 := uint8(i)
 		data, err := txformat.GetCheckpointData(
 			expectedTag,


### PR DESCRIPTION
Remove unnecessary index boundary check in checkpoint data processing since:
- Loop index `i` is always non-negative in Go
- [`NumberOfParts`](https://github.com/babylonlabs-io/babylon/blob/bf53a4aaa564afae9676a37f998ac0eeb2b96890/x/btccheckpoint/types/msgs.go#L30) is fixed at 2, so `i` will never exceed `math.MaxUint8`
