### PR TITLE
Fix: Removed unnecessary error handling

### DIFF
--- a/cmd/babylond/cmd/debug.go
+++ b/cmd/babylond/cmd/debug.go
@@ -58,9 +58,6 @@ func PrintBip340(cmd *cobra.Command, args []string) error {
 	}
 
 	bip340Key := types.BIP340PubKey(pk.Bytes())
-	if err != nil {
-		return err
-	}
 
 	cmd.Println("BIP340 Hex:", bip340Key.MarshalHex())
 	return nil


### PR DESCRIPTION
BIP340PubKey does not return an error. This check is unnecessary.