### PR TITLE
fix: Safely handle `db.Iterator` and `itr.Error` errors to prevent resource leaks

### DIFF
--- a/cmd/babylond/cmd/sizes_cmd.go
+++ b/cmd/babylond/cmd/sizes_cmd.go
@@ -99,7 +99,7 @@ func PrintDBStats(db dbm.DB, printInterval int) {
 
 	itr, err := db.Iterator(nil, nil)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to create iterator: %w", err)
 	}
 	fmt.Printf("****************** Retrieved database iterator ******************\n")
 
@@ -135,7 +135,7 @@ func PrintDBStats(db dbm.DB, printInterval int) {
 	}
 
 	if err := itr.Error(); err != nil {
-		panic(err)
+		return fmt.Errorf("iterator error: %w", err)
 	}
 	fmt.Printf("****************** Finished iterating over whole database ******************\n")
 	printModuleStats(storeKeyStats, &gs)


### PR DESCRIPTION
## Description
This PR modifies the error handling in PrintDBStats by replacing panic calls with returned errors. Specifically:
- db.Iterator errors now return a formatted error instead of causing a panic.
- itr.Error is also handled gracefully by returning an error.

## Motivation
In the current code, if db.Iterator() or itr.Error() causes a panic,
the defer itr.Close() might not be called. Depending on the database
implementation, resources may not be automatically cleaned up, which could
result in:
- Memory leaks.
- File handle leaks.
- Database lock issues.

This PR ensures that the iterator is closed properly even when errors occur.
If this behavior is already expected or deemed unnecessary, this PR can be
closed without merging.