### PR TITLE
fix: `HandleRewarding` gaps of unfinalized blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - [#374](https://github.com/babylonlabs-io/babylon/pull/374) Fix non-consecutive finalization
 of the block in `TallyBlocks` function
+- [#378](https://github.com/babylonlabs-io/babylon/pull/378) Fix give out rewards
+with gaps of unfinalized blocks
 
 ## v1.0.0-rc2
 

--- a/x/finality/keeper/rewarding.go
+++ b/x/finality/keeper/rewarding.go
@@ -30,10 +30,9 @@ func (k Keeper) HandleRewarding(ctx context.Context, targetHeight int64) {
 		if err != nil {
 			panic(err)
 		}
-		if !block.Finalized {
-			break
+		if block.Finalized {
+			k.rewardBTCStaking(ctx, height)
 		}
-		k.rewardBTCStaking(ctx, height)
 		nextHeightToReward = height + 1
 	}
 

--- a/x/finality/keeper/rewarding.go
+++ b/x/finality/keeper/rewarding.go
@@ -9,6 +9,7 @@ import (
 	"github.com/babylonlabs-io/babylon/x/finality/types"
 )
 
+// HandleRewarding calls the reward to stakers if the block is finalized
 func (k Keeper) HandleRewarding(ctx context.Context, targetHeight int64) {
 	// rewarding is executed in a range of [nextHeightToReward, heightToExamine]
 	// this is we don't know when a block will be finalized and we need ensure

--- a/x/finality/keeper/rewarding.go
+++ b/x/finality/keeper/rewarding.go
@@ -30,9 +30,10 @@ func (k Keeper) HandleRewarding(ctx context.Context, targetHeight int64) {
 		if err != nil {
 			panic(err)
 		}
-		if block.Finalized {
-			k.rewardBTCStaking(ctx, height)
+		if !block.Finalized {
+			continue
 		}
+		k.rewardBTCStaking(ctx, height)
 		nextHeightToReward = height + 1
 	}
 

--- a/x/finality/keeper/rewarding_test.go
+++ b/x/finality/keeper/rewarding_test.go
@@ -58,8 +58,8 @@ func FuzzHandleRewarding(f *testing.F) {
 		fKeeper.HandleRewarding(ctx, int64(targetHeight))
 
 		nextHeight := fKeeper.GetNextHeightToReward(ctx)
-		require.Equal(t, uint64(0), nextHeight,
-			"next height is not updated when no blocks finalized")
+		require.Zero(t, nextHeight,
+			"next height is not updated when no blocks finalized. Act: %d", nextHeight)
 
 		// Second phase: Finalize some blocks
 		firstBatchFinalized := datagen.RandomInt(r, 5) + 1
@@ -82,7 +82,7 @@ func FuzzHandleRewarding(f *testing.F) {
 		nextHeight = fKeeper.GetNextHeightToReward(ctx)
 		expectedNextHeight := activatedHeight + firstBatchFinalized
 		require.Equal(t, expectedNextHeight, nextHeight,
-			"next height should be after first batch of finalized blocks")
+			"next height should be after first batch of finalized blocks. Exp: %d, Act: %d", expectedNextHeight, nextHeight)
 
 		// Third phase: Finalize more blocks
 		secondBatchFinalized := datagen.RandomInt(r, int(totalBlocks-firstBatchFinalized)) + 1

--- a/x/finality/keeper/rewarding_test.go
+++ b/x/finality/keeper/rewarding_test.go
@@ -153,8 +153,13 @@ func TestHandleRewardingWithGapsOfUnfinalizedBlocks(t *testing.T) {
 	})
 	fKeeper.SetVotingPowerDistCache(ctx, 3, dc)
 
+	iKeeper.EXPECT().
+		RewardBTCStaking(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return().
+		Times(1) // number of finalized blocks processed
+
 	fKeeper.HandleRewarding(ctx, 3)
 
 	actNextBlockToBeRewarded := fKeeper.GetNextHeightToReward(ctx)
-	require.Equal(t, 4, actNextBlockToBeRewarded)
+	require.Equal(t, uint64(4), actNextBlockToBeRewarded)
 }

--- a/x/finality/keeper/rewarding_test.go
+++ b/x/finality/keeper/rewarding_test.go
@@ -132,8 +132,9 @@ func TestHandleRewardingWithGapsOfUnfinalizedBlocks(t *testing.T) {
 	fKeeper.SetBlock(ctx, &types.IndexedBlock{
 		Height:    1,
 		AppHash:   datagen.GenRandomByteArray(r, 32),
-		Finalized: false,
+		Finalized: true,
 	})
+
 	fKeeper.SetBlock(ctx, &types.IndexedBlock{
 		Height:    2,
 		AppHash:   datagen.GenRandomByteArray(r, 32),
@@ -151,12 +152,13 @@ func TestHandleRewardingWithGapsOfUnfinalizedBlocks(t *testing.T) {
 		BtcPk:          fpPK,
 		TotalBondedSat: 1,
 	})
+	fKeeper.SetVotingPowerDistCache(ctx, 1, dc)
 	fKeeper.SetVotingPowerDistCache(ctx, 3, dc)
 
 	iKeeper.EXPECT().
 		RewardBTCStaking(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return().
-		Times(1) // number of finalized blocks processed
+		Times(2) // number of finalized blocks processed
 
 	fKeeper.HandleRewarding(ctx, 3)
 


### PR DESCRIPTION
Prior to this fix, if we had an unfinalized block it would stuck to it as a next block to be rewarded


By using `continue` instead of `break`, if there is any finalized block in the interval (`nextBlockToBeRewarded` and `targetHeight`) it will give out rewards and update the next block to be rewarded