### PR TITLE
chore: tryfix e2e flunky `TestBTCRewardsDistribution`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+- [#391](https://github.com/babylonlabs-io/babylon/pull/391) Fix e2e `TestBTCRewardsDistribution` flunky
+check of rewards
+
 ## v1.0.0-rc3
 
 ### Bug fixes


### PR DESCRIPTION
This minimizes the possibility of querying in different blocks, but actually, there was no way to do multiple queries at the same block with guarantee

Runs: 
- https://github.com/babylonlabs-io/babylon/actions/runs/12658410867/job/35275446958?pr=391
- https://github.com/babylonlabs-io/babylon/actions/runs/12658410867/job/35279742461?pr=391
- https://github.com/babylonlabs-io/babylon/actions/runs/12658410867/job/35280945448?pr=391