### PR TITLE
fix: slashed fp and BTC rewards tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Bug fixes
+
+- [#371](https://github.com/babylonlabs-io/babylon/pull/371) Do not prune BTC
+reward tracker structures at the slash of finality provider.
+
+## v1.0.0-rc.1
+
 ### Improvements
 
 - [#306](https://github.com/babylonlabs-io/babylon/pull/306) feat: improve BTC reward distribution with

--- a/test/e2e/btc_rewards_distribution_e2e_test.go
+++ b/test/e2e/btc_rewards_distribution_e2e_test.go
@@ -402,13 +402,15 @@ func (s *BtcRewardsDistribution) Test7CheckRewards() {
 	// (del2) => 10_00000000
 	fp1RewardGaugePrev, fp2RewardGaugePrev, btcDel1RewardGaugePrev, btcDel2RewardGaugePrev := s.QueryRewardGauges(n2)
 	// wait a few block of rewards to calculate the difference
-	n2.WaitForNextBlocks(2)
 	s.AddFinalityVoteUntilCurrentHeight()
 	n2.WaitForNextBlocks(2)
 	s.AddFinalityVoteUntilCurrentHeight()
 	n2.WaitForNextBlocks(2)
 	s.AddFinalityVoteUntilCurrentHeight()
 	n2.WaitForNextBlocks(2)
+	s.AddFinalityVoteUntilCurrentHeight()
+	n2.WaitForNextBlocks(2)
+	s.AddFinalityVoteUntilCurrentHeight()
 
 	fp1RewardGauge, fp2RewardGauge, btcDel1RewardGauge, btcDel2RewardGauge := s.QueryRewardGauges(n2)
 

--- a/test/e2e/btc_rewards_distribution_e2e_test.go
+++ b/test/e2e/btc_rewards_distribution_e2e_test.go
@@ -317,8 +317,8 @@ func (s *BtcRewardsDistribution) Test5CheckRewardsFirstDelegations() {
 	s.Len(fps, 2)
 	s.Equal(fps[0].Commission.String(), fps[1].Commission.String())
 	for _, fp := range fps {
-		s.Equal(fp.SlashedBabylonHeight, 0)
-		s.Equal(fp.SlashedBtcHeight, 0)
+		s.Equal(fp.SlashedBabylonHeight, uint64(0))
+		s.Equal(fp.SlashedBtcHeight, uint32(0))
 	}
 
 	dels := n2.QueryFinalityProvidersDelegations(s.fp1.BtcPk.MarshalHex(), s.fp2.BtcPk.MarshalHex())

--- a/testutil/btcstaking-helper/keeper.go
+++ b/testutil/btcstaking-helper/keeper.go
@@ -230,7 +230,6 @@ func (h *Helper) CreateDelegation(
 	r *rand.Rand,
 	delSK *btcec.PrivateKey,
 	fpPK *btcec.PublicKey,
-	changeAddress string,
 	stakingValue int64,
 	stakingTime uint16,
 	unbondingValue int64,
@@ -239,7 +238,7 @@ func (h *Helper) CreateDelegation(
 	addToAllowList bool,
 ) (string, *types.MsgCreateBTCDelegation, *types.BTCDelegation, *btclctypes.BTCHeaderInfo, *types.InclusionProof, *UnbondingTxInfo, error) {
 	return h.CreateDelegationWithBtcBlockHeight(
-		r, delSK, fpPK, changeAddress, stakingValue,
+		r, delSK, fpPK, stakingValue,
 		stakingTime, unbondingValue, unbondingTime,
 		usePreApproval, addToAllowList, 10, 10,
 	)
@@ -249,7 +248,6 @@ func (h *Helper) CreateDelegationWithBtcBlockHeight(
 	r *rand.Rand,
 	delSK *btcec.PrivateKey,
 	fpPK *btcec.PublicKey,
-	changeAddress string,
 	stakingValue int64,
 	stakingTime uint16,
 	unbondingValue int64,

--- a/testutil/incentives-helper/keeper.go
+++ b/testutil/incentives-helper/keeper.go
@@ -69,9 +69,6 @@ func (h *IncentiveHelper) CreateBtcDelegation(
 ) (
 	stakingTxHash string, msgCreateBTCDel *bstypes.MsgCreateBTCDelegation, actualDel *bstypes.BTCDelegation, unbondingInfo *btcstkhelper.UnbondingTxInfo,
 ) {
-	changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-	h.NoError(err)
-
 	delSK, _, err := datagen.GenRandomBTCKeyPair(r)
 	h.NoError(err)
 
@@ -79,7 +76,6 @@ func (h *IncentiveHelper) CreateBtcDelegation(
 		r,
 		delSK,
 		fpPK,
-		changeAddress.EncodeAddress(),
 		stakingValue,
 		stakingTime,
 		0,

--- a/x/btcstaking/keeper/bench_test.go
+++ b/x/btcstaking/keeper/bench_test.go
@@ -28,8 +28,6 @@ func benchBeginBlock(b *testing.B, numFPs int, numDelsUnderFP int) {
 	h := testutil.NewHelper(b, btclcKeeper, btccKeeper)
 	// set all parameters
 	covenantSKs, _ := h.GenAndApplyParams(r)
-	changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-	h.NoError(err)
 
 	// generate new finality providers
 	fps := []*types.FinalityProvider{}
@@ -60,7 +58,6 @@ func benchBeginBlock(b *testing.B, numFPs int, numDelsUnderFP int) {
 				r,
 				delSK,
 				fp.BtcPk.MustToBTCPK(),
-				changeAddress.EncodeAddress(),
 				stakingValue,
 				1000,
 				0,

--- a/x/btcstaking/keeper/msg_server_test.go
+++ b/x/btcstaking/keeper/msg_server_test.go
@@ -193,9 +193,6 @@ func FuzzCreateBTCDelegation(f *testing.F) {
 		// set all parameters
 		h.GenAndApplyParams(r)
 
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		require.NoError(t, err)
-
 		// generate and insert new finality provider
 		_, fpPK, _ := h.CreateFinalityProvider(r)
 
@@ -213,7 +210,6 @@ func FuzzCreateBTCDelegation(f *testing.F) {
 				r,
 				delSK,
 				fpPK,
-				changeAddress.EncodeAddress(),
 				stakingValue,
 				1000,
 				0,
@@ -229,7 +225,6 @@ func FuzzCreateBTCDelegation(f *testing.F) {
 				r,
 				delSK,
 				fpPK,
-				changeAddress.EncodeAddress(),
 				stakingValue,
 				1000,
 				0,
@@ -305,9 +300,6 @@ func FuzzCreateBTCDelegationWithParamsFromBtcHeight(f *testing.F) {
 		require.Equal(t, version, expectedParamsVersion)
 
 		// creates one BTC delegation with BTC block height between expectedParamsBlockHeight and 500
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		h.NoError(err)
-
 		// generate and insert new finality provider
 		_, fpPK, _ := h.CreateFinalityProvider(r)
 
@@ -320,7 +312,6 @@ func FuzzCreateBTCDelegationWithParamsFromBtcHeight(f *testing.F) {
 			r,
 			delSK,
 			fpPK,
-			changeAddress.EncodeAddress(),
 			stakingValue,
 			1000,
 			0,
@@ -348,9 +339,6 @@ func TestProperVersionInDelegation(t *testing.T) {
 	// set all parameters
 	h.GenAndApplyParams(r)
 
-	changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-	require.NoError(t, err)
-
 	// generate and insert new finality provider
 	_, fpPK, _ := h.CreateFinalityProvider(r)
 
@@ -362,7 +350,6 @@ func TestProperVersionInDelegation(t *testing.T) {
 		r,
 		delSK,
 		fpPK,
-		changeAddress.EncodeAddress(),
 		stakingValue,
 		1000,
 		0,
@@ -396,7 +383,6 @@ func TestProperVersionInDelegation(t *testing.T) {
 		r,
 		delSK,
 		fpPK,
-		changeAddress.EncodeAddress(),
 		stakingValue,
 		10000,
 		stakingValue-1000,
@@ -428,9 +414,6 @@ func TestRejectActivationThatShouldNotUsePreApprovalFlow(t *testing.T) {
 	// set all parameters
 	covenantSKs, _ := h.GenAndApplyParams(r)
 
-	changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-	require.NoError(t, err)
-
 	// generate and insert new finality provider
 	_, fpPK, _ := h.CreateFinalityProvider(r)
 
@@ -439,7 +422,7 @@ func TestRejectActivationThatShouldNotUsePreApprovalFlow(t *testing.T) {
 	// params will be activate at block height 2
 	currentParams.BtcActivationHeight++
 	// Update new params
-	err = h.BTCStakingKeeper.SetParams(h.Ctx, currentParams)
+	err := h.BTCStakingKeeper.SetParams(h.Ctx, currentParams)
 	require.NoError(t, err)
 
 	// generate and insert new BTC delegation
@@ -450,7 +433,6 @@ func TestRejectActivationThatShouldNotUsePreApprovalFlow(t *testing.T) {
 		r,
 		delSK,
 		fpPK,
-		changeAddress.EncodeAddress(),
 		stakingValue,
 		1000,
 		0,
@@ -520,9 +502,6 @@ func FuzzAddCovenantSigs(f *testing.F) {
 		// set all parameters
 		covenantSKs, _ := h.GenAndApplyParams(r)
 
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		require.NoError(t, err)
-
 		// generate and insert new finality provider
 		_, fpPK, _ := h.CreateFinalityProvider(r)
 
@@ -540,7 +519,6 @@ func FuzzAddCovenantSigs(f *testing.F) {
 			r,
 			delSK,
 			fpPK,
-			changeAddress.EncodeAddress(),
 			stakingValue,
 			1000,
 			0,
@@ -610,8 +588,6 @@ func FuzzAddBTCDelegationInclusionProof(f *testing.F) {
 
 		// set all parameters
 		covenantSKs, _ := h.GenAndApplyParams(r)
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		require.NoError(t, err)
 
 		// generate and insert new finality provider
 		_, fpPK, _ := h.CreateFinalityProvider(r)
@@ -624,7 +600,6 @@ func FuzzAddBTCDelegationInclusionProof(f *testing.F) {
 			r,
 			delSK,
 			fpPK,
-			changeAddress.EncodeAddress(),
 			stakingValue,
 			1000,
 			0,
@@ -685,9 +660,6 @@ func FuzzBTCUndelegate(f *testing.F) {
 
 		bsParams := h.BTCStakingKeeper.GetParams(h.Ctx)
 
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		require.NoError(t, err)
-
 		// generate and insert new finality provider
 		_, fpPK, _ := h.CreateFinalityProvider(r)
 
@@ -699,7 +671,6 @@ func FuzzBTCUndelegate(f *testing.F) {
 			r,
 			delSK,
 			fpPK,
-			changeAddress.EncodeAddress(),
 			stakingValue,
 			1000,
 			0,
@@ -767,9 +738,6 @@ func FuzzBTCUndelegateExpired(f *testing.F) {
 
 		bsParams := h.BTCStakingKeeper.GetParams(h.Ctx)
 
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		require.NoError(t, err)
-
 		// generate and insert new finality provider
 		_, fpPK, _ := h.CreateFinalityProvider(r)
 
@@ -781,7 +749,6 @@ func FuzzBTCUndelegateExpired(f *testing.F) {
 			r,
 			delSK,
 			fpPK,
-			changeAddress.EncodeAddress(),
 			stakingValue,
 			1000,
 			0,
@@ -836,9 +803,6 @@ func FuzzSelectiveSlashing(f *testing.F) {
 		covenantSKs, _ := h.GenAndApplyParams(r)
 		bsParams := h.BTCStakingKeeper.GetParams(h.Ctx)
 
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		require.NoError(t, err)
-
 		// generate and insert new finality provider
 		fpSK, fpPK, _ := h.CreateFinalityProvider(r)
 		fpBtcPk := bbn.NewBIP340PubKeyFromBTCPK(fpPK)
@@ -851,7 +815,6 @@ func FuzzSelectiveSlashing(f *testing.F) {
 			r,
 			delSK,
 			fpPK,
-			changeAddress.EncodeAddress(),
 			stakingValue,
 			1000,
 			0,
@@ -916,9 +879,6 @@ func FuzzSelectiveSlashing_StakingTx(f *testing.F) {
 		covenantSKs, _ := h.GenAndApplyParams(r)
 		bsParams := h.BTCStakingKeeper.GetParams(h.Ctx)
 
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		require.NoError(t, err)
-
 		// generate and insert new finality provider
 		fpSK, fpPK, _ := h.CreateFinalityProvider(r)
 		fpBtcPk := bbn.NewBIP340PubKeyFromBTCPK(fpPK)
@@ -931,7 +891,6 @@ func FuzzSelectiveSlashing_StakingTx(f *testing.F) {
 			r,
 			delSK,
 			fpPK,
-			changeAddress.EncodeAddress(),
 			stakingValue,
 			1000,
 			0,
@@ -1166,9 +1125,6 @@ func TestCorrectUnbondingTimeInDelegation(t *testing.T) {
 			// set all parameters
 			_, _ = h.GenAndApplyCustomParams(r, tt.finalizationTimeout, tt.unbondingTimeInParams, 0)
 
-			changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-			require.NoError(t, err)
-
 			// generate and insert new finality provider
 			_, fpPK, _ := h.CreateFinalityProvider(r)
 
@@ -1180,7 +1136,6 @@ func TestCorrectUnbondingTimeInDelegation(t *testing.T) {
 				r,
 				delSK,
 				fpPK,
-				changeAddress.EncodeAddress(),
 				stakingValue,
 				1000,
 				stakingValue-1000,
@@ -1216,9 +1171,6 @@ func TestAllowList(t *testing.T) {
 	// set all parameters, use the allow list
 	h.GenAndApplyCustomParams(r, 100, 0, allowListExpirationHeight)
 
-	changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-	require.NoError(t, err)
-
 	// generate and insert new finality provider
 	_, fpPK, _ := h.CreateFinalityProvider(r)
 
@@ -1232,7 +1184,6 @@ func TestAllowList(t *testing.T) {
 		r,
 		delSK,
 		fpPK,
-		changeAddress.EncodeAddress(),
 		stakingValue,
 		1000,
 		0,
@@ -1252,7 +1203,6 @@ func TestAllowList(t *testing.T) {
 		r,
 		delSK1,
 		fpPK,
-		changeAddress.EncodeAddress(),
 		stakingValue,
 		1000,
 		0,
@@ -1275,7 +1225,6 @@ func TestAllowList(t *testing.T) {
 		r,
 		delSK2,
 		fpPK,
-		changeAddress.EncodeAddress(),
 		stakingValue,
 		1000,
 		0,

--- a/x/finality/keeper/liveness_test.go
+++ b/x/finality/keeper/liveness_test.go
@@ -103,8 +103,6 @@ func FuzzHandleLivenessDeterminism(f *testing.F) {
 		params := h1.BTCStakingKeeper.GetParams(h1.Ctx)
 		err := h2.BTCStakingKeeper.SetParams(h2.Ctx, params)
 		require.NoError(t, err)
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h1.Net)
-		require.NoError(t, err)
 
 		// Generate multiple finality providers
 		numFPs := 5 // Can be adjusted or randomized
@@ -125,7 +123,6 @@ func FuzzHandleLivenessDeterminism(f *testing.F) {
 				r,
 				delSK,
 				fpPK,
-				changeAddress.EncodeAddress(),
 				stakingValue,
 				1000,
 				0,
@@ -140,7 +137,6 @@ func FuzzHandleLivenessDeterminism(f *testing.F) {
 				r,
 				delSK,
 				fpPK,
-				changeAddress.EncodeAddress(),
 				stakingValue,
 				1000,
 				0,

--- a/x/finality/keeper/power_dist_change.go
+++ b/x/finality/keeper/power_dist_change.go
@@ -233,10 +233,17 @@ func (k Keeper) ProcessAllPowerDistUpdateEvents(
 			types.EmitSlashedFPEvent(sdkCtx, typedEvent.SlashedFp.Pk)
 			fpBTCPKHex := typedEvent.SlashedFp.Pk.MarshalHex()
 			slashedFPs[fpBTCPKHex] = struct{}{}
-			fp := k.loadFP(ctx, fpByBtcPkHex, fpBTCPKHex)
-			if err := k.IncentiveKeeper.FpSlashed(ctx, fp.Address()); err != nil {
-				panic(err)
-			}
+			// TODO(rafilx): handle slashed fps prunning
+			// It is not possible to slash fp and delete all of his data at the
+			// babylon block height that is being processed, because
+			// the function RewardBTCStaking is called a few blocks behind.
+			// If the data is deleted at the slash event, when slashed fps are
+			// receveing rewards from a few blocks behind HandleRewarding
+			// verifies the next block height to be rewarded.
+			// fp := k.loadFP(ctx, fpByBtcPkHex, fpBTCPKHex)
+			// if err := k.IncentiveKeeper.FpSlashed(ctx, fp.Address()); err != nil {
+			// 	panic(err)
+			// }
 		case *types.EventPowerDistUpdate_JailedFp:
 			// record jailed fps
 			types.EmitJailedFPEvent(sdkCtx, typedEvent.JailedFp.Pk)

--- a/x/finality/keeper/power_dist_change.go
+++ b/x/finality/keeper/power_dist_change.go
@@ -240,10 +240,6 @@ func (k Keeper) ProcessAllPowerDistUpdateEvents(
 			// If the data is deleted at the slash event, when slashed fps are
 			// receveing rewards from a few blocks behind HandleRewarding
 			// verifies the next block height to be rewarded.
-			// fp := k.loadFP(ctx, fpByBtcPkHex, fpBTCPKHex)
-			// if err := k.IncentiveKeeper.FpSlashed(ctx, fp.Address()); err != nil {
-			// 	panic(err)
-			// }
 		case *types.EventPowerDistUpdate_JailedFp:
 			// record jailed fps
 			types.EmitJailedFPEvent(sdkCtx, typedEvent.JailedFp.Pk)

--- a/x/finality/keeper/power_dist_change_test.go
+++ b/x/finality/keeper/power_dist_change_test.go
@@ -186,9 +186,10 @@ func FuzzProcessAllPowerDistUpdateEvents_PreApprovalWithSlahedFP(f *testing.F) {
 		require.Len(t, newDc.FinalityProviders, 1)
 		require.Equal(t, newDc.TotalVotingPower, delNoPreApproval.TotalSat)
 
-		// simulating a new BTC delegation with preapproval comming
+		// simulating a new BTC delegation with preapproval coming
 		delSKPreApproval, _, err := datagen.GenRandomBTCKeyPair(r)
 		h.NoError(err)
+
 		stakingTxHash, msgCreateBTCDelPreApproval, delPreApproval, btcHeaderInfo, inclusionProof, _, err := h.CreateDelegationWithBtcBlockHeight(
 			r,
 			delSKPreApproval,
@@ -202,6 +203,7 @@ func FuzzProcessAllPowerDistUpdateEvents_PreApprovalWithSlahedFP(f *testing.F) {
 			10,
 			10,
 		)
+		h.NoError(err)
 
 		// should not modify the amount of voting power
 		newDc.ApplyActiveFinalityProviders(100)

--- a/x/finality/keeper/power_table_test.go
+++ b/x/finality/keeper/power_table_test.go
@@ -32,8 +32,6 @@ func FuzzVotingPowerTable(f *testing.F) {
 
 		// set all parameters
 		covenantSKs, _ := h.GenAndApplyParams(r)
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		h.NoError(err)
 
 		// generate a random batch of finality providers, and commit pub rand list with timestamp
 		fps := []*types.FinalityProvider{}
@@ -56,7 +54,6 @@ func FuzzVotingPowerTable(f *testing.F) {
 					r,
 					delSK,
 					fps[i].BtcPk.MustToBTCPK(),
-					changeAddress.EncodeAddress(),
 					int64(stakingValue),
 					1000,
 					0,
@@ -78,7 +75,7 @@ func FuzzVotingPowerTable(f *testing.F) {
 		babylonHeight := datagen.RandomInt(r, 10) + 1
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(&btclctypes.BTCHeaderInfo{Height: 30}).AnyTimes()
-		err = h.BTCStakingKeeper.BeginBlocker(h.Ctx)
+		err := h.BTCStakingKeeper.BeginBlocker(h.Ctx)
 		require.NoError(t, err)
 		err = h.FinalityKeeper.BeginBlocker(h.Ctx)
 		require.NoError(t, err)
@@ -185,8 +182,6 @@ func FuzzRecordVotingPowerDistCache(f *testing.F) {
 
 		// set all parameters
 		covenantSKs, _ := h.GenAndApplyParams(r)
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		h.NoError(err)
 
 		// generate a random batch of finality providers, and commit
 		// pub rand list with timestamp
@@ -214,7 +209,6 @@ func FuzzRecordVotingPowerDistCache(f *testing.F) {
 					r,
 					delSK,
 					fp.BtcPk.MustToBTCPK(),
-					changeAddress.EncodeAddress(),
 					int64(stakingValue),
 					1000,
 					0,
@@ -265,8 +259,6 @@ func FuzzVotingPowerTable_ActiveFinalityProviders(f *testing.F) {
 
 		// set all parameters
 		covenantSKs, _ := h.GenAndApplyParams(r)
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		h.NoError(err)
 
 		// generate a random batch of finality providers, each with a BTC delegation with random power
 		fpsWithMeta := []*ftypes.FinalityProviderDistInfo{}
@@ -284,7 +276,6 @@ func FuzzVotingPowerTable_ActiveFinalityProviders(f *testing.F) {
 				r,
 				delSK,
 				fp.BtcPk.MustToBTCPK(),
-				changeAddress.EncodeAddress(),
 				int64(stakingValue),
 				1000,
 				0,
@@ -376,9 +367,6 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 		fParams.MaxActiveFinalityProviders = uint32(datagen.RandomInt(r, 20) + 10)
 		err := h.FinalityKeeper.SetParams(h.Ctx, fParams)
 		h.NoError(err)
-		// change address
-		changeAddress, err := datagen.GenRandomBTCAddress(r, h.Net)
-		h.NoError(err)
 
 		numFps := datagen.RandomInt(r, 20) + 10
 		numActiveFPs := int(min(numFps, uint64(fParams.MaxActiveFinalityProviders)))
@@ -403,7 +391,6 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 				r,
 				delSK,
 				fpPK,
-				changeAddress.EncodeAddress(),
 				int64(stakingValue),
 				1000,
 				0,
@@ -462,7 +449,6 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 				r,
 				delSK,
 				fpBTCPK.MustToBTCPK(),
-				changeAddress.EncodeAddress(),
 				int64(stakingValue),
 				1000,
 				0,
@@ -499,7 +485,6 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 				r,
 				delSK,
 				fpPK,
-				changeAddress.EncodeAddress(),
 				int64(stakingValue),
 				1000,
 				0,

--- a/x/finality/types/expected_keepers.go
+++ b/x/finality/types/expected_keepers.go
@@ -37,5 +37,4 @@ type IncentiveKeeper interface {
 	IndexRefundableMsg(ctx context.Context, msg sdk.Msg)
 	BtcDelegationActivated(ctx context.Context, fp, del sdk.AccAddress, sat uint64) error
 	BtcDelegationUnbonded(ctx context.Context, fp, del sdk.AccAddress, sat uint64) error
-	FpSlashed(ctx context.Context, fp sdk.AccAddress) error
 }

--- a/x/finality/types/power_table.go
+++ b/x/finality/types/power_table.go
@@ -87,6 +87,10 @@ func (dc *VotingPowerDistCache) ApplyActiveFinalityProviders(maxActiveFPs uint32
 		if fp.IsJailed {
 			break
 		}
+		if fp.IsSlashed {
+			break
+		}
+
 		numActiveFPs++
 	}
 
@@ -170,8 +174,8 @@ func (v *FinalityProviderDistInfo) GetBTCDelPortion(totalSatDelegation uint64) s
 // 2. IsJailed is true
 func SortFinalityProvidersWithZeroedVotingPower(fps []*FinalityProviderDistInfo) {
 	sort.SliceStable(fps, func(i, j int) bool {
-		iShouldBeZeroed := fps[i].IsJailed || !fps[i].IsTimestamped
-		jShouldBeZeroed := fps[j].IsJailed || !fps[j].IsTimestamped
+		iShouldBeZeroed := fps[i].IsJailed || !fps[i].IsTimestamped || fps[i].IsSlashed
+		jShouldBeZeroed := fps[j].IsJailed || !fps[j].IsTimestamped || fps[j].IsSlashed
 
 		if iShouldBeZeroed && !jShouldBeZeroed {
 			return false

--- a/x/incentive/keeper/btc_staking_gauge.go
+++ b/x/incentive/keeper/btc_staking_gauge.go
@@ -56,7 +56,7 @@ func (k Keeper) RewardBTCStaking(ctx context.Context, height uint64, dc *ftypes.
 		// reward the rest of coins to each BTC delegation proportional to its voting power portion
 		coinsForBTCDels := coinsForFpsAndDels.Sub(coinsForCommission...)
 		if err := k.AddFinalityProviderRewardsForBtcDelegations(ctx, fp.GetAddress(), coinsForBTCDels); err != nil {
-			panic(fmt.Errorf("failed to add fp rewards for btc delegation %s: %w", fp.GetAddress().String(), err))
+			panic(fmt.Errorf("failed to add fp rewards for btc delegation %s at height %d: %w", fp.GetAddress().String(), err, height))
 		}
 	}
 	// TODO: prune unnecessary state (delete BTCStakingGauge after the amount is used)

--- a/x/incentive/keeper/btc_staking_gauge.go
+++ b/x/incentive/keeper/btc_staking_gauge.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
 	sdkmath "cosmossdk.io/math"
 	"cosmossdk.io/store/prefix"
@@ -55,7 +56,7 @@ func (k Keeper) RewardBTCStaking(ctx context.Context, height uint64, dc *ftypes.
 		// reward the rest of coins to each BTC delegation proportional to its voting power portion
 		coinsForBTCDels := coinsForFpsAndDels.Sub(coinsForCommission...)
 		if err := k.AddFinalityProviderRewardsForBtcDelegations(ctx, fp.GetAddress(), coinsForBTCDels); err != nil {
-			panic(err)
+			panic(fmt.Errorf("failed to add fp rewards for btc delegation %s: %w", fp.GetAddress().String(), err))
 		}
 	}
 	// TODO: prune unnecessary state (delete BTCStakingGauge after the amount is used)

--- a/x/incentive/keeper/btc_staking_gauge.go
+++ b/x/incentive/keeper/btc_staking_gauge.go
@@ -56,7 +56,7 @@ func (k Keeper) RewardBTCStaking(ctx context.Context, height uint64, dc *ftypes.
 		// reward the rest of coins to each BTC delegation proportional to its voting power portion
 		coinsForBTCDels := coinsForFpsAndDels.Sub(coinsForCommission...)
 		if err := k.AddFinalityProviderRewardsForBtcDelegations(ctx, fp.GetAddress(), coinsForBTCDels); err != nil {
-			panic(fmt.Errorf("failed to add fp rewards for btc delegation %s at height %d: %w", fp.GetAddress().String(), err, height))
+			panic(fmt.Errorf("failed to add fp rewards for btc delegation %s at height %d: %w", fp.GetAddress().String(), height, err))
 		}
 	}
 	// TODO: prune unnecessary state (delete BTCStakingGauge after the amount is used)

--- a/x/incentive/keeper/reward_tracker_test.go
+++ b/x/incentive/keeper/reward_tracker_test.go
@@ -64,7 +64,7 @@ func FuzzCheckFpSlashed(f *testing.F) {
 		del2RwdGauge := k.GetRewardGauge(ctx, types.BTCDelegationType, del2)
 		coins.RequireCoinsDiffInPointOnePercentMargin(t, del2Fp1Rwds, del2RwdGauge.Coins)
 
-		// verifies that everything was deleted
+		// verifies that everything was deleted for fp1
 		_, err = k.GetBTCDelegationRewardsTracker(ctx, fp1, del1)
 		require.EqualError(t, err, types.ErrBTCDelegationRewardsTrackerNotFound.Error())
 		_, err = k.GetBTCDelegationRewardsTracker(ctx, fp1, del2)
@@ -73,6 +73,12 @@ func FuzzCheckFpSlashed(f *testing.F) {
 		require.EqualError(t, err, types.ErrFPCurrentRewardsNotFound.Error())
 		_, err = k.GetFinalityProviderHistoricalRewards(ctx, fp1, 1)
 		require.EqualError(t, err, types.ErrFPHistoricalRewardsNotFound.Error())
+
+		// verifies that for fp2 is all there
+		_, err = k.GetFinalityProviderCurrentRewards(ctx, fp2)
+		require.NoError(t, err)
+		_, err = k.GetFinalityProviderHistoricalRewards(ctx, fp2, 1)
+		require.NoError(t, err)
 
 		count := 0
 		err = k.iterBtcDelegationsByDelegator(ctx, del1, func(del, fp sdk.AccAddress) error {


### PR DESCRIPTION
`EventPowerDistUpdate_SlashedFp` and [`RewardBTCStaking`](https://github.com/babylonlabs-io/babylon/blob/b132d16483d2e12ac68be74a524a4b7121edac65/x/incentive/keeper/btc_staking_gauge.go#L19) are called at different blocks. 
The rewards are being called a few blocks behind and if the slashed fp is pruned in BTC reward tracker data, it fails to find and panics 

On babylond-deployments an fp is being slashed at block height 46, the call of `RewardBTCStaking` happens at Babylon block 48 but is called to distribute rewards of voting power table from block 44 (which didn't had the FP slashed yet) which then checks for fp rewards for the FP that was pruned at the slashing processed event.

```
6:04PM INF finalizing commit of block hash=153E869F7B0056A9CD8208301F2019FFACA2BEFBBB35AEADF70DCA14C15F3972 height=47 module=consensus num_txs=2 root=62B5F025459DEEBE2EE6F5D869C5BCBE903299FF80825FB9DE62551E6B725D52
 ERR CONSENSUS FAILURE!!! err="failed to add fp rewards for btc delegation bbn1wwkaq6z3kdkekm7ltwxng4ftvzux8gzp2xjx8d at height 44: finality provider current rewards not found
``` 


```shell
$~ babylond q btcstaking finality-providers -o json | jq
...
    {
      "description": {
        "moniker": "Finality Provider 0",
        "identity": "",
        "website": "",
        "security_contact": "",
        "details": ""
      },
      "commission": "0.050000000000000000",
      "addr": "bbn1wwkaq6z3kdkekm7ltwxng4ftvzux8gzp2xjx8d",
      "btc_pk": "6ba387c315dc6105ec02b50684593505103a9f13452d3a597c16ac2f22b924dc",
      "pop": {
        "btc_sig_type": "BIP340",
        "btc_sig": "Q3PcfiKT0fwWOVx95rjV+mQvI/juTbYIV84Hfz2NAmQByiHRXz8OWnFbyugJgOrd/TrqR+6BOgtr10bZUFDFbA=="
      },
      "slashed_babylon_height": "46",
      "slashed_btc_height": 131,
      "height": "46",
      "jailed": false,
      "highest_voted_height": 45
    },
```


Basically, this means we are processing the rewards a few blocks down the road after the slash and then it is not possible to prune the data for reward tracker until that fp slashed height is processed.

The fix for the time being: do nothing at the btc reward tracker structures if some fp gets slashed just continue to store that data. In the future during the issue https://github.com/babylonlabs-io/babylon/issues/362 we can properly handle the pruning of slashed finality provider data

