### PR TITLE
fix: swagger doc gen incentive v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ check of rewards
 - [#404](https://github.com/babylonlabs-io/babylon/pull/404) Improve adaptor
 signature nonce generation to match reference implementation
 - [#413](https://github.com/babylonlabs-io/babylon/pull/413) Fix adaptor
-signature R verification
+signature R verification`
 - [#441](https://github.com/babylonlabs-io/babylon/pull/441) Fix fuzzing test for
 `CreateBTCDelegationWithParamsFromBtcHeight`
 - [#443](https://github.com/babylonlabs-io/babylon/pull/443) Fix swagger generation for incentive missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ check of rewards
 signature nonce generation to match reference implementation
 - [#413](https://github.com/babylonlabs-io/babylon/pull/413) Fix adaptor
 signature R verification
+- [#443](https://github.com/babylonlabs-io/babylon/pull/443) Fix swagger generation for incentive missing
+`v1` in path
 
 ## v1.0.0-rc3
 

--- a/client/docs/config.json
+++ b/client/docs/config.json
@@ -59,12 +59,14 @@
       "url": "./tmp-swagger-gen/babylon/btcstkconsumer/v1/query.swagger.json",
       "operationIds": {
         "rename": {
-          "Params": "BtcStkConsumerParams"
+          "Params": "BtcStkConsumerParams",
+          "FinalityProviders": "FinalityProvidersConsumer",
+          "FinalityProvider": "FinalityProviderConsumer"
         }
       }
     },
     {
-      "url": "./tmp-swagger-gen/babylon/incentive/v1/query.swagger.json",
+      "url": "./tmp-swagger-gen/babylon/incentive/query.swagger.json",
       "operationIds": {
         "rename": {
           "Params": "IncentiveParams"

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -9817,6 +9817,5898 @@ paths:
           type: boolean
       tags:
         - Query
+  /babylon/btcstkconsumer/v1/consumer_registry_list:
+    get:
+      summary: >-
+        ConsumerRegistryList queries the list of consumers that are registered
+        to Babylon
+      operationId: ConsumerRegistryList
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              consumer_ids:
+                type: array
+                items:
+                  type: string
+                title: >-
+                  consumer_ids are IDs of the consumers in ascending
+                  alphabetical order
+              pagination:
+                title: pagination defines the pagination in the response
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+            title: >-
+              QueryConsumerRegistryListResponse is response type for the
+              Query/ConsumerRegistryList RPC method
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /babylon/btcstkconsumer/v1/consumers_registry/{consumer_ids}:
+    get:
+      summary: >-
+        ConsumersRegistry queries the latest info for a given list of consumers
+        in Babylon's view
+      operationId: ConsumersRegistry
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              consumers_register:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    consumer_id:
+                      type: string
+                      title: >-
+                        consumer_id is the ID of the consumer
+
+                        - for Cosmos SDK chains, the consumer ID will be the IBC
+                        client ID
+
+                        - for ETH L2 chains, the consumer ID will be the chain
+                        ID of the ETH L2
+                          chain
+                    consumer_name:
+                      type: string
+                      title: consumer_name is the name of the consumer
+                    consumer_description:
+                      type: string
+                      title: >-
+                        consumer_description is a description for the consumer
+                        (can be empty)
+                    cosmos_consumer_metadata:
+                      type: object
+                      properties:
+                        channel_id:
+                          type: string
+                          title: >-
+                            channel_id defines the IBC channel ID for the
+                            consumer chain
+                      title: >-
+                        CosmosConsumerMetadata is the metadata for the Cosmos
+                        integration
+                    eth_l2_consumer_metadata:
+                      type: object
+                      properties:
+                        finality_contract_address:
+                          type: string
+                          title: >-
+                            finality_contract_address is the address of the
+                            finality contract for
+
+                            the ETH L2 integration
+                      title: >-
+                        ETHL2ConsumerMetadata is the metadata for the ETH L2
+                        integration
+                  title: >-
+                    ConsumerRegister is the registration information of a
+                    consumer
+            description: >-
+              QueryConsumersRegistryResponse is response type for the
+              Query/ConsumersRegistry RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: consumer_ids
+          in: path
+          required: true
+          type: array
+          items:
+            type: string
+          collectionFormat: csv
+          minItems: 1
+      tags:
+        - Query
+  /babylon/btcstkconsumer/v1/finality_provider/{consumer_id}/{fp_btc_pk_hex}:
+    get:
+      summary: FinalityProvider info about one finality provider
+      operationId: FinalityProviderConsumer
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              finality_provider:
+                title: finality_provider contains the FinalityProvider
+                type: object
+                properties:
+                  description:
+                    description: >-
+                      description defines the description terms for the finality
+                      provider.
+                    type: object
+                    properties:
+                      moniker:
+                        type: string
+                        description: >-
+                          moniker defines a human-readable name for the
+                          validator.
+                      identity:
+                        type: string
+                        description: >-
+                          identity defines an optional identity signature (ex.
+                          UPort or Keybase).
+                      website:
+                        type: string
+                        description: website defines an optional website link.
+                      security_contact:
+                        type: string
+                        description: >-
+                          security_contact defines an optional email for
+                          security contact.
+                      details:
+                        type: string
+                        description: details define other optional details.
+                  commission:
+                    type: string
+                    description: >-
+                      commission defines the commission rate of the finality
+                      provider.
+                  addr:
+                    type: string
+                    title: >-
+                      babylon_pk is the Babylon secp256k1 PK of this finality
+                      provider
+                  btc_pk:
+                    type: string
+                    format: byte
+                    title: >-
+                      btc_pk is the Bitcoin secp256k1 PK of this finality
+                      provider
+
+                      the PK follows encoding in BIP-340 spec
+                  pop:
+                    title: pop is the proof of possession of babylon_pk and btc_pk
+                    type: object
+                    properties:
+                      btc_sig_type:
+                        title: btc_sig_type indicates the type of btc_sig in the pop
+                        type: string
+                        enum:
+                          - BIP340
+                          - BIP322
+                          - ECDSA
+                        default: BIP340
+                        description: >-
+                          - BIP340: BIP340 means the btc_sig will follow the
+                          BIP-340 encoding
+                           - BIP322: BIP322 means the btc_sig will follow the BIP-322 encoding
+                           - ECDSA: ECDSA means the btc_sig will follow the ECDSA encoding
+                          ref:
+                          https://github.com/okx/js-wallet-sdk/blob/a57c2acbe6ce917c0aa4e951d96c4e562ad58444/packages/coin-bitcoin/src/BtcWallet.ts#L331
+                      btc_sig:
+                        type: string
+                        format: byte
+                        title: >-
+                          btc_sig is the signature generated via sign(sk_btc,
+                          babylon_staker_address)
+
+                          the signature follows encoding in either BIP-340 spec
+                          or BIP-322 spec
+                  slashed_babylon_height:
+                    type: string
+                    format: uint64
+                    title: |-
+                      slashed_babylon_height indicates the Babylon height when
+                      the finality provider is slashed.
+                      if it's 0 then the finality provider is not slashed
+                  slashed_btc_height:
+                    type: integer
+                    format: int64
+                    title: |-
+                      slashed_btc_height indicates the BTC height when
+                      the finality provider is slashed.
+                      if it's 0 then the finality provider is not slashed
+                  height:
+                    type: string
+                    format: uint64
+                    title: height is the queried Babylon height
+                  voting_power:
+                    type: string
+                    format: uint64
+                    title: >-
+                      voting_power is the voting power of this finality provider
+                      at the given height
+                  consumer_id:
+                    type: string
+                    title: >-
+                      consumer_id is the consumer id this finality provider is
+                      registered to
+                description: >-
+                  FinalityProviderResponse defines a finality provider with
+                  voting power information.
+            title: >-
+              QueryFinalityProviderResponse contains information about a
+              finality provider
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: consumer_id
+          description: >-
+            consumer id is the consumer id this finality provider is registered
+            to
+          in: path
+          required: true
+          type: string
+        - name: fp_btc_pk_hex
+          description: >-
+            fp_btc_pk_hex is the hex str of Bitcoin secp256k1 PK of the finality
+            provider
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /babylon/btcstkconsumer/v1/finality_provider_consumer/{fp_btc_pk_hex}:
+    get:
+      summary: FinalityProviderConsumer info about one finality provider's consumer id
+      operationId: FinalityProviderConsumer
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              consumer_id:
+                type: string
+            title: >-
+              QueryFinalityProviderConsumerResponse returns the CZ finality
+              provier consumer id
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: fp_btc_pk_hex
+          description: >-
+            fp_btc_pk_hex is the hex str of Bitcoin secp256k1 PK of the finality
+            provider
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /babylon/btcstkconsumer/v1/finality_providers/{consumer_id}:
+    get:
+      summary: FinalityProviders queries all finality providers for a given consumer
+      operationId: FinalityProvidersConsumer
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              finality_providers:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    description:
+                      description: >-
+                        description defines the description terms for the
+                        finality provider.
+                      type: object
+                      properties:
+                        moniker:
+                          type: string
+                          description: >-
+                            moniker defines a human-readable name for the
+                            validator.
+                        identity:
+                          type: string
+                          description: >-
+                            identity defines an optional identity signature (ex.
+                            UPort or Keybase).
+                        website:
+                          type: string
+                          description: website defines an optional website link.
+                        security_contact:
+                          type: string
+                          description: >-
+                            security_contact defines an optional email for
+                            security contact.
+                        details:
+                          type: string
+                          description: details define other optional details.
+                    commission:
+                      type: string
+                      description: >-
+                        commission defines the commission rate of the finality
+                        provider.
+                    addr:
+                      type: string
+                      title: >-
+                        babylon_pk is the Babylon secp256k1 PK of this finality
+                        provider
+                    btc_pk:
+                      type: string
+                      format: byte
+                      title: >-
+                        btc_pk is the Bitcoin secp256k1 PK of this finality
+                        provider
+
+                        the PK follows encoding in BIP-340 spec
+                    pop:
+                      title: pop is the proof of possession of babylon_pk and btc_pk
+                      type: object
+                      properties:
+                        btc_sig_type:
+                          title: >-
+                            btc_sig_type indicates the type of btc_sig in the
+                            pop
+                          type: string
+                          enum:
+                            - BIP340
+                            - BIP322
+                            - ECDSA
+                          default: BIP340
+                          description: >-
+                            - BIP340: BIP340 means the btc_sig will follow the
+                            BIP-340 encoding
+                             - BIP322: BIP322 means the btc_sig will follow the BIP-322 encoding
+                             - ECDSA: ECDSA means the btc_sig will follow the ECDSA encoding
+                            ref:
+                            https://github.com/okx/js-wallet-sdk/blob/a57c2acbe6ce917c0aa4e951d96c4e562ad58444/packages/coin-bitcoin/src/BtcWallet.ts#L331
+                        btc_sig:
+                          type: string
+                          format: byte
+                          title: >-
+                            btc_sig is the signature generated via sign(sk_btc,
+                            babylon_staker_address)
+
+                            the signature follows encoding in either BIP-340
+                            spec or BIP-322 spec
+                    slashed_babylon_height:
+                      type: string
+                      format: uint64
+                      title: |-
+                        slashed_babylon_height indicates the Babylon height when
+                        the finality provider is slashed.
+                        if it's 0 then the finality provider is not slashed
+                    slashed_btc_height:
+                      type: integer
+                      format: int64
+                      title: |-
+                        slashed_btc_height indicates the BTC height when
+                        the finality provider is slashed.
+                        if it's 0 then the finality provider is not slashed
+                    height:
+                      type: string
+                      format: uint64
+                      title: height is the queried Babylon height
+                    voting_power:
+                      type: string
+                      format: uint64
+                      title: >-
+                        voting_power is the voting power of this finality
+                        provider at the given height
+                    consumer_id:
+                      type: string
+                      title: >-
+                        consumer_id is the consumer id this finality provider is
+                        registered to
+                  description: >-
+                    FinalityProviderResponse defines a finality provider with
+                    voting power information.
+                title: finality_providers contains all the finality providers
+              pagination:
+                description: pagination defines the pagination in the response.
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+            description: |-
+              QueryFinalityProvidersResponse is the response type for the
+              Query/FinalityProviders RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: consumer_id
+          in: path
+          required: true
+          type: string
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /babylon/btcstkconsumer/v1/params:
+    get:
+      summary: Parameters queries the parameters of the module.
+      operationId: BtcStkConsumerParams
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              params:
+                description: params holds all the parameters of this module.
+                type: object
+                properties:
+                  permissioned_integration:
+                    type: boolean
+                    description: >-
+                      permissioned_integration is a flag to enable permissioned
+                      integration, i.e.,
+
+                      requiring governance proposal to approve new integrations.
+            description: >-
+              QueryParamsResponse is response type for the Query/Params RPC
+              method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      tags:
+        - Query
+  /babylon/incentive/address/{address}/reward_gauge:
+    get:
+      summary: RewardGauge queries the reward gauge of a given stakeholder address
+      operationId: RewardGauges
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              reward_gauges:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    coins:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          denom:
+                            type: string
+                          amount:
+                            type: string
+                        description: >-
+                          Coin defines a token with a denomination and an
+                          amount.
+
+
+                          NOTE: The amount field is an Int which implements the
+                          custom method
+
+                          signatures required by gogoproto.
+                      title: |-
+                        coins are coins that have been in the gauge
+                        Can have multiple coin denoms
+                    withdrawn_coins:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          denom:
+                            type: string
+                          amount:
+                            type: string
+                        description: >-
+                          Coin defines a token with a denomination and an
+                          amount.
+
+
+                          NOTE: The amount field is an Int which implements the
+                          custom method
+
+                          signatures required by gogoproto.
+                      title: >-
+                        withdrawn_coins are coins that have been withdrawn by
+                        the stakeholder already
+                  title: >-
+                    RewardGaugesResponse is an object that stores rewards
+                    distributed to a BTC staking stakeholder
+                title: >-
+                  reward_gauges is the map of reward gauges, where key is the
+                  stakeholder type
+
+                  and value is the reward gauge holding all rewards for the
+                  stakeholder in that type
+            description: >-
+              QueryRewardGaugesResponse is response type for the
+              Query/RewardGauges RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: address
+          description: address is the address of the stakeholder in bech32 string
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /babylon/incentive/btc_staking_gauge/{height}:
+    get:
+      summary: BTCStakingGauge queries the BTC staking gauge of a given height
+      operationId: BTCStakingGauge
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              gauge:
+                title: gauge is the BTC staking gauge at the queried height
+                type: object
+                properties:
+                  coins:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        denom:
+                          type: string
+                        amount:
+                          type: string
+                      description: >-
+                        Coin defines a token with a denomination and an amount.
+
+
+                        NOTE: The amount field is an Int which implements the
+                        custom method
+
+                        signatures required by gogoproto.
+                    title: |-
+                      coins that have been in the gauge
+                      can have multiple coin denoms
+                description: >-
+                  BTCStakingGaugeResponse is response type for the
+                  Query/BTCStakingGauge RPC method.
+            description: >-
+              QueryBTCStakingGaugeResponse is response type for the
+              Query/BTCStakingGauge RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: height
+          description: height is the queried Babylon height
+          in: path
+          required: true
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /babylon/incentive/delegators/{delegator_address}/withdraw_address:
+    get:
+      summary: DelegatorWithdrawAddress queries withdraw address of a delegator.
+      operationId: DelegatorWithdrawAddress
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              withdraw_address:
+                type: string
+                description: withdraw_address defines the delegator address to query for.
+            description: |-
+              QueryDelegatorWithdrawAddressResponse is the response type for the
+              Query/DelegatorWithdrawAddress RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: delegator_address
+          description: delegator_address defines the delegator address to query for.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /babylon/incentive/params:
+    get:
+      summary: Parameters queries the parameters of the module.
+      operationId: IncentiveParams
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              params:
+                description: params holds all the parameters of this module.
+                type: object
+                properties:
+                  btc_staking_portion:
+                    type: string
+                    title: >-
+                      btc_staking_portion is the portion of rewards that goes to
+                      Finality Providers/delegations
+
+                      NOTE: the portion of each Finality Provider/delegation is
+                      calculated by using its voting
+
+                      power and finality provider's commission
+                title: >-
+                  Params defines the parameters for the module, including
+                  portions of rewards
+
+                  distributed to each type of stakeholder. Note that sum of the
+                  portions should
+
+                  be strictly less than 1 so that the rest will go to Comet
+                  validators/delegations
+
+                  adapted from
+                  https://github.com/cosmos/cosmos-sdk/blob/release/v0.47.x/proto/cosmos/distribution/v1beta1/distribution.proto
+            description: >-
+              QueryParamsResponse is response type for the Query/Params RPC
+              method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      tags:
+        - Query
+  /babylon/zoneconcierge/v1/chain_info/{consumer_id}/header/{height}:
+    get:
+      summary: Header queries the CZ header and fork headers at a given height.
+      operationId: Header
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              header:
+                type: object
+                properties:
+                  consumer_id:
+                    type: string
+                    title: consumer_id is the unique ID of the consumer
+                  hash:
+                    type: string
+                    format: byte
+                    title: hash is the hash of this header
+                  height:
+                    type: string
+                    format: uint64
+                    title: >-
+                      height is the height of this header on CZ ledger
+
+                      (hash, height) jointly provides the position of the header
+                      on CZ ledger
+                  time:
+                    type: string
+                    format: date-time
+                    title: >-
+                      time is the timestamp of this header on CZ ledger
+
+                      it is needed for CZ to unbond all mature
+                      validators/delegations
+
+                      before this timestamp when this header is BTC-finalised
+                  babylon_header_hash:
+                    type: string
+                    format: byte
+                    title: >-
+                      babylon_header_hash is the hash of the babylon block that
+                      includes this CZ
+
+                      header
+                  babylon_header_height:
+                    type: string
+                    format: uint64
+                    title: >-
+                      babylon_header_height is the height of the babylon block
+                      that includes this CZ
+
+                      header
+                  babylon_epoch:
+                    type: string
+                    format: uint64
+                    title: epoch is the epoch number of this header on Babylon ledger
+                  babylon_tx_hash:
+                    type: string
+                    format: byte
+                    title: >-
+                      babylon_tx_hash is the hash of the tx that includes this
+                      header
+
+                      (babylon_block_height, babylon_tx_hash) jointly provides
+                      the position of
+
+                      the header on Babylon ledger
+                title: IndexedHeader is the metadata of a CZ header
+              fork_headers:
+                type: object
+                properties:
+                  headers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        consumer_id:
+                          type: string
+                          title: consumer_id is the unique ID of the consumer
+                        hash:
+                          type: string
+                          format: byte
+                          title: hash is the hash of this header
+                        height:
+                          type: string
+                          format: uint64
+                          title: >-
+                            height is the height of this header on CZ ledger
+
+                            (hash, height) jointly provides the position of the
+                            header on CZ ledger
+                        time:
+                          type: string
+                          format: date-time
+                          title: >-
+                            time is the timestamp of this header on CZ ledger
+
+                            it is needed for CZ to unbond all mature
+                            validators/delegations
+
+                            before this timestamp when this header is
+                            BTC-finalised
+                        babylon_header_hash:
+                          type: string
+                          format: byte
+                          title: >-
+                            babylon_header_hash is the hash of the babylon block
+                            that includes this CZ
+
+                            header
+                        babylon_header_height:
+                          type: string
+                          format: uint64
+                          title: >-
+                            babylon_header_height is the height of the babylon
+                            block that includes this CZ
+
+                            header
+                        babylon_epoch:
+                          type: string
+                          format: uint64
+                          title: >-
+                            epoch is the epoch number of this header on Babylon
+                            ledger
+                        babylon_tx_hash:
+                          type: string
+                          format: byte
+                          title: >-
+                            babylon_tx_hash is the hash of the tx that includes
+                            this header
+
+                            (babylon_block_height, babylon_tx_hash) jointly
+                            provides the position of
+
+                            the header on Babylon ledger
+                      title: IndexedHeader is the metadata of a CZ header
+                    title: >-
+                      blocks is the list of non-canonical indexed headers at the
+                      same height
+                description: >-
+                  Forks is a list of non-canonical `IndexedHeader`s at the same
+                  height.
+
+                  For example, assuming the following blockchain
+
+                  ```
+
+                  A <- B <- C <- D <- E
+                             \ -- D1
+                             \ -- D2
+                  ```
+
+                  Then the fork will be {[D1, D2]} where each item is in struct
+                  `IndexedBlock`.
+
+
+                  Note that each `IndexedHeader` in the fork should have a valid
+                  quorum
+
+                  certificate. Such forks exist since Babylon considers CZs
+                  might have
+
+                  dishonest majority. Also note that the IBC-Go implementation
+                  will only
+
+                  consider the first header in a fork valid, since the
+                  subsequent headers
+
+                  cannot be verified without knowing the validator set in the
+                  previous header.
+            description: >-
+              QueryHeaderResponse is response type for the Query/Header RPC
+              method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: consumer_id
+          in: path
+          required: true
+          type: string
+        - name: height
+          in: path
+          required: true
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /babylon/zoneconcierge/v1/chains:
+    get:
+      summary: ChainList queries the list of chains that checkpoint to Babylon
+      operationId: ChainList
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              consumer_ids:
+                type: array
+                items:
+                  type: string
+                title: >-
+                  consumer_ids are IDs of the chains in ascending alphabetical
+                  order
+              pagination:
+                title: pagination defines the pagination in the response
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+            title: >-
+              QueryChainListResponse is response type for the Query/ChainList
+              RPC method
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /babylon/zoneconcierge/v1/chains_info:
+    get:
+      summary: >-
+        ChainsInfo queries the latest info for a given list of chains in
+        Babylon's view
+      operationId: ChainsInfo
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              chains_info:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    consumer_id:
+                      type: string
+                      title: consumer_id is the ID of the consumer
+                    latest_header:
+                      type: object
+                      properties:
+                        consumer_id:
+                          type: string
+                          title: consumer_id is the unique ID of the consumer
+                        hash:
+                          type: string
+                          format: byte
+                          title: hash is the hash of this header
+                        height:
+                          type: string
+                          format: uint64
+                          title: >-
+                            height is the height of this header on CZ ledger
+
+                            (hash, height) jointly provides the position of the
+                            header on CZ ledger
+                        time:
+                          type: string
+                          format: date-time
+                          title: >-
+                            time is the timestamp of this header on CZ ledger
+
+                            it is needed for CZ to unbond all mature
+                            validators/delegations
+
+                            before this timestamp when this header is
+                            BTC-finalised
+                        babylon_header_hash:
+                          type: string
+                          format: byte
+                          title: >-
+                            babylon_header_hash is the hash of the babylon block
+                            that includes this CZ
+
+                            header
+                        babylon_header_height:
+                          type: string
+                          format: uint64
+                          title: >-
+                            babylon_header_height is the height of the babylon
+                            block that includes this CZ
+
+                            header
+                        babylon_epoch:
+                          type: string
+                          format: uint64
+                          title: >-
+                            epoch is the epoch number of this header on Babylon
+                            ledger
+                        babylon_tx_hash:
+                          type: string
+                          format: byte
+                          title: >-
+                            babylon_tx_hash is the hash of the tx that includes
+                            this header
+
+                            (babylon_block_height, babylon_tx_hash) jointly
+                            provides the position of
+
+                            the header on Babylon ledger
+                      title: IndexedHeader is the metadata of a CZ header
+                    latest_forks:
+                      type: object
+                      properties:
+                        headers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              consumer_id:
+                                type: string
+                                title: consumer_id is the unique ID of the consumer
+                              hash:
+                                type: string
+                                format: byte
+                                title: hash is the hash of this header
+                              height:
+                                type: string
+                                format: uint64
+                                title: >-
+                                  height is the height of this header on CZ
+                                  ledger
+
+                                  (hash, height) jointly provides the position
+                                  of the header on CZ ledger
+                              time:
+                                type: string
+                                format: date-time
+                                title: >-
+                                  time is the timestamp of this header on CZ
+                                  ledger
+
+                                  it is needed for CZ to unbond all mature
+                                  validators/delegations
+
+                                  before this timestamp when this header is
+                                  BTC-finalised
+                              babylon_header_hash:
+                                type: string
+                                format: byte
+                                title: >-
+                                  babylon_header_hash is the hash of the babylon
+                                  block that includes this CZ
+
+                                  header
+                              babylon_header_height:
+                                type: string
+                                format: uint64
+                                title: >-
+                                  babylon_header_height is the height of the
+                                  babylon block that includes this CZ
+
+                                  header
+                              babylon_epoch:
+                                type: string
+                                format: uint64
+                                title: >-
+                                  epoch is the epoch number of this header on
+                                  Babylon ledger
+                              babylon_tx_hash:
+                                type: string
+                                format: byte
+                                title: >-
+                                  babylon_tx_hash is the hash of the tx that
+                                  includes this header
+
+                                  (babylon_block_height, babylon_tx_hash)
+                                  jointly provides the position of
+
+                                  the header on Babylon ledger
+                            title: IndexedHeader is the metadata of a CZ header
+                          title: >-
+                            blocks is the list of non-canonical indexed headers
+                            at the same height
+                      description: >-
+                        Forks is a list of non-canonical `IndexedHeader`s at the
+                        same height.
+
+                        For example, assuming the following blockchain
+
+                        ```
+
+                        A <- B <- C <- D <- E
+                                   \ -- D1
+                                   \ -- D2
+                        ```
+
+                        Then the fork will be {[D1, D2]} where each item is in
+                        struct `IndexedBlock`.
+
+
+                        Note that each `IndexedHeader` in the fork should have a
+                        valid quorum
+
+                        certificate. Such forks exist since Babylon considers
+                        CZs might have
+
+                        dishonest majority. Also note that the IBC-Go
+                        implementation will only
+
+                        consider the first header in a fork valid, since the
+                        subsequent headers
+
+                        cannot be verified without knowing the validator set in
+                        the previous header.
+                      title: >-
+                        latest_forks is the latest forks, formed as a series of
+                        IndexedHeader (from
+
+                        low to high)
+                    timestamped_headers_count:
+                      type: string
+                      format: uint64
+                      title: >-
+                        timestamped_headers_count is the number of timestamped
+                        headers in CZ's
+
+                        canonical chain
+                  title: ChainInfo is the information of a CZ
+            description: >-
+              QueryChainsInfoResponse is response type for the Query/ChainsInfo
+              RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: consumer_ids
+          in: query
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+      tags:
+        - Query
+  /babylon/zoneconcierge/v1/epoch_chains_info:
+    get:
+      summary: |-
+        EpochChainsInfo queries the latest info for a list of chains
+        in a given epoch in Babylon's view
+      operationId: EpochChainsInfo
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              chains_info:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    consumer_id:
+                      type: string
+                      title: consumer_id is the ID of the consumer
+                    latest_header:
+                      type: object
+                      properties:
+                        consumer_id:
+                          type: string
+                          title: consumer_id is the unique ID of the consumer
+                        hash:
+                          type: string
+                          format: byte
+                          title: hash is the hash of this header
+                        height:
+                          type: string
+                          format: uint64
+                          title: >-
+                            height is the height of this header on CZ ledger
+
+                            (hash, height) jointly provides the position of the
+                            header on CZ ledger
+                        time:
+                          type: string
+                          format: date-time
+                          title: >-
+                            time is the timestamp of this header on CZ ledger
+
+                            it is needed for CZ to unbond all mature
+                            validators/delegations
+
+                            before this timestamp when this header is
+                            BTC-finalised
+                        babylon_header_hash:
+                          type: string
+                          format: byte
+                          title: >-
+                            babylon_header_hash is the hash of the babylon block
+                            that includes this CZ
+
+                            header
+                        babylon_header_height:
+                          type: string
+                          format: uint64
+                          title: >-
+                            babylon_header_height is the height of the babylon
+                            block that includes this CZ
+
+                            header
+                        babylon_epoch:
+                          type: string
+                          format: uint64
+                          title: >-
+                            epoch is the epoch number of this header on Babylon
+                            ledger
+                        babylon_tx_hash:
+                          type: string
+                          format: byte
+                          title: >-
+                            babylon_tx_hash is the hash of the tx that includes
+                            this header
+
+                            (babylon_block_height, babylon_tx_hash) jointly
+                            provides the position of
+
+                            the header on Babylon ledger
+                      title: IndexedHeader is the metadata of a CZ header
+                    latest_forks:
+                      type: object
+                      properties:
+                        headers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              consumer_id:
+                                type: string
+                                title: consumer_id is the unique ID of the consumer
+                              hash:
+                                type: string
+                                format: byte
+                                title: hash is the hash of this header
+                              height:
+                                type: string
+                                format: uint64
+                                title: >-
+                                  height is the height of this header on CZ
+                                  ledger
+
+                                  (hash, height) jointly provides the position
+                                  of the header on CZ ledger
+                              time:
+                                type: string
+                                format: date-time
+                                title: >-
+                                  time is the timestamp of this header on CZ
+                                  ledger
+
+                                  it is needed for CZ to unbond all mature
+                                  validators/delegations
+
+                                  before this timestamp when this header is
+                                  BTC-finalised
+                              babylon_header_hash:
+                                type: string
+                                format: byte
+                                title: >-
+                                  babylon_header_hash is the hash of the babylon
+                                  block that includes this CZ
+
+                                  header
+                              babylon_header_height:
+                                type: string
+                                format: uint64
+                                title: >-
+                                  babylon_header_height is the height of the
+                                  babylon block that includes this CZ
+
+                                  header
+                              babylon_epoch:
+                                type: string
+                                format: uint64
+                                title: >-
+                                  epoch is the epoch number of this header on
+                                  Babylon ledger
+                              babylon_tx_hash:
+                                type: string
+                                format: byte
+                                title: >-
+                                  babylon_tx_hash is the hash of the tx that
+                                  includes this header
+
+                                  (babylon_block_height, babylon_tx_hash)
+                                  jointly provides the position of
+
+                                  the header on Babylon ledger
+                            title: IndexedHeader is the metadata of a CZ header
+                          title: >-
+                            blocks is the list of non-canonical indexed headers
+                            at the same height
+                      description: >-
+                        Forks is a list of non-canonical `IndexedHeader`s at the
+                        same height.
+
+                        For example, assuming the following blockchain
+
+                        ```
+
+                        A <- B <- C <- D <- E
+                                   \ -- D1
+                                   \ -- D2
+                        ```
+
+                        Then the fork will be {[D1, D2]} where each item is in
+                        struct `IndexedBlock`.
+
+
+                        Note that each `IndexedHeader` in the fork should have a
+                        valid quorum
+
+                        certificate. Such forks exist since Babylon considers
+                        CZs might have
+
+                        dishonest majority. Also note that the IBC-Go
+                        implementation will only
+
+                        consider the first header in a fork valid, since the
+                        subsequent headers
+
+                        cannot be verified without knowing the validator set in
+                        the previous header.
+                      title: >-
+                        latest_forks is the latest forks, formed as a series of
+                        IndexedHeader (from
+
+                        low to high)
+                    timestamped_headers_count:
+                      type: string
+                      format: uint64
+                      title: >-
+                        timestamped_headers_count is the number of timestamped
+                        headers in CZ's
+
+                        canonical chain
+                  title: ChainInfo is the information of a CZ
+                title: chain_info is the info of the CZ
+            description: >-
+              QueryEpochChainsInfoResponse is response type for the
+              Query/EpochChainsInfo RPC
+
+              method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: epoch_num
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: consumer_ids
+          in: query
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+      tags:
+        - Query
+  /babylon/zoneconcierge/v1/finalized_chain_info/{consumer_id}/height/{height}:
+    get:
+      summary: >-
+        FinalizedChainInfoUntilHeight queries the BTC-finalised info no later
+        than
+
+        the provided CZ height, with proofs
+      operationId: FinalizedChainInfoUntilHeight
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              finalized_chain_info:
+                type: object
+                properties:
+                  consumer_id:
+                    type: string
+                    title: consumer_id is the ID of the consumer
+                  latest_header:
+                    type: object
+                    properties:
+                      consumer_id:
+                        type: string
+                        title: consumer_id is the unique ID of the consumer
+                      hash:
+                        type: string
+                        format: byte
+                        title: hash is the hash of this header
+                      height:
+                        type: string
+                        format: uint64
+                        title: >-
+                          height is the height of this header on CZ ledger
+
+                          (hash, height) jointly provides the position of the
+                          header on CZ ledger
+                      time:
+                        type: string
+                        format: date-time
+                        title: >-
+                          time is the timestamp of this header on CZ ledger
+
+                          it is needed for CZ to unbond all mature
+                          validators/delegations
+
+                          before this timestamp when this header is
+                          BTC-finalised
+                      babylon_header_hash:
+                        type: string
+                        format: byte
+                        title: >-
+                          babylon_header_hash is the hash of the babylon block
+                          that includes this CZ
+
+                          header
+                      babylon_header_height:
+                        type: string
+                        format: uint64
+                        title: >-
+                          babylon_header_height is the height of the babylon
+                          block that includes this CZ
+
+                          header
+                      babylon_epoch:
+                        type: string
+                        format: uint64
+                        title: >-
+                          epoch is the epoch number of this header on Babylon
+                          ledger
+                      babylon_tx_hash:
+                        type: string
+                        format: byte
+                        title: >-
+                          babylon_tx_hash is the hash of the tx that includes
+                          this header
+
+                          (babylon_block_height, babylon_tx_hash) jointly
+                          provides the position of
+
+                          the header on Babylon ledger
+                    title: IndexedHeader is the metadata of a CZ header
+                  latest_forks:
+                    type: object
+                    properties:
+                      headers:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            consumer_id:
+                              type: string
+                              title: consumer_id is the unique ID of the consumer
+                            hash:
+                              type: string
+                              format: byte
+                              title: hash is the hash of this header
+                            height:
+                              type: string
+                              format: uint64
+                              title: >-
+                                height is the height of this header on CZ ledger
+
+                                (hash, height) jointly provides the position of
+                                the header on CZ ledger
+                            time:
+                              type: string
+                              format: date-time
+                              title: >-
+                                time is the timestamp of this header on CZ
+                                ledger
+
+                                it is needed for CZ to unbond all mature
+                                validators/delegations
+
+                                before this timestamp when this header is
+                                BTC-finalised
+                            babylon_header_hash:
+                              type: string
+                              format: byte
+                              title: >-
+                                babylon_header_hash is the hash of the babylon
+                                block that includes this CZ
+
+                                header
+                            babylon_header_height:
+                              type: string
+                              format: uint64
+                              title: >-
+                                babylon_header_height is the height of the
+                                babylon block that includes this CZ
+
+                                header
+                            babylon_epoch:
+                              type: string
+                              format: uint64
+                              title: >-
+                                epoch is the epoch number of this header on
+                                Babylon ledger
+                            babylon_tx_hash:
+                              type: string
+                              format: byte
+                              title: >-
+                                babylon_tx_hash is the hash of the tx that
+                                includes this header
+
+                                (babylon_block_height, babylon_tx_hash) jointly
+                                provides the position of
+
+                                the header on Babylon ledger
+                          title: IndexedHeader is the metadata of a CZ header
+                        title: >-
+                          blocks is the list of non-canonical indexed headers at
+                          the same height
+                    description: >-
+                      Forks is a list of non-canonical `IndexedHeader`s at the
+                      same height.
+
+                      For example, assuming the following blockchain
+
+                      ```
+
+                      A <- B <- C <- D <- E
+                                 \ -- D1
+                                 \ -- D2
+                      ```
+
+                      Then the fork will be {[D1, D2]} where each item is in
+                      struct `IndexedBlock`.
+
+
+                      Note that each `IndexedHeader` in the fork should have a
+                      valid quorum
+
+                      certificate. Such forks exist since Babylon considers CZs
+                      might have
+
+                      dishonest majority. Also note that the IBC-Go
+                      implementation will only
+
+                      consider the first header in a fork valid, since the
+                      subsequent headers
+
+                      cannot be verified without knowing the validator set in
+                      the previous header.
+                    title: >-
+                      latest_forks is the latest forks, formed as a series of
+                      IndexedHeader (from
+
+                      low to high)
+                  timestamped_headers_count:
+                    type: string
+                    format: uint64
+                    title: >-
+                      timestamped_headers_count is the number of timestamped
+                      headers in CZ's
+
+                      canonical chain
+                title: ChainInfo is the information of a CZ
+              epoch_info:
+                title: epoch_info is the metadata of the last BTC-finalised epoch
+                type: object
+                properties:
+                  epoch_number:
+                    type: string
+                    format: uint64
+                    title: epoch_number is the number of this epoch
+                  current_epoch_interval:
+                    type: string
+                    format: uint64
+                    title: >-
+                      current_epoch_interval is the epoch interval at the time
+                      of this epoch
+                  first_block_height:
+                    type: string
+                    format: uint64
+                    title: >-
+                      first_block_height is the height of the first block in
+                      this epoch
+                  last_block_time:
+                    type: string
+                    format: date-time
+                    description: >-
+                      last_block_time is the time of the last block in this
+                      epoch.
+
+                      Babylon needs to remember the last header's time of each
+                      epoch to complete
+
+                      unbonding validators/delegations when a previous epoch's
+                      checkpoint is
+
+                      finalised. The last_block_time field is nil in the epoch's
+                      beginning, and
+
+                      is set upon the end of this epoch.
+                  sealer_app_hash:
+                    type: string
+                    format: byte
+                    title: >-
+                      sealer is the last block of the sealed epoch
+
+                      sealer_app_hash points to the sealer but stored in the 1st
+                      header
+
+                      of the next epoch
+                  sealer_block_hash:
+                    type: string
+                    format: byte
+                    title: >-
+                      sealer_block_hash is the hash of the sealer
+
+                      the validator set has generated a BLS multisig on the
+                      hash,
+
+                      i.e., hash of the last block in the epoch
+              raw_checkpoint:
+                title: raw_checkpoint is the raw checkpoint of this epoch
+                type: object
+                properties:
+                  epoch_num:
+                    type: string
+                    format: uint64
+                    title: >-
+                      epoch_num defines the epoch number the raw checkpoint is
+                      for
+                  block_hash:
+                    type: string
+                    format: byte
+                    title: >-
+                      block_hash defines the 'BlockID.Hash', which is the hash
+                      of
+
+                      the block that individual BLS sigs are signed on
+                  bitmap:
+                    type: string
+                    format: byte
+                    title: >-
+                      bitmap defines the bitmap that indicates the signers of
+                      the BLS multi sig
+                  bls_multi_sig:
+                    type: string
+                    format: byte
+                    title: >-
+                      bls_multi_sig defines the multi sig that is aggregated
+                      from individual BLS
+
+                      sigs
+              btc_submission_key:
+                title: >-
+                  btc_submission_key is position of two BTC txs that include the
+                  raw
+
+                  checkpoint of this epoch
+                type: object
+                properties:
+                  key:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        index:
+                          type: integer
+                          format: int64
+                        hash:
+                          type: string
+                          format: byte
+                      title: >-
+                        Each provided OP_RETURN transaction can be identified by
+                        hash of block in
+
+                        which transaction was included and transaction index in
+                        the block
+              proof:
+                title: proof is the proof that the chain info is finalized
+                type: object
+                properties:
+                  proof_cz_header_in_epoch:
+                    title: >-
+                      proof_cz_header_in_epoch is the proof that the CZ header
+                      is timestamped
+
+                      within a certain epoch
+                    type: object
+                    properties:
+                      ops:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            key:
+                              type: string
+                              format: byte
+                            data:
+                              type: string
+                              format: byte
+                          title: >-
+                            ProofOp defines an operation used for calculating
+                            Merkle root
+
+                            The data could be arbitrary format, providing
+                            nessecary data
+
+                            for example neighbouring node hash
+                  proof_epoch_sealed:
+                    title: proof_epoch_sealed is the proof that the epoch is sealed
+                    type: object
+                    properties:
+                      validator_set:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            validator_address:
+                              type: string
+                              title: >-
+                                validator_address is the address of the
+                                validator
+                            bls_pub_key:
+                              type: string
+                              format: byte
+                              title: >-
+                                bls_pub_key is the BLS public key of the
+                                validator
+                            voting_power:
+                              type: string
+                              format: uint64
+                              title: >-
+                                voting_power is the voting power of the
+                                validator at the given epoch
+                          title: >-
+                            ValidatorWithBlsKey couples validator address,
+                            voting power, and its bls
+
+                            public key
+                        title: >-
+                          validator_set is the validator set of the sealed epoch
+
+                          This validator set has generated a BLS multisig on
+                          `app_hash` of
+
+                          the sealer header
+                      proof_epoch_info:
+                        title: >-
+                          proof_epoch_info is the Merkle proof that the epoch's
+                          metadata is committed
+
+                          to `app_hash` of the sealer header
+                        type: object
+                        properties:
+                          ops:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
+                                key:
+                                  type: string
+                                  format: byte
+                                data:
+                                  type: string
+                                  format: byte
+                              title: >-
+                                ProofOp defines an operation used for
+                                calculating Merkle root
+
+                                The data could be arbitrary format, providing
+                                nessecary data
+
+                                for example neighbouring node hash
+                      proof_epoch_val_set:
+                        title: >-
+                          proof_epoch_info is the Merkle proof that the epoch's
+                          validator set is
+
+                          committed to `app_hash` of the sealer header
+                        type: object
+                        properties:
+                          ops:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
+                                key:
+                                  type: string
+                                  format: byte
+                                data:
+                                  type: string
+                                  format: byte
+                              title: >-
+                                ProofOp defines an operation used for
+                                calculating Merkle root
+
+                                The data could be arbitrary format, providing
+                                nessecary data
+
+                                for example neighbouring node hash
+                  proof_epoch_submitted:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: object
+                          properties:
+                            index:
+                              type: integer
+                              format: int64
+                            hash:
+                              type: string
+                              format: byte
+                          title: >-
+                            Each provided OP_RETURN transaction can be
+                            identified by hash of block in
+
+                            which transaction was included and transaction index
+                            in the block
+                          description: >-
+                            key is the position (txIdx, blockHash) of this tx on
+                            BTC blockchain
+
+                            Although it is already a part of SubmissionKey, we
+                            store it here again
+
+                            to make TransactionInfo self-contained.
+
+                            For example, storing the key allows TransactionInfo
+                            to not relay on
+
+                            the fact that TransactionInfo will be ordered in the
+                            same order as
+
+                            TransactionKeys in SubmissionKey.
+                        transaction:
+                          type: string
+                          format: byte
+                          title: transaction is the full transaction in bytes
+                        proof:
+                          type: string
+                          format: byte
+                          title: >-
+                            proof is the Merkle proof that this tx is included
+                            in the position in `key`
+
+                            TODO: maybe it could use here better format as we
+                            already processed and
+
+                            validated the proof?
+                      title: |-
+                        TransactionInfo is the info of a tx on Bitcoin,
+                        including
+                        - the position of the tx on BTC blockchain
+                        - the full tx content
+                        - the Merkle proof that this tx is on the above position
+                    title: >-
+                      proof_epoch_submitted is the proof that the epoch's
+                      checkpoint is included
+
+                      in BTC ledger It is the two TransactionInfo in the best
+                      (i.e., earliest)
+
+                      checkpoint submission
+            description: >-
+              QueryFinalizedChainInfoUntilHeightResponse is response type for
+              the
+
+              Query/FinalizedChainInfoUntilHeight RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: consumer_id
+          description: consumer_id is the ID of the CZ
+          in: path
+          required: true
+          type: string
+        - name: height
+          description: >-
+            height is the height of the CZ chain
+
+            such that the returned finalised chain info will be no later than
+            this
+
+            height
+          in: path
+          required: true
+          type: string
+          format: uint64
+        - name: prove
+          description: >-
+            prove indicates whether the querier wants to get proofs of this
+            timestamp.
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /babylon/zoneconcierge/v1/finalized_chains_info:
+    get:
+      summary: >-
+        FinalizedChainsInfo queries the BTC-finalised info of chains with given
+        IDs, with proofs
+      operationId: FinalizedChainsInfo
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              finalized_chains_info:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    consumer_id:
+                      type: string
+                      title: consumer_id is the ID of the consumer
+                    finalized_chain_info:
+                      type: object
+                      properties:
+                        consumer_id:
+                          type: string
+                          title: consumer_id is the ID of the consumer
+                        latest_header:
+                          type: object
+                          properties:
+                            consumer_id:
+                              type: string
+                              title: consumer_id is the unique ID of the consumer
+                            hash:
+                              type: string
+                              format: byte
+                              title: hash is the hash of this header
+                            height:
+                              type: string
+                              format: uint64
+                              title: >-
+                                height is the height of this header on CZ ledger
+
+                                (hash, height) jointly provides the position of
+                                the header on CZ ledger
+                            time:
+                              type: string
+                              format: date-time
+                              title: >-
+                                time is the timestamp of this header on CZ
+                                ledger
+
+                                it is needed for CZ to unbond all mature
+                                validators/delegations
+
+                                before this timestamp when this header is
+                                BTC-finalised
+                            babylon_header_hash:
+                              type: string
+                              format: byte
+                              title: >-
+                                babylon_header_hash is the hash of the babylon
+                                block that includes this CZ
+
+                                header
+                            babylon_header_height:
+                              type: string
+                              format: uint64
+                              title: >-
+                                babylon_header_height is the height of the
+                                babylon block that includes this CZ
+
+                                header
+                            babylon_epoch:
+                              type: string
+                              format: uint64
+                              title: >-
+                                epoch is the epoch number of this header on
+                                Babylon ledger
+                            babylon_tx_hash:
+                              type: string
+                              format: byte
+                              title: >-
+                                babylon_tx_hash is the hash of the tx that
+                                includes this header
+
+                                (babylon_block_height, babylon_tx_hash) jointly
+                                provides the position of
+
+                                the header on Babylon ledger
+                          title: IndexedHeader is the metadata of a CZ header
+                        latest_forks:
+                          type: object
+                          properties:
+                            headers:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  consumer_id:
+                                    type: string
+                                    title: >-
+                                      consumer_id is the unique ID of the
+                                      consumer
+                                  hash:
+                                    type: string
+                                    format: byte
+                                    title: hash is the hash of this header
+                                  height:
+                                    type: string
+                                    format: uint64
+                                    title: >-
+                                      height is the height of this header on CZ
+                                      ledger
+
+                                      (hash, height) jointly provides the
+                                      position of the header on CZ ledger
+                                  time:
+                                    type: string
+                                    format: date-time
+                                    title: >-
+                                      time is the timestamp of this header on CZ
+                                      ledger
+
+                                      it is needed for CZ to unbond all mature
+                                      validators/delegations
+
+                                      before this timestamp when this header is
+                                      BTC-finalised
+                                  babylon_header_hash:
+                                    type: string
+                                    format: byte
+                                    title: >-
+                                      babylon_header_hash is the hash of the
+                                      babylon block that includes this CZ
+
+                                      header
+                                  babylon_header_height:
+                                    type: string
+                                    format: uint64
+                                    title: >-
+                                      babylon_header_height is the height of the
+                                      babylon block that includes this CZ
+
+                                      header
+                                  babylon_epoch:
+                                    type: string
+                                    format: uint64
+                                    title: >-
+                                      epoch is the epoch number of this header
+                                      on Babylon ledger
+                                  babylon_tx_hash:
+                                    type: string
+                                    format: byte
+                                    title: >-
+                                      babylon_tx_hash is the hash of the tx that
+                                      includes this header
+
+                                      (babylon_block_height, babylon_tx_hash)
+                                      jointly provides the position of
+
+                                      the header on Babylon ledger
+                                title: IndexedHeader is the metadata of a CZ header
+                              title: >-
+                                blocks is the list of non-canonical indexed
+                                headers at the same height
+                          description: >-
+                            Forks is a list of non-canonical `IndexedHeader`s at
+                            the same height.
+
+                            For example, assuming the following blockchain
+
+                            ```
+
+                            A <- B <- C <- D <- E
+                                       \ -- D1
+                                       \ -- D2
+                            ```
+
+                            Then the fork will be {[D1, D2]} where each item is
+                            in struct `IndexedBlock`.
+
+
+                            Note that each `IndexedHeader` in the fork should
+                            have a valid quorum
+
+                            certificate. Such forks exist since Babylon
+                            considers CZs might have
+
+                            dishonest majority. Also note that the IBC-Go
+                            implementation will only
+
+                            consider the first header in a fork valid, since the
+                            subsequent headers
+
+                            cannot be verified without knowing the validator set
+                            in the previous header.
+                          title: >-
+                            latest_forks is the latest forks, formed as a series
+                            of IndexedHeader (from
+
+                            low to high)
+                        timestamped_headers_count:
+                          type: string
+                          format: uint64
+                          title: >-
+                            timestamped_headers_count is the number of
+                            timestamped headers in CZ's
+
+                            canonical chain
+                      title: ChainInfo is the information of a CZ
+                    epoch_info:
+                      title: >-
+                        epoch_info is the metadata of the last BTC-finalised
+                        epoch
+                      type: object
+                      properties:
+                        epoch_number:
+                          type: string
+                          format: uint64
+                          title: epoch_number is the number of this epoch
+                        current_epoch_interval:
+                          type: string
+                          format: uint64
+                          title: >-
+                            current_epoch_interval is the epoch interval at the
+                            time of this epoch
+                        first_block_height:
+                          type: string
+                          format: uint64
+                          title: >-
+                            first_block_height is the height of the first block
+                            in this epoch
+                        last_block_time:
+                          type: string
+                          format: date-time
+                          description: >-
+                            last_block_time is the time of the last block in
+                            this epoch.
+
+                            Babylon needs to remember the last header's time of
+                            each epoch to complete
+
+                            unbonding validators/delegations when a previous
+                            epoch's checkpoint is
+
+                            finalised. The last_block_time field is nil in the
+                            epoch's beginning, and
+
+                            is set upon the end of this epoch.
+                        sealer_app_hash:
+                          type: string
+                          format: byte
+                          title: >-
+                            sealer is the last block of the sealed epoch
+
+                            sealer_app_hash points to the sealer but stored in
+                            the 1st header
+
+                            of the next epoch
+                        sealer_block_hash:
+                          type: string
+                          format: byte
+                          title: >-
+                            sealer_block_hash is the hash of the sealer
+
+                            the validator set has generated a BLS multisig on
+                            the hash,
+
+                            i.e., hash of the last block in the epoch
+                    raw_checkpoint:
+                      title: raw_checkpoint is the raw checkpoint of this epoch
+                      type: object
+                      properties:
+                        epoch_num:
+                          type: string
+                          format: uint64
+                          title: >-
+                            epoch_num defines the epoch number the raw
+                            checkpoint is for
+                        block_hash:
+                          type: string
+                          format: byte
+                          title: >-
+                            block_hash defines the 'BlockID.Hash', which is the
+                            hash of
+
+                            the block that individual BLS sigs are signed on
+                        bitmap:
+                          type: string
+                          format: byte
+                          title: >-
+                            bitmap defines the bitmap that indicates the signers
+                            of the BLS multi sig
+                        bls_multi_sig:
+                          type: string
+                          format: byte
+                          title: >-
+                            bls_multi_sig defines the multi sig that is
+                            aggregated from individual BLS
+
+                            sigs
+                    btc_submission_key:
+                      title: >-
+                        btc_submission_key is position of two BTC txs that
+                        include the raw
+
+                        checkpoint of this epoch
+                      type: object
+                      properties:
+                        key:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              index:
+                                type: integer
+                                format: int64
+                              hash:
+                                type: string
+                                format: byte
+                            title: >-
+                              Each provided OP_RETURN transaction can be
+                              identified by hash of block in
+
+                              which transaction was included and transaction
+                              index in the block
+                    proof:
+                      title: proof is the proof that the chain info is finalized
+                      type: object
+                      properties:
+                        proof_cz_header_in_epoch:
+                          title: >-
+                            proof_cz_header_in_epoch is the proof that the CZ
+                            header is timestamped
+
+                            within a certain epoch
+                          type: object
+                          properties:
+                            ops:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
+                                  key:
+                                    type: string
+                                    format: byte
+                                  data:
+                                    type: string
+                                    format: byte
+                                title: >-
+                                  ProofOp defines an operation used for
+                                  calculating Merkle root
+
+                                  The data could be arbitrary format, providing
+                                  nessecary data
+
+                                  for example neighbouring node hash
+                        proof_epoch_sealed:
+                          title: >-
+                            proof_epoch_sealed is the proof that the epoch is
+                            sealed
+                          type: object
+                          properties:
+                            validator_set:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  validator_address:
+                                    type: string
+                                    title: >-
+                                      validator_address is the address of the
+                                      validator
+                                  bls_pub_key:
+                                    type: string
+                                    format: byte
+                                    title: >-
+                                      bls_pub_key is the BLS public key of the
+                                      validator
+                                  voting_power:
+                                    type: string
+                                    format: uint64
+                                    title: >-
+                                      voting_power is the voting power of the
+                                      validator at the given epoch
+                                title: >-
+                                  ValidatorWithBlsKey couples validator address,
+                                  voting power, and its bls
+
+                                  public key
+                              title: >-
+                                validator_set is the validator set of the sealed
+                                epoch
+
+                                This validator set has generated a BLS multisig
+                                on `app_hash` of
+
+                                the sealer header
+                            proof_epoch_info:
+                              title: >-
+                                proof_epoch_info is the Merkle proof that the
+                                epoch's metadata is committed
+
+                                to `app_hash` of the sealer header
+                              type: object
+                              properties:
+                                ops:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                      key:
+                                        type: string
+                                        format: byte
+                                      data:
+                                        type: string
+                                        format: byte
+                                    title: >-
+                                      ProofOp defines an operation used for
+                                      calculating Merkle root
+
+                                      The data could be arbitrary format,
+                                      providing nessecary data
+
+                                      for example neighbouring node hash
+                            proof_epoch_val_set:
+                              title: >-
+                                proof_epoch_info is the Merkle proof that the
+                                epoch's validator set is
+
+                                committed to `app_hash` of the sealer header
+                              type: object
+                              properties:
+                                ops:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                      key:
+                                        type: string
+                                        format: byte
+                                      data:
+                                        type: string
+                                        format: byte
+                                    title: >-
+                                      ProofOp defines an operation used for
+                                      calculating Merkle root
+
+                                      The data could be arbitrary format,
+                                      providing nessecary data
+
+                                      for example neighbouring node hash
+                        proof_epoch_submitted:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                type: object
+                                properties:
+                                  index:
+                                    type: integer
+                                    format: int64
+                                  hash:
+                                    type: string
+                                    format: byte
+                                title: >-
+                                  Each provided OP_RETURN transaction can be
+                                  identified by hash of block in
+
+                                  which transaction was included and transaction
+                                  index in the block
+                                description: >-
+                                  key is the position (txIdx, blockHash) of this
+                                  tx on BTC blockchain
+
+                                  Although it is already a part of
+                                  SubmissionKey, we store it here again
+
+                                  to make TransactionInfo self-contained.
+
+                                  For example, storing the key allows
+                                  TransactionInfo to not relay on
+
+                                  the fact that TransactionInfo will be ordered
+                                  in the same order as
+
+                                  TransactionKeys in SubmissionKey.
+                              transaction:
+                                type: string
+                                format: byte
+                                title: transaction is the full transaction in bytes
+                              proof:
+                                type: string
+                                format: byte
+                                title: >-
+                                  proof is the Merkle proof that this tx is
+                                  included in the position in `key`
+
+                                  TODO: maybe it could use here better format as
+                                  we already processed and
+
+                                  validated the proof?
+                            title: >-
+                              TransactionInfo is the info of a tx on Bitcoin,
+
+                              including
+
+                              - the position of the tx on BTC blockchain
+
+                              - the full tx content
+
+                              - the Merkle proof that this tx is on the above
+                              position
+                          title: >-
+                            proof_epoch_submitted is the proof that the epoch's
+                            checkpoint is included
+
+                            in BTC ledger It is the two TransactionInfo in the
+                            best (i.e., earliest)
+
+                            checkpoint submission
+                  title: >-
+                    FinalizedChainInfo is the information of a CZ that is
+                    BTC-finalised
+            description: |-
+              QueryFinalizedChainsInfoResponse is response type for the
+              Query/FinalizedChainsInfo RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: consumer_ids
+          description: consumer_ids is the list of ids of CZs.
+          in: query
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+        - name: prove
+          description: >-
+            prove indicates whether the querier wants to get proofs of this
+            timestamp.
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /babylon/zoneconcierge/v1/headers/{consumer_id}:
+    get:
+      summary: |-
+        ListHeaders queries the headers of a chain in Babylon's view, with
+        pagination support
+      operationId: ListHeaders
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              headers:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    consumer_id:
+                      type: string
+                      title: consumer_id is the unique ID of the consumer
+                    hash:
+                      type: string
+                      format: byte
+                      title: hash is the hash of this header
+                    height:
+                      type: string
+                      format: uint64
+                      title: >-
+                        height is the height of this header on CZ ledger
+
+                        (hash, height) jointly provides the position of the
+                        header on CZ ledger
+                    time:
+                      type: string
+                      format: date-time
+                      title: >-
+                        time is the timestamp of this header on CZ ledger
+
+                        it is needed for CZ to unbond all mature
+                        validators/delegations
+
+                        before this timestamp when this header is BTC-finalised
+                    babylon_header_hash:
+                      type: string
+                      format: byte
+                      title: >-
+                        babylon_header_hash is the hash of the babylon block
+                        that includes this CZ
+
+                        header
+                    babylon_header_height:
+                      type: string
+                      format: uint64
+                      title: >-
+                        babylon_header_height is the height of the babylon block
+                        that includes this CZ
+
+                        header
+                    babylon_epoch:
+                      type: string
+                      format: uint64
+                      title: >-
+                        epoch is the epoch number of this header on Babylon
+                        ledger
+                    babylon_tx_hash:
+                      type: string
+                      format: byte
+                      title: >-
+                        babylon_tx_hash is the hash of the tx that includes this
+                        header
+
+                        (babylon_block_height, babylon_tx_hash) jointly provides
+                        the position of
+
+                        the header on Babylon ledger
+                  title: IndexedHeader is the metadata of a CZ header
+                title: headers is the list of headers
+              pagination:
+                title: pagination defines the pagination in the response
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+            description: >-
+              QueryListHeadersResponse is response type for the
+              Query/ListHeaders RPC
+
+              method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: consumer_id
+          in: path
+          required: true
+          type: string
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /babylon/zoneconcierge/v1/headers/{consumer_id}/epochs/{epoch_num}:
+    get:
+      summary: |-
+        ListEpochHeaders queries the headers of a chain timestamped in a given
+        epoch of Babylon, with pagination support
+      operationId: ListEpochHeaders
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              headers:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    consumer_id:
+                      type: string
+                      title: consumer_id is the unique ID of the consumer
+                    hash:
+                      type: string
+                      format: byte
+                      title: hash is the hash of this header
+                    height:
+                      type: string
+                      format: uint64
+                      title: >-
+                        height is the height of this header on CZ ledger
+
+                        (hash, height) jointly provides the position of the
+                        header on CZ ledger
+                    time:
+                      type: string
+                      format: date-time
+                      title: >-
+                        time is the timestamp of this header on CZ ledger
+
+                        it is needed for CZ to unbond all mature
+                        validators/delegations
+
+                        before this timestamp when this header is BTC-finalised
+                    babylon_header_hash:
+                      type: string
+                      format: byte
+                      title: >-
+                        babylon_header_hash is the hash of the babylon block
+                        that includes this CZ
+
+                        header
+                    babylon_header_height:
+                      type: string
+                      format: uint64
+                      title: >-
+                        babylon_header_height is the height of the babylon block
+                        that includes this CZ
+
+                        header
+                    babylon_epoch:
+                      type: string
+                      format: uint64
+                      title: >-
+                        epoch is the epoch number of this header on Babylon
+                        ledger
+                    babylon_tx_hash:
+                      type: string
+                      format: byte
+                      title: >-
+                        babylon_tx_hash is the hash of the tx that includes this
+                        header
+
+                        (babylon_block_height, babylon_tx_hash) jointly provides
+                        the position of
+
+                        the header on Babylon ledger
+                  title: IndexedHeader is the metadata of a CZ header
+                title: headers is the list of headers
+            description: >-
+              QueryListEpochHeadersResponse is response type for the
+              Query/ListEpochHeaders
+
+              RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: consumer_id
+          in: path
+          required: true
+          type: string
+        - name: epoch_num
+          in: path
+          required: true
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /babylon/zoneconcierge/v1/params:
+    get:
+      summary: Params queries the parameters of the module.
+      operationId: ZoneConciergeParams
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              params:
+                description: params holds all the parameters of this module.
+                type: object
+                properties:
+                  ibc_packet_timeout_seconds:
+                    type: integer
+                    format: int64
+                    title: >-
+                      ibc_packet_timeout_seconds is the time period after which
+                      an unrelayed 
+
+                      IBC packet becomes timeout, measured in seconds
+            description: >-
+              QueryParamsResponse is the response type for the Query/Params RPC
+              method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+                        // or ...
+                        if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+                          foo = any.unpack(Foo.getDefaultInstance());
+                        }
+
+                    Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                    Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+                    JSON
+
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      tags:
+        - Query
 definitions:
   babylon.btccheckpoint.v1.BTCCheckpointInfoResponse:
     type: object
@@ -15572,3 +21464,3751 @@ definitions:
           transition and the time (in both timestamp and block height) of this
           transition.
     description: RawCheckpointWithMetaResponse wraps the raw checkpoint with metadata.
+  babylon.btcstkconsumer.v1.ConsumerRegister:
+    type: object
+    properties:
+      consumer_id:
+        type: string
+        title: >-
+          consumer_id is the ID of the consumer
+
+          - for Cosmos SDK chains, the consumer ID will be the IBC client ID
+
+          - for ETH L2 chains, the consumer ID will be the chain ID of the ETH
+          L2
+            chain
+      consumer_name:
+        type: string
+        title: consumer_name is the name of the consumer
+      consumer_description:
+        type: string
+        title: consumer_description is a description for the consumer (can be empty)
+      cosmos_consumer_metadata:
+        type: object
+        properties:
+          channel_id:
+            type: string
+            title: channel_id defines the IBC channel ID for the consumer chain
+        title: CosmosConsumerMetadata is the metadata for the Cosmos integration
+      eth_l2_consumer_metadata:
+        type: object
+        properties:
+          finality_contract_address:
+            type: string
+            title: >-
+              finality_contract_address is the address of the finality contract
+              for
+
+              the ETH L2 integration
+        title: ETHL2ConsumerMetadata is the metadata for the ETH L2 integration
+    title: ConsumerRegister is the registration information of a consumer
+  babylon.btcstkconsumer.v1.CosmosConsumerMetadata:
+    type: object
+    properties:
+      channel_id:
+        type: string
+        title: channel_id defines the IBC channel ID for the consumer chain
+    title: CosmosConsumerMetadata is the metadata for the Cosmos integration
+  babylon.btcstkconsumer.v1.ETHL2ConsumerMetadata:
+    type: object
+    properties:
+      finality_contract_address:
+        type: string
+        title: |-
+          finality_contract_address is the address of the finality contract for
+          the ETH L2 integration
+    title: ETHL2ConsumerMetadata is the metadata for the ETH L2 integration
+  babylon.btcstkconsumer.v1.FinalityProviderResponse:
+    type: object
+    properties:
+      description:
+        description: description defines the description terms for the finality provider.
+        type: object
+        properties:
+          moniker:
+            type: string
+            description: moniker defines a human-readable name for the validator.
+          identity:
+            type: string
+            description: >-
+              identity defines an optional identity signature (ex. UPort or
+              Keybase).
+          website:
+            type: string
+            description: website defines an optional website link.
+          security_contact:
+            type: string
+            description: security_contact defines an optional email for security contact.
+          details:
+            type: string
+            description: details define other optional details.
+      commission:
+        type: string
+        description: commission defines the commission rate of the finality provider.
+      addr:
+        type: string
+        title: babylon_pk is the Babylon secp256k1 PK of this finality provider
+      btc_pk:
+        type: string
+        format: byte
+        title: |-
+          btc_pk is the Bitcoin secp256k1 PK of this finality provider
+          the PK follows encoding in BIP-340 spec
+      pop:
+        title: pop is the proof of possession of babylon_pk and btc_pk
+        type: object
+        properties:
+          btc_sig_type:
+            title: btc_sig_type indicates the type of btc_sig in the pop
+            type: string
+            enum:
+              - BIP340
+              - BIP322
+              - ECDSA
+            default: BIP340
+            description: >-
+              - BIP340: BIP340 means the btc_sig will follow the BIP-340
+              encoding
+               - BIP322: BIP322 means the btc_sig will follow the BIP-322 encoding
+               - ECDSA: ECDSA means the btc_sig will follow the ECDSA encoding
+              ref:
+              https://github.com/okx/js-wallet-sdk/blob/a57c2acbe6ce917c0aa4e951d96c4e562ad58444/packages/coin-bitcoin/src/BtcWallet.ts#L331
+          btc_sig:
+            type: string
+            format: byte
+            title: >-
+              btc_sig is the signature generated via sign(sk_btc,
+              babylon_staker_address)
+
+              the signature follows encoding in either BIP-340 spec or BIP-322
+              spec
+      slashed_babylon_height:
+        type: string
+        format: uint64
+        title: |-
+          slashed_babylon_height indicates the Babylon height when
+          the finality provider is slashed.
+          if it's 0 then the finality provider is not slashed
+      slashed_btc_height:
+        type: integer
+        format: int64
+        title: |-
+          slashed_btc_height indicates the BTC height when
+          the finality provider is slashed.
+          if it's 0 then the finality provider is not slashed
+      height:
+        type: string
+        format: uint64
+        title: height is the queried Babylon height
+      voting_power:
+        type: string
+        format: uint64
+        title: >-
+          voting_power is the voting power of this finality provider at the
+          given height
+      consumer_id:
+        type: string
+        title: consumer_id is the consumer id this finality provider is registered to
+    description: >-
+      FinalityProviderResponse defines a finality provider with voting power
+      information.
+  babylon.btcstkconsumer.v1.Params:
+    type: object
+    properties:
+      permissioned_integration:
+        type: boolean
+        description: >-
+          permissioned_integration is a flag to enable permissioned integration,
+          i.e.,
+
+          requiring governance proposal to approve new integrations.
+    description: Params defines the parameters for the module.
+  babylon.btcstkconsumer.v1.QueryConsumerRegistryListResponse:
+    type: object
+    properties:
+      consumer_ids:
+        type: array
+        items:
+          type: string
+        title: consumer_ids are IDs of the consumers in ascending alphabetical order
+      pagination:
+        title: pagination defines the pagination in the response
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
+    title: >-
+      QueryConsumerRegistryListResponse is response type for the
+      Query/ConsumerRegistryList RPC method
+  babylon.btcstkconsumer.v1.QueryConsumersRegistryResponse:
+    type: object
+    properties:
+      consumers_register:
+        type: array
+        items:
+          type: object
+          properties:
+            consumer_id:
+              type: string
+              title: >-
+                consumer_id is the ID of the consumer
+
+                - for Cosmos SDK chains, the consumer ID will be the IBC client
+                ID
+
+                - for ETH L2 chains, the consumer ID will be the chain ID of the
+                ETH L2
+                  chain
+            consumer_name:
+              type: string
+              title: consumer_name is the name of the consumer
+            consumer_description:
+              type: string
+              title: >-
+                consumer_description is a description for the consumer (can be
+                empty)
+            cosmos_consumer_metadata:
+              type: object
+              properties:
+                channel_id:
+                  type: string
+                  title: channel_id defines the IBC channel ID for the consumer chain
+              title: >-
+                CosmosConsumerMetadata is the metadata for the Cosmos
+                integration
+            eth_l2_consumer_metadata:
+              type: object
+              properties:
+                finality_contract_address:
+                  type: string
+                  title: >-
+                    finality_contract_address is the address of the finality
+                    contract for
+
+                    the ETH L2 integration
+              title: ETHL2ConsumerMetadata is the metadata for the ETH L2 integration
+          title: ConsumerRegister is the registration information of a consumer
+    description: >-
+      QueryConsumersRegistryResponse is response type for the
+      Query/ConsumersRegistry RPC method.
+  babylon.btcstkconsumer.v1.QueryFinalityProviderConsumerResponse:
+    type: object
+    properties:
+      consumer_id:
+        type: string
+    title: >-
+      QueryFinalityProviderConsumerResponse returns the CZ finality provier
+      consumer id
+  babylon.btcstkconsumer.v1.QueryFinalityProviderResponse:
+    type: object
+    properties:
+      finality_provider:
+        title: finality_provider contains the FinalityProvider
+        type: object
+        properties:
+          description:
+            description: >-
+              description defines the description terms for the finality
+              provider.
+            type: object
+            properties:
+              moniker:
+                type: string
+                description: moniker defines a human-readable name for the validator.
+              identity:
+                type: string
+                description: >-
+                  identity defines an optional identity signature (ex. UPort or
+                  Keybase).
+              website:
+                type: string
+                description: website defines an optional website link.
+              security_contact:
+                type: string
+                description: >-
+                  security_contact defines an optional email for security
+                  contact.
+              details:
+                type: string
+                description: details define other optional details.
+          commission:
+            type: string
+            description: commission defines the commission rate of the finality provider.
+          addr:
+            type: string
+            title: babylon_pk is the Babylon secp256k1 PK of this finality provider
+          btc_pk:
+            type: string
+            format: byte
+            title: |-
+              btc_pk is the Bitcoin secp256k1 PK of this finality provider
+              the PK follows encoding in BIP-340 spec
+          pop:
+            title: pop is the proof of possession of babylon_pk and btc_pk
+            type: object
+            properties:
+              btc_sig_type:
+                title: btc_sig_type indicates the type of btc_sig in the pop
+                type: string
+                enum:
+                  - BIP340
+                  - BIP322
+                  - ECDSA
+                default: BIP340
+                description: >-
+                  - BIP340: BIP340 means the btc_sig will follow the BIP-340
+                  encoding
+                   - BIP322: BIP322 means the btc_sig will follow the BIP-322 encoding
+                   - ECDSA: ECDSA means the btc_sig will follow the ECDSA encoding
+                  ref:
+                  https://github.com/okx/js-wallet-sdk/blob/a57c2acbe6ce917c0aa4e951d96c4e562ad58444/packages/coin-bitcoin/src/BtcWallet.ts#L331
+              btc_sig:
+                type: string
+                format: byte
+                title: >-
+                  btc_sig is the signature generated via sign(sk_btc,
+                  babylon_staker_address)
+
+                  the signature follows encoding in either BIP-340 spec or
+                  BIP-322 spec
+          slashed_babylon_height:
+            type: string
+            format: uint64
+            title: |-
+              slashed_babylon_height indicates the Babylon height when
+              the finality provider is slashed.
+              if it's 0 then the finality provider is not slashed
+          slashed_btc_height:
+            type: integer
+            format: int64
+            title: |-
+              slashed_btc_height indicates the BTC height when
+              the finality provider is slashed.
+              if it's 0 then the finality provider is not slashed
+          height:
+            type: string
+            format: uint64
+            title: height is the queried Babylon height
+          voting_power:
+            type: string
+            format: uint64
+            title: >-
+              voting_power is the voting power of this finality provider at the
+              given height
+          consumer_id:
+            type: string
+            title: >-
+              consumer_id is the consumer id this finality provider is
+              registered to
+        description: >-
+          FinalityProviderResponse defines a finality provider with voting power
+          information.
+    title: >-
+      QueryFinalityProviderResponse contains information about a finality
+      provider
+  babylon.btcstkconsumer.v1.QueryFinalityProvidersResponse:
+    type: object
+    properties:
+      finality_providers:
+        type: array
+        items:
+          type: object
+          properties:
+            description:
+              description: >-
+                description defines the description terms for the finality
+                provider.
+              type: object
+              properties:
+                moniker:
+                  type: string
+                  description: moniker defines a human-readable name for the validator.
+                identity:
+                  type: string
+                  description: >-
+                    identity defines an optional identity signature (ex. UPort
+                    or Keybase).
+                website:
+                  type: string
+                  description: website defines an optional website link.
+                security_contact:
+                  type: string
+                  description: >-
+                    security_contact defines an optional email for security
+                    contact.
+                details:
+                  type: string
+                  description: details define other optional details.
+            commission:
+              type: string
+              description: commission defines the commission rate of the finality provider.
+            addr:
+              type: string
+              title: babylon_pk is the Babylon secp256k1 PK of this finality provider
+            btc_pk:
+              type: string
+              format: byte
+              title: |-
+                btc_pk is the Bitcoin secp256k1 PK of this finality provider
+                the PK follows encoding in BIP-340 spec
+            pop:
+              title: pop is the proof of possession of babylon_pk and btc_pk
+              type: object
+              properties:
+                btc_sig_type:
+                  title: btc_sig_type indicates the type of btc_sig in the pop
+                  type: string
+                  enum:
+                    - BIP340
+                    - BIP322
+                    - ECDSA
+                  default: BIP340
+                  description: >-
+                    - BIP340: BIP340 means the btc_sig will follow the BIP-340
+                    encoding
+                     - BIP322: BIP322 means the btc_sig will follow the BIP-322 encoding
+                     - ECDSA: ECDSA means the btc_sig will follow the ECDSA encoding
+                    ref:
+                    https://github.com/okx/js-wallet-sdk/blob/a57c2acbe6ce917c0aa4e951d96c4e562ad58444/packages/coin-bitcoin/src/BtcWallet.ts#L331
+                btc_sig:
+                  type: string
+                  format: byte
+                  title: >-
+                    btc_sig is the signature generated via sign(sk_btc,
+                    babylon_staker_address)
+
+                    the signature follows encoding in either BIP-340 spec or
+                    BIP-322 spec
+            slashed_babylon_height:
+              type: string
+              format: uint64
+              title: |-
+                slashed_babylon_height indicates the Babylon height when
+                the finality provider is slashed.
+                if it's 0 then the finality provider is not slashed
+            slashed_btc_height:
+              type: integer
+              format: int64
+              title: |-
+                slashed_btc_height indicates the BTC height when
+                the finality provider is slashed.
+                if it's 0 then the finality provider is not slashed
+            height:
+              type: string
+              format: uint64
+              title: height is the queried Babylon height
+            voting_power:
+              type: string
+              format: uint64
+              title: >-
+                voting_power is the voting power of this finality provider at
+                the given height
+            consumer_id:
+              type: string
+              title: >-
+                consumer_id is the consumer id this finality provider is
+                registered to
+          description: >-
+            FinalityProviderResponse defines a finality provider with voting
+            power information.
+        title: finality_providers contains all the finality providers
+      pagination:
+        description: pagination defines the pagination in the response.
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+    description: |-
+      QueryFinalityProvidersResponse is the response type for the
+      Query/FinalityProviders RPC method.
+  babylon.btcstkconsumer.v1.QueryParamsResponse:
+    type: object
+    properties:
+      params:
+        description: params holds all the parameters of this module.
+        type: object
+        properties:
+          permissioned_integration:
+            type: boolean
+            description: >-
+              permissioned_integration is a flag to enable permissioned
+              integration, i.e.,
+
+              requiring governance proposal to approve new integrations.
+    description: QueryParamsResponse is response type for the Query/Params RPC method.
+  babylon.incentive.BTCStakingGaugeResponse:
+    type: object
+    properties:
+      coins:
+        type: array
+        items:
+          type: object
+          properties:
+            denom:
+              type: string
+            amount:
+              type: string
+          description: |-
+            Coin defines a token with a denomination and an amount.
+
+            NOTE: The amount field is an Int which implements the custom method
+            signatures required by gogoproto.
+        title: |-
+          coins that have been in the gauge
+          can have multiple coin denoms
+    description: >-
+      BTCStakingGaugeResponse is response type for the Query/BTCStakingGauge RPC
+      method.
+  babylon.incentive.Params:
+    type: object
+    properties:
+      btc_staking_portion:
+        type: string
+        title: >-
+          btc_staking_portion is the portion of rewards that goes to Finality
+          Providers/delegations
+
+          NOTE: the portion of each Finality Provider/delegation is calculated
+          by using its voting
+
+          power and finality provider's commission
+    title: >-
+      Params defines the parameters for the module, including portions of
+      rewards
+
+      distributed to each type of stakeholder. Note that sum of the portions
+      should
+
+      be strictly less than 1 so that the rest will go to Comet
+      validators/delegations
+
+      adapted from
+      https://github.com/cosmos/cosmos-sdk/blob/release/v0.47.x/proto/cosmos/distribution/v1beta1/distribution.proto
+  babylon.incentive.QueryBTCStakingGaugeResponse:
+    type: object
+    properties:
+      gauge:
+        title: gauge is the BTC staking gauge at the queried height
+        type: object
+        properties:
+          coins:
+            type: array
+            items:
+              type: object
+              properties:
+                denom:
+                  type: string
+                amount:
+                  type: string
+              description: >-
+                Coin defines a token with a denomination and an amount.
+
+
+                NOTE: The amount field is an Int which implements the custom
+                method
+
+                signatures required by gogoproto.
+            title: |-
+              coins that have been in the gauge
+              can have multiple coin denoms
+        description: >-
+          BTCStakingGaugeResponse is response type for the Query/BTCStakingGauge
+          RPC method.
+    description: >-
+      QueryBTCStakingGaugeResponse is response type for the
+      Query/BTCStakingGauge RPC method.
+  babylon.incentive.QueryDelegatorWithdrawAddressResponse:
+    type: object
+    properties:
+      withdraw_address:
+        type: string
+        description: withdraw_address defines the delegator address to query for.
+    description: |-
+      QueryDelegatorWithdrawAddressResponse is the response type for the
+      Query/DelegatorWithdrawAddress RPC method.
+  babylon.incentive.QueryParamsResponse:
+    type: object
+    properties:
+      params:
+        description: params holds all the parameters of this module.
+        type: object
+        properties:
+          btc_staking_portion:
+            type: string
+            title: >-
+              btc_staking_portion is the portion of rewards that goes to
+              Finality Providers/delegations
+
+              NOTE: the portion of each Finality Provider/delegation is
+              calculated by using its voting
+
+              power and finality provider's commission
+        title: >-
+          Params defines the parameters for the module, including portions of
+          rewards
+
+          distributed to each type of stakeholder. Note that sum of the portions
+          should
+
+          be strictly less than 1 so that the rest will go to Comet
+          validators/delegations
+
+          adapted from
+          https://github.com/cosmos/cosmos-sdk/blob/release/v0.47.x/proto/cosmos/distribution/v1beta1/distribution.proto
+    description: QueryParamsResponse is response type for the Query/Params RPC method.
+  babylon.incentive.QueryRewardGaugesResponse:
+    type: object
+    properties:
+      reward_gauges:
+        type: object
+        additionalProperties:
+          type: object
+          properties:
+            coins:
+              type: array
+              items:
+                type: object
+                properties:
+                  denom:
+                    type: string
+                  amount:
+                    type: string
+                description: >-
+                  Coin defines a token with a denomination and an amount.
+
+
+                  NOTE: The amount field is an Int which implements the custom
+                  method
+
+                  signatures required by gogoproto.
+              title: |-
+                coins are coins that have been in the gauge
+                Can have multiple coin denoms
+            withdrawn_coins:
+              type: array
+              items:
+                type: object
+                properties:
+                  denom:
+                    type: string
+                  amount:
+                    type: string
+                description: >-
+                  Coin defines a token with a denomination and an amount.
+
+
+                  NOTE: The amount field is an Int which implements the custom
+                  method
+
+                  signatures required by gogoproto.
+              title: >-
+                withdrawn_coins are coins that have been withdrawn by the
+                stakeholder already
+          title: >-
+            RewardGaugesResponse is an object that stores rewards distributed to
+            a BTC staking stakeholder
+        title: >-
+          reward_gauges is the map of reward gauges, where key is the
+          stakeholder type
+
+          and value is the reward gauge holding all rewards for the stakeholder
+          in that type
+    description: >-
+      QueryRewardGaugesResponse is response type for the Query/RewardGauges RPC
+      method.
+  babylon.incentive.RewardGaugesResponse:
+    type: object
+    properties:
+      coins:
+        type: array
+        items:
+          type: object
+          properties:
+            denom:
+              type: string
+            amount:
+              type: string
+          description: |-
+            Coin defines a token with a denomination and an amount.
+
+            NOTE: The amount field is an Int which implements the custom method
+            signatures required by gogoproto.
+        title: |-
+          coins are coins that have been in the gauge
+          Can have multiple coin denoms
+      withdrawn_coins:
+        type: array
+        items:
+          type: object
+          properties:
+            denom:
+              type: string
+            amount:
+              type: string
+          description: |-
+            Coin defines a token with a denomination and an amount.
+
+            NOTE: The amount field is an Int which implements the custom method
+            signatures required by gogoproto.
+        title: >-
+          withdrawn_coins are coins that have been withdrawn by the stakeholder
+          already
+    title: >-
+      RewardGaugesResponse is an object that stores rewards distributed to a BTC
+      staking stakeholder
+  babylon.btccheckpoint.v1.SubmissionKey:
+    type: object
+    properties:
+      key:
+        type: array
+        items:
+          type: object
+          properties:
+            index:
+              type: integer
+              format: int64
+            hash:
+              type: string
+              format: byte
+          title: >-
+            Each provided OP_RETURN transaction can be identified by hash of
+            block in
+
+            which transaction was included and transaction index in the block
+    title: >-
+      Checkpoint can be composed from multiple transactions, so to identify
+      whole
+
+      submission we need list of transaction keys.
+
+      Each submission can generally be identified by this list of (txIdx,
+
+      blockHash) tuples. Note: this could possibly be optimized as if
+      transactions
+
+      were in one block they would have the same block hash and different
+      indexes,
+
+      but each blockhash is only 33 (1  byte for prefix encoding and 32 byte
+      hash),
+
+      so there should be other strong arguments for this optimization
+  babylon.btccheckpoint.v1.TransactionInfo:
+    type: object
+    properties:
+      key:
+        type: object
+        properties:
+          index:
+            type: integer
+            format: int64
+          hash:
+            type: string
+            format: byte
+        title: >-
+          Each provided OP_RETURN transaction can be identified by hash of block
+          in
+
+          which transaction was included and transaction index in the block
+        description: |-
+          key is the position (txIdx, blockHash) of this tx on BTC blockchain
+          Although it is already a part of SubmissionKey, we store it here again
+          to make TransactionInfo self-contained.
+          For example, storing the key allows TransactionInfo to not relay on
+          the fact that TransactionInfo will be ordered in the same order as
+          TransactionKeys in SubmissionKey.
+      transaction:
+        type: string
+        format: byte
+        title: transaction is the full transaction in bytes
+      proof:
+        type: string
+        format: byte
+        title: >-
+          proof is the Merkle proof that this tx is included in the position in
+          `key`
+
+          TODO: maybe it could use here better format as we already processed
+          and
+
+          validated the proof?
+    title: |-
+      TransactionInfo is the info of a tx on Bitcoin,
+      including
+      - the position of the tx on BTC blockchain
+      - the full tx content
+      - the Merkle proof that this tx is on the above position
+  babylon.btccheckpoint.v1.TransactionKey:
+    type: object
+    properties:
+      index:
+        type: integer
+        format: int64
+      hash:
+        type: string
+        format: byte
+    title: |-
+      Each provided OP_RETURN transaction can be identified by hash of block in
+      which transaction was included and transaction index in the block
+  babylon.checkpointing.v1.RawCheckpoint:
+    type: object
+    properties:
+      epoch_num:
+        type: string
+        format: uint64
+        title: epoch_num defines the epoch number the raw checkpoint is for
+      block_hash:
+        type: string
+        format: byte
+        title: |-
+          block_hash defines the 'BlockID.Hash', which is the hash of
+          the block that individual BLS sigs are signed on
+      bitmap:
+        type: string
+        format: byte
+        title: >-
+          bitmap defines the bitmap that indicates the signers of the BLS multi
+          sig
+      bls_multi_sig:
+        type: string
+        format: byte
+        title: >-
+          bls_multi_sig defines the multi sig that is aggregated from individual
+          BLS
+
+          sigs
+    title: RawCheckpoint wraps the BLS multi sig with metadata
+  babylon.checkpointing.v1.ValidatorWithBlsKey:
+    type: object
+    properties:
+      validator_address:
+        type: string
+        title: validator_address is the address of the validator
+      bls_pub_key:
+        type: string
+        format: byte
+        title: bls_pub_key is the BLS public key of the validator
+      voting_power:
+        type: string
+        format: uint64
+        title: voting_power is the voting power of the validator at the given epoch
+    title: |-
+      ValidatorWithBlsKey couples validator address, voting power, and its bls
+      public key
+  babylon.epoching.v1.Epoch:
+    type: object
+    properties:
+      epoch_number:
+        type: string
+        format: uint64
+        title: epoch_number is the number of this epoch
+      current_epoch_interval:
+        type: string
+        format: uint64
+        title: current_epoch_interval is the epoch interval at the time of this epoch
+      first_block_height:
+        type: string
+        format: uint64
+        title: first_block_height is the height of the first block in this epoch
+      last_block_time:
+        type: string
+        format: date-time
+        description: >-
+          last_block_time is the time of the last block in this epoch.
+
+          Babylon needs to remember the last header's time of each epoch to
+          complete
+
+          unbonding validators/delegations when a previous epoch's checkpoint is
+
+          finalised. The last_block_time field is nil in the epoch's beginning,
+          and
+
+          is set upon the end of this epoch.
+      sealer_app_hash:
+        type: string
+        format: byte
+        title: |-
+          sealer is the last block of the sealed epoch
+          sealer_app_hash points to the sealer but stored in the 1st header
+          of the next epoch
+      sealer_block_hash:
+        type: string
+        format: byte
+        title: |-
+          sealer_block_hash is the hash of the sealer
+          the validator set has generated a BLS multisig on the hash,
+          i.e., hash of the last block in the epoch
+    title: Epoch is a structure that contains the metadata of an epoch
+  babylon.zoneconcierge.v1.ChainInfo:
+    type: object
+    properties:
+      consumer_id:
+        type: string
+        title: consumer_id is the ID of the consumer
+      latest_header:
+        type: object
+        properties:
+          consumer_id:
+            type: string
+            title: consumer_id is the unique ID of the consumer
+          hash:
+            type: string
+            format: byte
+            title: hash is the hash of this header
+          height:
+            type: string
+            format: uint64
+            title: >-
+              height is the height of this header on CZ ledger
+
+              (hash, height) jointly provides the position of the header on CZ
+              ledger
+          time:
+            type: string
+            format: date-time
+            title: |-
+              time is the timestamp of this header on CZ ledger
+              it is needed for CZ to unbond all mature validators/delegations
+              before this timestamp when this header is BTC-finalised
+          babylon_header_hash:
+            type: string
+            format: byte
+            title: >-
+              babylon_header_hash is the hash of the babylon block that includes
+              this CZ
+
+              header
+          babylon_header_height:
+            type: string
+            format: uint64
+            title: >-
+              babylon_header_height is the height of the babylon block that
+              includes this CZ
+
+              header
+          babylon_epoch:
+            type: string
+            format: uint64
+            title: epoch is the epoch number of this header on Babylon ledger
+          babylon_tx_hash:
+            type: string
+            format: byte
+            title: >-
+              babylon_tx_hash is the hash of the tx that includes this header
+
+              (babylon_block_height, babylon_tx_hash) jointly provides the
+              position of
+
+              the header on Babylon ledger
+        title: IndexedHeader is the metadata of a CZ header
+      latest_forks:
+        type: object
+        properties:
+          headers:
+            type: array
+            items:
+              type: object
+              properties:
+                consumer_id:
+                  type: string
+                  title: consumer_id is the unique ID of the consumer
+                hash:
+                  type: string
+                  format: byte
+                  title: hash is the hash of this header
+                height:
+                  type: string
+                  format: uint64
+                  title: >-
+                    height is the height of this header on CZ ledger
+
+                    (hash, height) jointly provides the position of the header
+                    on CZ ledger
+                time:
+                  type: string
+                  format: date-time
+                  title: >-
+                    time is the timestamp of this header on CZ ledger
+
+                    it is needed for CZ to unbond all mature
+                    validators/delegations
+
+                    before this timestamp when this header is BTC-finalised
+                babylon_header_hash:
+                  type: string
+                  format: byte
+                  title: >-
+                    babylon_header_hash is the hash of the babylon block that
+                    includes this CZ
+
+                    header
+                babylon_header_height:
+                  type: string
+                  format: uint64
+                  title: >-
+                    babylon_header_height is the height of the babylon block
+                    that includes this CZ
+
+                    header
+                babylon_epoch:
+                  type: string
+                  format: uint64
+                  title: epoch is the epoch number of this header on Babylon ledger
+                babylon_tx_hash:
+                  type: string
+                  format: byte
+                  title: >-
+                    babylon_tx_hash is the hash of the tx that includes this
+                    header
+
+                    (babylon_block_height, babylon_tx_hash) jointly provides the
+                    position of
+
+                    the header on Babylon ledger
+              title: IndexedHeader is the metadata of a CZ header
+            title: >-
+              blocks is the list of non-canonical indexed headers at the same
+              height
+        description: >-
+          Forks is a list of non-canonical `IndexedHeader`s at the same height.
+
+          For example, assuming the following blockchain
+
+          ```
+
+          A <- B <- C <- D <- E
+                     \ -- D1
+                     \ -- D2
+          ```
+
+          Then the fork will be {[D1, D2]} where each item is in struct
+          `IndexedBlock`.
+
+
+          Note that each `IndexedHeader` in the fork should have a valid quorum
+
+          certificate. Such forks exist since Babylon considers CZs might have
+
+          dishonest majority. Also note that the IBC-Go implementation will only
+
+          consider the first header in a fork valid, since the subsequent
+          headers
+
+          cannot be verified without knowing the validator set in the previous
+          header.
+        title: >-
+          latest_forks is the latest forks, formed as a series of IndexedHeader
+          (from
+
+          low to high)
+      timestamped_headers_count:
+        type: string
+        format: uint64
+        title: |-
+          timestamped_headers_count is the number of timestamped headers in CZ's
+          canonical chain
+    title: ChainInfo is the information of a CZ
+  babylon.zoneconcierge.v1.FinalizedChainInfo:
+    type: object
+    properties:
+      consumer_id:
+        type: string
+        title: consumer_id is the ID of the consumer
+      finalized_chain_info:
+        type: object
+        properties:
+          consumer_id:
+            type: string
+            title: consumer_id is the ID of the consumer
+          latest_header:
+            type: object
+            properties:
+              consumer_id:
+                type: string
+                title: consumer_id is the unique ID of the consumer
+              hash:
+                type: string
+                format: byte
+                title: hash is the hash of this header
+              height:
+                type: string
+                format: uint64
+                title: >-
+                  height is the height of this header on CZ ledger
+
+                  (hash, height) jointly provides the position of the header on
+                  CZ ledger
+              time:
+                type: string
+                format: date-time
+                title: >-
+                  time is the timestamp of this header on CZ ledger
+
+                  it is needed for CZ to unbond all mature
+                  validators/delegations
+
+                  before this timestamp when this header is BTC-finalised
+              babylon_header_hash:
+                type: string
+                format: byte
+                title: >-
+                  babylon_header_hash is the hash of the babylon block that
+                  includes this CZ
+
+                  header
+              babylon_header_height:
+                type: string
+                format: uint64
+                title: >-
+                  babylon_header_height is the height of the babylon block that
+                  includes this CZ
+
+                  header
+              babylon_epoch:
+                type: string
+                format: uint64
+                title: epoch is the epoch number of this header on Babylon ledger
+              babylon_tx_hash:
+                type: string
+                format: byte
+                title: >-
+                  babylon_tx_hash is the hash of the tx that includes this
+                  header
+
+                  (babylon_block_height, babylon_tx_hash) jointly provides the
+                  position of
+
+                  the header on Babylon ledger
+            title: IndexedHeader is the metadata of a CZ header
+          latest_forks:
+            type: object
+            properties:
+              headers:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    consumer_id:
+                      type: string
+                      title: consumer_id is the unique ID of the consumer
+                    hash:
+                      type: string
+                      format: byte
+                      title: hash is the hash of this header
+                    height:
+                      type: string
+                      format: uint64
+                      title: >-
+                        height is the height of this header on CZ ledger
+
+                        (hash, height) jointly provides the position of the
+                        header on CZ ledger
+                    time:
+                      type: string
+                      format: date-time
+                      title: >-
+                        time is the timestamp of this header on CZ ledger
+
+                        it is needed for CZ to unbond all mature
+                        validators/delegations
+
+                        before this timestamp when this header is BTC-finalised
+                    babylon_header_hash:
+                      type: string
+                      format: byte
+                      title: >-
+                        babylon_header_hash is the hash of the babylon block
+                        that includes this CZ
+
+                        header
+                    babylon_header_height:
+                      type: string
+                      format: uint64
+                      title: >-
+                        babylon_header_height is the height of the babylon block
+                        that includes this CZ
+
+                        header
+                    babylon_epoch:
+                      type: string
+                      format: uint64
+                      title: >-
+                        epoch is the epoch number of this header on Babylon
+                        ledger
+                    babylon_tx_hash:
+                      type: string
+                      format: byte
+                      title: >-
+                        babylon_tx_hash is the hash of the tx that includes this
+                        header
+
+                        (babylon_block_height, babylon_tx_hash) jointly provides
+                        the position of
+
+                        the header on Babylon ledger
+                  title: IndexedHeader is the metadata of a CZ header
+                title: >-
+                  blocks is the list of non-canonical indexed headers at the
+                  same height
+            description: >-
+              Forks is a list of non-canonical `IndexedHeader`s at the same
+              height.
+
+              For example, assuming the following blockchain
+
+              ```
+
+              A <- B <- C <- D <- E
+                         \ -- D1
+                         \ -- D2
+              ```
+
+              Then the fork will be {[D1, D2]} where each item is in struct
+              `IndexedBlock`.
+
+
+              Note that each `IndexedHeader` in the fork should have a valid
+              quorum
+
+              certificate. Such forks exist since Babylon considers CZs might
+              have
+
+              dishonest majority. Also note that the IBC-Go implementation will
+              only
+
+              consider the first header in a fork valid, since the subsequent
+              headers
+
+              cannot be verified without knowing the validator set in the
+              previous header.
+            title: >-
+              latest_forks is the latest forks, formed as a series of
+              IndexedHeader (from
+
+              low to high)
+          timestamped_headers_count:
+            type: string
+            format: uint64
+            title: >-
+              timestamped_headers_count is the number of timestamped headers in
+              CZ's
+
+              canonical chain
+        title: ChainInfo is the information of a CZ
+      epoch_info:
+        title: epoch_info is the metadata of the last BTC-finalised epoch
+        type: object
+        properties:
+          epoch_number:
+            type: string
+            format: uint64
+            title: epoch_number is the number of this epoch
+          current_epoch_interval:
+            type: string
+            format: uint64
+            title: >-
+              current_epoch_interval is the epoch interval at the time of this
+              epoch
+          first_block_height:
+            type: string
+            format: uint64
+            title: first_block_height is the height of the first block in this epoch
+          last_block_time:
+            type: string
+            format: date-time
+            description: >-
+              last_block_time is the time of the last block in this epoch.
+
+              Babylon needs to remember the last header's time of each epoch to
+              complete
+
+              unbonding validators/delegations when a previous epoch's
+              checkpoint is
+
+              finalised. The last_block_time field is nil in the epoch's
+              beginning, and
+
+              is set upon the end of this epoch.
+          sealer_app_hash:
+            type: string
+            format: byte
+            title: |-
+              sealer is the last block of the sealed epoch
+              sealer_app_hash points to the sealer but stored in the 1st header
+              of the next epoch
+          sealer_block_hash:
+            type: string
+            format: byte
+            title: |-
+              sealer_block_hash is the hash of the sealer
+              the validator set has generated a BLS multisig on the hash,
+              i.e., hash of the last block in the epoch
+      raw_checkpoint:
+        title: raw_checkpoint is the raw checkpoint of this epoch
+        type: object
+        properties:
+          epoch_num:
+            type: string
+            format: uint64
+            title: epoch_num defines the epoch number the raw checkpoint is for
+          block_hash:
+            type: string
+            format: byte
+            title: |-
+              block_hash defines the 'BlockID.Hash', which is the hash of
+              the block that individual BLS sigs are signed on
+          bitmap:
+            type: string
+            format: byte
+            title: >-
+              bitmap defines the bitmap that indicates the signers of the BLS
+              multi sig
+          bls_multi_sig:
+            type: string
+            format: byte
+            title: >-
+              bls_multi_sig defines the multi sig that is aggregated from
+              individual BLS
+
+              sigs
+      btc_submission_key:
+        title: |-
+          btc_submission_key is position of two BTC txs that include the raw
+          checkpoint of this epoch
+        type: object
+        properties:
+          key:
+            type: array
+            items:
+              type: object
+              properties:
+                index:
+                  type: integer
+                  format: int64
+                hash:
+                  type: string
+                  format: byte
+              title: >-
+                Each provided OP_RETURN transaction can be identified by hash of
+                block in
+
+                which transaction was included and transaction index in the
+                block
+      proof:
+        title: proof is the proof that the chain info is finalized
+        type: object
+        properties:
+          proof_cz_header_in_epoch:
+            title: >-
+              proof_cz_header_in_epoch is the proof that the CZ header is
+              timestamped
+
+              within a certain epoch
+            type: object
+            properties:
+              ops:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    key:
+                      type: string
+                      format: byte
+                    data:
+                      type: string
+                      format: byte
+                  title: >-
+                    ProofOp defines an operation used for calculating Merkle
+                    root
+
+                    The data could be arbitrary format, providing nessecary data
+
+                    for example neighbouring node hash
+          proof_epoch_sealed:
+            title: proof_epoch_sealed is the proof that the epoch is sealed
+            type: object
+            properties:
+              validator_set:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    validator_address:
+                      type: string
+                      title: validator_address is the address of the validator
+                    bls_pub_key:
+                      type: string
+                      format: byte
+                      title: bls_pub_key is the BLS public key of the validator
+                    voting_power:
+                      type: string
+                      format: uint64
+                      title: >-
+                        voting_power is the voting power of the validator at the
+                        given epoch
+                  title: >-
+                    ValidatorWithBlsKey couples validator address, voting power,
+                    and its bls
+
+                    public key
+                title: >-
+                  validator_set is the validator set of the sealed epoch
+
+                  This validator set has generated a BLS multisig on `app_hash`
+                  of
+
+                  the sealer header
+              proof_epoch_info:
+                title: >-
+                  proof_epoch_info is the Merkle proof that the epoch's metadata
+                  is committed
+
+                  to `app_hash` of the sealer header
+                type: object
+                properties:
+                  ops:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        key:
+                          type: string
+                          format: byte
+                        data:
+                          type: string
+                          format: byte
+                      title: >-
+                        ProofOp defines an operation used for calculating Merkle
+                        root
+
+                        The data could be arbitrary format, providing nessecary
+                        data
+
+                        for example neighbouring node hash
+              proof_epoch_val_set:
+                title: >-
+                  proof_epoch_info is the Merkle proof that the epoch's
+                  validator set is
+
+                  committed to `app_hash` of the sealer header
+                type: object
+                properties:
+                  ops:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        key:
+                          type: string
+                          format: byte
+                        data:
+                          type: string
+                          format: byte
+                      title: >-
+                        ProofOp defines an operation used for calculating Merkle
+                        root
+
+                        The data could be arbitrary format, providing nessecary
+                        data
+
+                        for example neighbouring node hash
+          proof_epoch_submitted:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: object
+                  properties:
+                    index:
+                      type: integer
+                      format: int64
+                    hash:
+                      type: string
+                      format: byte
+                  title: >-
+                    Each provided OP_RETURN transaction can be identified by
+                    hash of block in
+
+                    which transaction was included and transaction index in the
+                    block
+                  description: >-
+                    key is the position (txIdx, blockHash) of this tx on BTC
+                    blockchain
+
+                    Although it is already a part of SubmissionKey, we store it
+                    here again
+
+                    to make TransactionInfo self-contained.
+
+                    For example, storing the key allows TransactionInfo to not
+                    relay on
+
+                    the fact that TransactionInfo will be ordered in the same
+                    order as
+
+                    TransactionKeys in SubmissionKey.
+                transaction:
+                  type: string
+                  format: byte
+                  title: transaction is the full transaction in bytes
+                proof:
+                  type: string
+                  format: byte
+                  title: >-
+                    proof is the Merkle proof that this tx is included in the
+                    position in `key`
+
+                    TODO: maybe it could use here better format as we already
+                    processed and
+
+                    validated the proof?
+              title: |-
+                TransactionInfo is the info of a tx on Bitcoin,
+                including
+                - the position of the tx on BTC blockchain
+                - the full tx content
+                - the Merkle proof that this tx is on the above position
+            title: >-
+              proof_epoch_submitted is the proof that the epoch's checkpoint is
+              included
+
+              in BTC ledger It is the two TransactionInfo in the best (i.e.,
+              earliest)
+
+              checkpoint submission
+    title: FinalizedChainInfo is the information of a CZ that is BTC-finalised
+  babylon.zoneconcierge.v1.Forks:
+    type: object
+    properties:
+      headers:
+        type: array
+        items:
+          type: object
+          properties:
+            consumer_id:
+              type: string
+              title: consumer_id is the unique ID of the consumer
+            hash:
+              type: string
+              format: byte
+              title: hash is the hash of this header
+            height:
+              type: string
+              format: uint64
+              title: >-
+                height is the height of this header on CZ ledger
+
+                (hash, height) jointly provides the position of the header on CZ
+                ledger
+            time:
+              type: string
+              format: date-time
+              title: |-
+                time is the timestamp of this header on CZ ledger
+                it is needed for CZ to unbond all mature validators/delegations
+                before this timestamp when this header is BTC-finalised
+            babylon_header_hash:
+              type: string
+              format: byte
+              title: >-
+                babylon_header_hash is the hash of the babylon block that
+                includes this CZ
+
+                header
+            babylon_header_height:
+              type: string
+              format: uint64
+              title: >-
+                babylon_header_height is the height of the babylon block that
+                includes this CZ
+
+                header
+            babylon_epoch:
+              type: string
+              format: uint64
+              title: epoch is the epoch number of this header on Babylon ledger
+            babylon_tx_hash:
+              type: string
+              format: byte
+              title: >-
+                babylon_tx_hash is the hash of the tx that includes this header
+
+                (babylon_block_height, babylon_tx_hash) jointly provides the
+                position of
+
+                the header on Babylon ledger
+          title: IndexedHeader is the metadata of a CZ header
+        title: blocks is the list of non-canonical indexed headers at the same height
+    description: >-
+      Forks is a list of non-canonical `IndexedHeader`s at the same height.
+
+      For example, assuming the following blockchain
+
+      ```
+
+      A <- B <- C <- D <- E
+                 \ -- D1
+                 \ -- D2
+      ```
+
+      Then the fork will be {[D1, D2]} where each item is in struct
+      `IndexedBlock`.
+
+
+      Note that each `IndexedHeader` in the fork should have a valid quorum
+
+      certificate. Such forks exist since Babylon considers CZs might have
+
+      dishonest majority. Also note that the IBC-Go implementation will only
+
+      consider the first header in a fork valid, since the subsequent headers
+
+      cannot be verified without knowing the validator set in the previous
+      header.
+  babylon.zoneconcierge.v1.IndexedHeader:
+    type: object
+    properties:
+      consumer_id:
+        type: string
+        title: consumer_id is the unique ID of the consumer
+      hash:
+        type: string
+        format: byte
+        title: hash is the hash of this header
+      height:
+        type: string
+        format: uint64
+        title: >-
+          height is the height of this header on CZ ledger
+
+          (hash, height) jointly provides the position of the header on CZ
+          ledger
+      time:
+        type: string
+        format: date-time
+        title: |-
+          time is the timestamp of this header on CZ ledger
+          it is needed for CZ to unbond all mature validators/delegations
+          before this timestamp when this header is BTC-finalised
+      babylon_header_hash:
+        type: string
+        format: byte
+        title: >-
+          babylon_header_hash is the hash of the babylon block that includes
+          this CZ
+
+          header
+      babylon_header_height:
+        type: string
+        format: uint64
+        title: >-
+          babylon_header_height is the height of the babylon block that includes
+          this CZ
+
+          header
+      babylon_epoch:
+        type: string
+        format: uint64
+        title: epoch is the epoch number of this header on Babylon ledger
+      babylon_tx_hash:
+        type: string
+        format: byte
+        title: >-
+          babylon_tx_hash is the hash of the tx that includes this header
+
+          (babylon_block_height, babylon_tx_hash) jointly provides the position
+          of
+
+          the header on Babylon ledger
+    title: IndexedHeader is the metadata of a CZ header
+  babylon.zoneconcierge.v1.Params:
+    type: object
+    properties:
+      ibc_packet_timeout_seconds:
+        type: integer
+        format: int64
+        title: >-
+          ibc_packet_timeout_seconds is the time period after which an
+          unrelayed 
+
+          IBC packet becomes timeout, measured in seconds
+    description: Params defines the parameters for the module.
+  babylon.zoneconcierge.v1.ProofEpochSealed:
+    type: object
+    properties:
+      validator_set:
+        type: array
+        items:
+          type: object
+          properties:
+            validator_address:
+              type: string
+              title: validator_address is the address of the validator
+            bls_pub_key:
+              type: string
+              format: byte
+              title: bls_pub_key is the BLS public key of the validator
+            voting_power:
+              type: string
+              format: uint64
+              title: >-
+                voting_power is the voting power of the validator at the given
+                epoch
+          title: >-
+            ValidatorWithBlsKey couples validator address, voting power, and its
+            bls
+
+            public key
+        title: |-
+          validator_set is the validator set of the sealed epoch
+          This validator set has generated a BLS multisig on `app_hash` of
+          the sealer header
+      proof_epoch_info:
+        title: >-
+          proof_epoch_info is the Merkle proof that the epoch's metadata is
+          committed
+
+          to `app_hash` of the sealer header
+        type: object
+        properties:
+          ops:
+            type: array
+            items:
+              type: object
+              properties:
+                type:
+                  type: string
+                key:
+                  type: string
+                  format: byte
+                data:
+                  type: string
+                  format: byte
+              title: |-
+                ProofOp defines an operation used for calculating Merkle root
+                The data could be arbitrary format, providing nessecary data
+                for example neighbouring node hash
+      proof_epoch_val_set:
+        title: |-
+          proof_epoch_info is the Merkle proof that the epoch's validator set is
+          committed to `app_hash` of the sealer header
+        type: object
+        properties:
+          ops:
+            type: array
+            items:
+              type: object
+              properties:
+                type:
+                  type: string
+                key:
+                  type: string
+                  format: byte
+                data:
+                  type: string
+                  format: byte
+              title: |-
+                ProofOp defines an operation used for calculating Merkle root
+                The data could be arbitrary format, providing nessecary data
+                for example neighbouring node hash
+    title: >-
+      ProofEpochSealed is the proof that an epoch is sealed by the sealer
+      header,
+
+      i.e., the 2nd header of the next epoch With the access of metadata
+
+      - Metadata of this epoch, which includes the sealer header
+
+      - Raw checkpoint of this epoch
+
+      The verifier can perform the following verification rules:
+
+      - The raw checkpoint's `app_hash` is same as in the sealer header
+
+      - More than 2/3 (in voting power) validators in the validator set of this
+
+      epoch have signed `app_hash` of the sealer header
+
+      - The epoch metadata is committed to the `app_hash` of the sealer header
+
+      - The validator set is committed to the `app_hash` of the sealer header
+  babylon.zoneconcierge.v1.ProofFinalizedChainInfo:
+    type: object
+    properties:
+      proof_cz_header_in_epoch:
+        title: >-
+          proof_cz_header_in_epoch is the proof that the CZ header is
+          timestamped
+
+          within a certain epoch
+        type: object
+        properties:
+          ops:
+            type: array
+            items:
+              type: object
+              properties:
+                type:
+                  type: string
+                key:
+                  type: string
+                  format: byte
+                data:
+                  type: string
+                  format: byte
+              title: |-
+                ProofOp defines an operation used for calculating Merkle root
+                The data could be arbitrary format, providing nessecary data
+                for example neighbouring node hash
+      proof_epoch_sealed:
+        title: proof_epoch_sealed is the proof that the epoch is sealed
+        type: object
+        properties:
+          validator_set:
+            type: array
+            items:
+              type: object
+              properties:
+                validator_address:
+                  type: string
+                  title: validator_address is the address of the validator
+                bls_pub_key:
+                  type: string
+                  format: byte
+                  title: bls_pub_key is the BLS public key of the validator
+                voting_power:
+                  type: string
+                  format: uint64
+                  title: >-
+                    voting_power is the voting power of the validator at the
+                    given epoch
+              title: >-
+                ValidatorWithBlsKey couples validator address, voting power, and
+                its bls
+
+                public key
+            title: |-
+              validator_set is the validator set of the sealed epoch
+              This validator set has generated a BLS multisig on `app_hash` of
+              the sealer header
+          proof_epoch_info:
+            title: >-
+              proof_epoch_info is the Merkle proof that the epoch's metadata is
+              committed
+
+              to `app_hash` of the sealer header
+            type: object
+            properties:
+              ops:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    key:
+                      type: string
+                      format: byte
+                    data:
+                      type: string
+                      format: byte
+                  title: >-
+                    ProofOp defines an operation used for calculating Merkle
+                    root
+
+                    The data could be arbitrary format, providing nessecary data
+
+                    for example neighbouring node hash
+          proof_epoch_val_set:
+            title: >-
+              proof_epoch_info is the Merkle proof that the epoch's validator
+              set is
+
+              committed to `app_hash` of the sealer header
+            type: object
+            properties:
+              ops:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    key:
+                      type: string
+                      format: byte
+                    data:
+                      type: string
+                      format: byte
+                  title: >-
+                    ProofOp defines an operation used for calculating Merkle
+                    root
+
+                    The data could be arbitrary format, providing nessecary data
+
+                    for example neighbouring node hash
+      proof_epoch_submitted:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: object
+              properties:
+                index:
+                  type: integer
+                  format: int64
+                hash:
+                  type: string
+                  format: byte
+              title: >-
+                Each provided OP_RETURN transaction can be identified by hash of
+                block in
+
+                which transaction was included and transaction index in the
+                block
+              description: >-
+                key is the position (txIdx, blockHash) of this tx on BTC
+                blockchain
+
+                Although it is already a part of SubmissionKey, we store it here
+                again
+
+                to make TransactionInfo self-contained.
+
+                For example, storing the key allows TransactionInfo to not relay
+                on
+
+                the fact that TransactionInfo will be ordered in the same order
+                as
+
+                TransactionKeys in SubmissionKey.
+            transaction:
+              type: string
+              format: byte
+              title: transaction is the full transaction in bytes
+            proof:
+              type: string
+              format: byte
+              title: >-
+                proof is the Merkle proof that this tx is included in the
+                position in `key`
+
+                TODO: maybe it could use here better format as we already
+                processed and
+
+                validated the proof?
+          title: |-
+            TransactionInfo is the info of a tx on Bitcoin,
+            including
+            - the position of the tx on BTC blockchain
+            - the full tx content
+            - the Merkle proof that this tx is on the above position
+        title: >-
+          proof_epoch_submitted is the proof that the epoch's checkpoint is
+          included
+
+          in BTC ledger It is the two TransactionInfo in the best (i.e.,
+          earliest)
+
+          checkpoint submission
+    title: |-
+      ProofFinalizedChainInfo is a set of proofs that attest a chain info is
+      BTC-finalised
+  babylon.zoneconcierge.v1.QueryChainListResponse:
+    type: object
+    properties:
+      consumer_ids:
+        type: array
+        items:
+          type: string
+        title: consumer_ids are IDs of the chains in ascending alphabetical order
+      pagination:
+        title: pagination defines the pagination in the response
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
+    title: QueryChainListResponse is response type for the Query/ChainList RPC method
+  babylon.zoneconcierge.v1.QueryChainsInfoResponse:
+    type: object
+    properties:
+      chains_info:
+        type: array
+        items:
+          type: object
+          properties:
+            consumer_id:
+              type: string
+              title: consumer_id is the ID of the consumer
+            latest_header:
+              type: object
+              properties:
+                consumer_id:
+                  type: string
+                  title: consumer_id is the unique ID of the consumer
+                hash:
+                  type: string
+                  format: byte
+                  title: hash is the hash of this header
+                height:
+                  type: string
+                  format: uint64
+                  title: >-
+                    height is the height of this header on CZ ledger
+
+                    (hash, height) jointly provides the position of the header
+                    on CZ ledger
+                time:
+                  type: string
+                  format: date-time
+                  title: >-
+                    time is the timestamp of this header on CZ ledger
+
+                    it is needed for CZ to unbond all mature
+                    validators/delegations
+
+                    before this timestamp when this header is BTC-finalised
+                babylon_header_hash:
+                  type: string
+                  format: byte
+                  title: >-
+                    babylon_header_hash is the hash of the babylon block that
+                    includes this CZ
+
+                    header
+                babylon_header_height:
+                  type: string
+                  format: uint64
+                  title: >-
+                    babylon_header_height is the height of the babylon block
+                    that includes this CZ
+
+                    header
+                babylon_epoch:
+                  type: string
+                  format: uint64
+                  title: epoch is the epoch number of this header on Babylon ledger
+                babylon_tx_hash:
+                  type: string
+                  format: byte
+                  title: >-
+                    babylon_tx_hash is the hash of the tx that includes this
+                    header
+
+                    (babylon_block_height, babylon_tx_hash) jointly provides the
+                    position of
+
+                    the header on Babylon ledger
+              title: IndexedHeader is the metadata of a CZ header
+            latest_forks:
+              type: object
+              properties:
+                headers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      consumer_id:
+                        type: string
+                        title: consumer_id is the unique ID of the consumer
+                      hash:
+                        type: string
+                        format: byte
+                        title: hash is the hash of this header
+                      height:
+                        type: string
+                        format: uint64
+                        title: >-
+                          height is the height of this header on CZ ledger
+
+                          (hash, height) jointly provides the position of the
+                          header on CZ ledger
+                      time:
+                        type: string
+                        format: date-time
+                        title: >-
+                          time is the timestamp of this header on CZ ledger
+
+                          it is needed for CZ to unbond all mature
+                          validators/delegations
+
+                          before this timestamp when this header is
+                          BTC-finalised
+                      babylon_header_hash:
+                        type: string
+                        format: byte
+                        title: >-
+                          babylon_header_hash is the hash of the babylon block
+                          that includes this CZ
+
+                          header
+                      babylon_header_height:
+                        type: string
+                        format: uint64
+                        title: >-
+                          babylon_header_height is the height of the babylon
+                          block that includes this CZ
+
+                          header
+                      babylon_epoch:
+                        type: string
+                        format: uint64
+                        title: >-
+                          epoch is the epoch number of this header on Babylon
+                          ledger
+                      babylon_tx_hash:
+                        type: string
+                        format: byte
+                        title: >-
+                          babylon_tx_hash is the hash of the tx that includes
+                          this header
+
+                          (babylon_block_height, babylon_tx_hash) jointly
+                          provides the position of
+
+                          the header on Babylon ledger
+                    title: IndexedHeader is the metadata of a CZ header
+                  title: >-
+                    blocks is the list of non-canonical indexed headers at the
+                    same height
+              description: >-
+                Forks is a list of non-canonical `IndexedHeader`s at the same
+                height.
+
+                For example, assuming the following blockchain
+
+                ```
+
+                A <- B <- C <- D <- E
+                           \ -- D1
+                           \ -- D2
+                ```
+
+                Then the fork will be {[D1, D2]} where each item is in struct
+                `IndexedBlock`.
+
+
+                Note that each `IndexedHeader` in the fork should have a valid
+                quorum
+
+                certificate. Such forks exist since Babylon considers CZs might
+                have
+
+                dishonest majority. Also note that the IBC-Go implementation
+                will only
+
+                consider the first header in a fork valid, since the subsequent
+                headers
+
+                cannot be verified without knowing the validator set in the
+                previous header.
+              title: >-
+                latest_forks is the latest forks, formed as a series of
+                IndexedHeader (from
+
+                low to high)
+            timestamped_headers_count:
+              type: string
+              format: uint64
+              title: >-
+                timestamped_headers_count is the number of timestamped headers
+                in CZ's
+
+                canonical chain
+          title: ChainInfo is the information of a CZ
+    description: >-
+      QueryChainsInfoResponse is response type for the Query/ChainsInfo RPC
+      method.
+  babylon.zoneconcierge.v1.QueryEpochChainsInfoResponse:
+    type: object
+    properties:
+      chains_info:
+        type: array
+        items:
+          type: object
+          properties:
+            consumer_id:
+              type: string
+              title: consumer_id is the ID of the consumer
+            latest_header:
+              type: object
+              properties:
+                consumer_id:
+                  type: string
+                  title: consumer_id is the unique ID of the consumer
+                hash:
+                  type: string
+                  format: byte
+                  title: hash is the hash of this header
+                height:
+                  type: string
+                  format: uint64
+                  title: >-
+                    height is the height of this header on CZ ledger
+
+                    (hash, height) jointly provides the position of the header
+                    on CZ ledger
+                time:
+                  type: string
+                  format: date-time
+                  title: >-
+                    time is the timestamp of this header on CZ ledger
+
+                    it is needed for CZ to unbond all mature
+                    validators/delegations
+
+                    before this timestamp when this header is BTC-finalised
+                babylon_header_hash:
+                  type: string
+                  format: byte
+                  title: >-
+                    babylon_header_hash is the hash of the babylon block that
+                    includes this CZ
+
+                    header
+                babylon_header_height:
+                  type: string
+                  format: uint64
+                  title: >-
+                    babylon_header_height is the height of the babylon block
+                    that includes this CZ
+
+                    header
+                babylon_epoch:
+                  type: string
+                  format: uint64
+                  title: epoch is the epoch number of this header on Babylon ledger
+                babylon_tx_hash:
+                  type: string
+                  format: byte
+                  title: >-
+                    babylon_tx_hash is the hash of the tx that includes this
+                    header
+
+                    (babylon_block_height, babylon_tx_hash) jointly provides the
+                    position of
+
+                    the header on Babylon ledger
+              title: IndexedHeader is the metadata of a CZ header
+            latest_forks:
+              type: object
+              properties:
+                headers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      consumer_id:
+                        type: string
+                        title: consumer_id is the unique ID of the consumer
+                      hash:
+                        type: string
+                        format: byte
+                        title: hash is the hash of this header
+                      height:
+                        type: string
+                        format: uint64
+                        title: >-
+                          height is the height of this header on CZ ledger
+
+                          (hash, height) jointly provides the position of the
+                          header on CZ ledger
+                      time:
+                        type: string
+                        format: date-time
+                        title: >-
+                          time is the timestamp of this header on CZ ledger
+
+                          it is needed for CZ to unbond all mature
+                          validators/delegations
+
+                          before this timestamp when this header is
+                          BTC-finalised
+                      babylon_header_hash:
+                        type: string
+                        format: byte
+                        title: >-
+                          babylon_header_hash is the hash of the babylon block
+                          that includes this CZ
+
+                          header
+                      babylon_header_height:
+                        type: string
+                        format: uint64
+                        title: >-
+                          babylon_header_height is the height of the babylon
+                          block that includes this CZ
+
+                          header
+                      babylon_epoch:
+                        type: string
+                        format: uint64
+                        title: >-
+                          epoch is the epoch number of this header on Babylon
+                          ledger
+                      babylon_tx_hash:
+                        type: string
+                        format: byte
+                        title: >-
+                          babylon_tx_hash is the hash of the tx that includes
+                          this header
+
+                          (babylon_block_height, babylon_tx_hash) jointly
+                          provides the position of
+
+                          the header on Babylon ledger
+                    title: IndexedHeader is the metadata of a CZ header
+                  title: >-
+                    blocks is the list of non-canonical indexed headers at the
+                    same height
+              description: >-
+                Forks is a list of non-canonical `IndexedHeader`s at the same
+                height.
+
+                For example, assuming the following blockchain
+
+                ```
+
+                A <- B <- C <- D <- E
+                           \ -- D1
+                           \ -- D2
+                ```
+
+                Then the fork will be {[D1, D2]} where each item is in struct
+                `IndexedBlock`.
+
+
+                Note that each `IndexedHeader` in the fork should have a valid
+                quorum
+
+                certificate. Such forks exist since Babylon considers CZs might
+                have
+
+                dishonest majority. Also note that the IBC-Go implementation
+                will only
+
+                consider the first header in a fork valid, since the subsequent
+                headers
+
+                cannot be verified without knowing the validator set in the
+                previous header.
+              title: >-
+                latest_forks is the latest forks, formed as a series of
+                IndexedHeader (from
+
+                low to high)
+            timestamped_headers_count:
+              type: string
+              format: uint64
+              title: >-
+                timestamped_headers_count is the number of timestamped headers
+                in CZ's
+
+                canonical chain
+          title: ChainInfo is the information of a CZ
+        title: chain_info is the info of the CZ
+    description: >-
+      QueryEpochChainsInfoResponse is response type for the
+      Query/EpochChainsInfo RPC
+
+      method.
+  babylon.zoneconcierge.v1.QueryFinalizedChainInfoUntilHeightResponse:
+    type: object
+    properties:
+      finalized_chain_info:
+        type: object
+        properties:
+          consumer_id:
+            type: string
+            title: consumer_id is the ID of the consumer
+          latest_header:
+            type: object
+            properties:
+              consumer_id:
+                type: string
+                title: consumer_id is the unique ID of the consumer
+              hash:
+                type: string
+                format: byte
+                title: hash is the hash of this header
+              height:
+                type: string
+                format: uint64
+                title: >-
+                  height is the height of this header on CZ ledger
+
+                  (hash, height) jointly provides the position of the header on
+                  CZ ledger
+              time:
+                type: string
+                format: date-time
+                title: >-
+                  time is the timestamp of this header on CZ ledger
+
+                  it is needed for CZ to unbond all mature
+                  validators/delegations
+
+                  before this timestamp when this header is BTC-finalised
+              babylon_header_hash:
+                type: string
+                format: byte
+                title: >-
+                  babylon_header_hash is the hash of the babylon block that
+                  includes this CZ
+
+                  header
+              babylon_header_height:
+                type: string
+                format: uint64
+                title: >-
+                  babylon_header_height is the height of the babylon block that
+                  includes this CZ
+
+                  header
+              babylon_epoch:
+                type: string
+                format: uint64
+                title: epoch is the epoch number of this header on Babylon ledger
+              babylon_tx_hash:
+                type: string
+                format: byte
+                title: >-
+                  babylon_tx_hash is the hash of the tx that includes this
+                  header
+
+                  (babylon_block_height, babylon_tx_hash) jointly provides the
+                  position of
+
+                  the header on Babylon ledger
+            title: IndexedHeader is the metadata of a CZ header
+          latest_forks:
+            type: object
+            properties:
+              headers:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    consumer_id:
+                      type: string
+                      title: consumer_id is the unique ID of the consumer
+                    hash:
+                      type: string
+                      format: byte
+                      title: hash is the hash of this header
+                    height:
+                      type: string
+                      format: uint64
+                      title: >-
+                        height is the height of this header on CZ ledger
+
+                        (hash, height) jointly provides the position of the
+                        header on CZ ledger
+                    time:
+                      type: string
+                      format: date-time
+                      title: >-
+                        time is the timestamp of this header on CZ ledger
+
+                        it is needed for CZ to unbond all mature
+                        validators/delegations
+
+                        before this timestamp when this header is BTC-finalised
+                    babylon_header_hash:
+                      type: string
+                      format: byte
+                      title: >-
+                        babylon_header_hash is the hash of the babylon block
+                        that includes this CZ
+
+                        header
+                    babylon_header_height:
+                      type: string
+                      format: uint64
+                      title: >-
+                        babylon_header_height is the height of the babylon block
+                        that includes this CZ
+
+                        header
+                    babylon_epoch:
+                      type: string
+                      format: uint64
+                      title: >-
+                        epoch is the epoch number of this header on Babylon
+                        ledger
+                    babylon_tx_hash:
+                      type: string
+                      format: byte
+                      title: >-
+                        babylon_tx_hash is the hash of the tx that includes this
+                        header
+
+                        (babylon_block_height, babylon_tx_hash) jointly provides
+                        the position of
+
+                        the header on Babylon ledger
+                  title: IndexedHeader is the metadata of a CZ header
+                title: >-
+                  blocks is the list of non-canonical indexed headers at the
+                  same height
+            description: >-
+              Forks is a list of non-canonical `IndexedHeader`s at the same
+              height.
+
+              For example, assuming the following blockchain
+
+              ```
+
+              A <- B <- C <- D <- E
+                         \ -- D1
+                         \ -- D2
+              ```
+
+              Then the fork will be {[D1, D2]} where each item is in struct
+              `IndexedBlock`.
+
+
+              Note that each `IndexedHeader` in the fork should have a valid
+              quorum
+
+              certificate. Such forks exist since Babylon considers CZs might
+              have
+
+              dishonest majority. Also note that the IBC-Go implementation will
+              only
+
+              consider the first header in a fork valid, since the subsequent
+              headers
+
+              cannot be verified without knowing the validator set in the
+              previous header.
+            title: >-
+              latest_forks is the latest forks, formed as a series of
+              IndexedHeader (from
+
+              low to high)
+          timestamped_headers_count:
+            type: string
+            format: uint64
+            title: >-
+              timestamped_headers_count is the number of timestamped headers in
+              CZ's
+
+              canonical chain
+        title: ChainInfo is the information of a CZ
+      epoch_info:
+        title: epoch_info is the metadata of the last BTC-finalised epoch
+        type: object
+        properties:
+          epoch_number:
+            type: string
+            format: uint64
+            title: epoch_number is the number of this epoch
+          current_epoch_interval:
+            type: string
+            format: uint64
+            title: >-
+              current_epoch_interval is the epoch interval at the time of this
+              epoch
+          first_block_height:
+            type: string
+            format: uint64
+            title: first_block_height is the height of the first block in this epoch
+          last_block_time:
+            type: string
+            format: date-time
+            description: >-
+              last_block_time is the time of the last block in this epoch.
+
+              Babylon needs to remember the last header's time of each epoch to
+              complete
+
+              unbonding validators/delegations when a previous epoch's
+              checkpoint is
+
+              finalised. The last_block_time field is nil in the epoch's
+              beginning, and
+
+              is set upon the end of this epoch.
+          sealer_app_hash:
+            type: string
+            format: byte
+            title: |-
+              sealer is the last block of the sealed epoch
+              sealer_app_hash points to the sealer but stored in the 1st header
+              of the next epoch
+          sealer_block_hash:
+            type: string
+            format: byte
+            title: |-
+              sealer_block_hash is the hash of the sealer
+              the validator set has generated a BLS multisig on the hash,
+              i.e., hash of the last block in the epoch
+      raw_checkpoint:
+        title: raw_checkpoint is the raw checkpoint of this epoch
+        type: object
+        properties:
+          epoch_num:
+            type: string
+            format: uint64
+            title: epoch_num defines the epoch number the raw checkpoint is for
+          block_hash:
+            type: string
+            format: byte
+            title: |-
+              block_hash defines the 'BlockID.Hash', which is the hash of
+              the block that individual BLS sigs are signed on
+          bitmap:
+            type: string
+            format: byte
+            title: >-
+              bitmap defines the bitmap that indicates the signers of the BLS
+              multi sig
+          bls_multi_sig:
+            type: string
+            format: byte
+            title: >-
+              bls_multi_sig defines the multi sig that is aggregated from
+              individual BLS
+
+              sigs
+      btc_submission_key:
+        title: |-
+          btc_submission_key is position of two BTC txs that include the raw
+          checkpoint of this epoch
+        type: object
+        properties:
+          key:
+            type: array
+            items:
+              type: object
+              properties:
+                index:
+                  type: integer
+                  format: int64
+                hash:
+                  type: string
+                  format: byte
+              title: >-
+                Each provided OP_RETURN transaction can be identified by hash of
+                block in
+
+                which transaction was included and transaction index in the
+                block
+      proof:
+        title: proof is the proof that the chain info is finalized
+        type: object
+        properties:
+          proof_cz_header_in_epoch:
+            title: >-
+              proof_cz_header_in_epoch is the proof that the CZ header is
+              timestamped
+
+              within a certain epoch
+            type: object
+            properties:
+              ops:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    key:
+                      type: string
+                      format: byte
+                    data:
+                      type: string
+                      format: byte
+                  title: >-
+                    ProofOp defines an operation used for calculating Merkle
+                    root
+
+                    The data could be arbitrary format, providing nessecary data
+
+                    for example neighbouring node hash
+          proof_epoch_sealed:
+            title: proof_epoch_sealed is the proof that the epoch is sealed
+            type: object
+            properties:
+              validator_set:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    validator_address:
+                      type: string
+                      title: validator_address is the address of the validator
+                    bls_pub_key:
+                      type: string
+                      format: byte
+                      title: bls_pub_key is the BLS public key of the validator
+                    voting_power:
+                      type: string
+                      format: uint64
+                      title: >-
+                        voting_power is the voting power of the validator at the
+                        given epoch
+                  title: >-
+                    ValidatorWithBlsKey couples validator address, voting power,
+                    and its bls
+
+                    public key
+                title: >-
+                  validator_set is the validator set of the sealed epoch
+
+                  This validator set has generated a BLS multisig on `app_hash`
+                  of
+
+                  the sealer header
+              proof_epoch_info:
+                title: >-
+                  proof_epoch_info is the Merkle proof that the epoch's metadata
+                  is committed
+
+                  to `app_hash` of the sealer header
+                type: object
+                properties:
+                  ops:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        key:
+                          type: string
+                          format: byte
+                        data:
+                          type: string
+                          format: byte
+                      title: >-
+                        ProofOp defines an operation used for calculating Merkle
+                        root
+
+                        The data could be arbitrary format, providing nessecary
+                        data
+
+                        for example neighbouring node hash
+              proof_epoch_val_set:
+                title: >-
+                  proof_epoch_info is the Merkle proof that the epoch's
+                  validator set is
+
+                  committed to `app_hash` of the sealer header
+                type: object
+                properties:
+                  ops:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        key:
+                          type: string
+                          format: byte
+                        data:
+                          type: string
+                          format: byte
+                      title: >-
+                        ProofOp defines an operation used for calculating Merkle
+                        root
+
+                        The data could be arbitrary format, providing nessecary
+                        data
+
+                        for example neighbouring node hash
+          proof_epoch_submitted:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: object
+                  properties:
+                    index:
+                      type: integer
+                      format: int64
+                    hash:
+                      type: string
+                      format: byte
+                  title: >-
+                    Each provided OP_RETURN transaction can be identified by
+                    hash of block in
+
+                    which transaction was included and transaction index in the
+                    block
+                  description: >-
+                    key is the position (txIdx, blockHash) of this tx on BTC
+                    blockchain
+
+                    Although it is already a part of SubmissionKey, we store it
+                    here again
+
+                    to make TransactionInfo self-contained.
+
+                    For example, storing the key allows TransactionInfo to not
+                    relay on
+
+                    the fact that TransactionInfo will be ordered in the same
+                    order as
+
+                    TransactionKeys in SubmissionKey.
+                transaction:
+                  type: string
+                  format: byte
+                  title: transaction is the full transaction in bytes
+                proof:
+                  type: string
+                  format: byte
+                  title: >-
+                    proof is the Merkle proof that this tx is included in the
+                    position in `key`
+
+                    TODO: maybe it could use here better format as we already
+                    processed and
+
+                    validated the proof?
+              title: |-
+                TransactionInfo is the info of a tx on Bitcoin,
+                including
+                - the position of the tx on BTC blockchain
+                - the full tx content
+                - the Merkle proof that this tx is on the above position
+            title: >-
+              proof_epoch_submitted is the proof that the epoch's checkpoint is
+              included
+
+              in BTC ledger It is the two TransactionInfo in the best (i.e.,
+              earliest)
+
+              checkpoint submission
+    description: |-
+      QueryFinalizedChainInfoUntilHeightResponse is response type for the
+      Query/FinalizedChainInfoUntilHeight RPC method.
+  babylon.zoneconcierge.v1.QueryFinalizedChainsInfoResponse:
+    type: object
+    properties:
+      finalized_chains_info:
+        type: array
+        items:
+          type: object
+          properties:
+            consumer_id:
+              type: string
+              title: consumer_id is the ID of the consumer
+            finalized_chain_info:
+              type: object
+              properties:
+                consumer_id:
+                  type: string
+                  title: consumer_id is the ID of the consumer
+                latest_header:
+                  type: object
+                  properties:
+                    consumer_id:
+                      type: string
+                      title: consumer_id is the unique ID of the consumer
+                    hash:
+                      type: string
+                      format: byte
+                      title: hash is the hash of this header
+                    height:
+                      type: string
+                      format: uint64
+                      title: >-
+                        height is the height of this header on CZ ledger
+
+                        (hash, height) jointly provides the position of the
+                        header on CZ ledger
+                    time:
+                      type: string
+                      format: date-time
+                      title: >-
+                        time is the timestamp of this header on CZ ledger
+
+                        it is needed for CZ to unbond all mature
+                        validators/delegations
+
+                        before this timestamp when this header is BTC-finalised
+                    babylon_header_hash:
+                      type: string
+                      format: byte
+                      title: >-
+                        babylon_header_hash is the hash of the babylon block
+                        that includes this CZ
+
+                        header
+                    babylon_header_height:
+                      type: string
+                      format: uint64
+                      title: >-
+                        babylon_header_height is the height of the babylon block
+                        that includes this CZ
+
+                        header
+                    babylon_epoch:
+                      type: string
+                      format: uint64
+                      title: >-
+                        epoch is the epoch number of this header on Babylon
+                        ledger
+                    babylon_tx_hash:
+                      type: string
+                      format: byte
+                      title: >-
+                        babylon_tx_hash is the hash of the tx that includes this
+                        header
+
+                        (babylon_block_height, babylon_tx_hash) jointly provides
+                        the position of
+
+                        the header on Babylon ledger
+                  title: IndexedHeader is the metadata of a CZ header
+                latest_forks:
+                  type: object
+                  properties:
+                    headers:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          consumer_id:
+                            type: string
+                            title: consumer_id is the unique ID of the consumer
+                          hash:
+                            type: string
+                            format: byte
+                            title: hash is the hash of this header
+                          height:
+                            type: string
+                            format: uint64
+                            title: >-
+                              height is the height of this header on CZ ledger
+
+                              (hash, height) jointly provides the position of
+                              the header on CZ ledger
+                          time:
+                            type: string
+                            format: date-time
+                            title: >-
+                              time is the timestamp of this header on CZ ledger
+
+                              it is needed for CZ to unbond all mature
+                              validators/delegations
+
+                              before this timestamp when this header is
+                              BTC-finalised
+                          babylon_header_hash:
+                            type: string
+                            format: byte
+                            title: >-
+                              babylon_header_hash is the hash of the babylon
+                              block that includes this CZ
+
+                              header
+                          babylon_header_height:
+                            type: string
+                            format: uint64
+                            title: >-
+                              babylon_header_height is the height of the babylon
+                              block that includes this CZ
+
+                              header
+                          babylon_epoch:
+                            type: string
+                            format: uint64
+                            title: >-
+                              epoch is the epoch number of this header on
+                              Babylon ledger
+                          babylon_tx_hash:
+                            type: string
+                            format: byte
+                            title: >-
+                              babylon_tx_hash is the hash of the tx that
+                              includes this header
+
+                              (babylon_block_height, babylon_tx_hash) jointly
+                              provides the position of
+
+                              the header on Babylon ledger
+                        title: IndexedHeader is the metadata of a CZ header
+                      title: >-
+                        blocks is the list of non-canonical indexed headers at
+                        the same height
+                  description: >-
+                    Forks is a list of non-canonical `IndexedHeader`s at the
+                    same height.
+
+                    For example, assuming the following blockchain
+
+                    ```
+
+                    A <- B <- C <- D <- E
+                               \ -- D1
+                               \ -- D2
+                    ```
+
+                    Then the fork will be {[D1, D2]} where each item is in
+                    struct `IndexedBlock`.
+
+
+                    Note that each `IndexedHeader` in the fork should have a
+                    valid quorum
+
+                    certificate. Such forks exist since Babylon considers CZs
+                    might have
+
+                    dishonest majority. Also note that the IBC-Go implementation
+                    will only
+
+                    consider the first header in a fork valid, since the
+                    subsequent headers
+
+                    cannot be verified without knowing the validator set in the
+                    previous header.
+                  title: >-
+                    latest_forks is the latest forks, formed as a series of
+                    IndexedHeader (from
+
+                    low to high)
+                timestamped_headers_count:
+                  type: string
+                  format: uint64
+                  title: >-
+                    timestamped_headers_count is the number of timestamped
+                    headers in CZ's
+
+                    canonical chain
+              title: ChainInfo is the information of a CZ
+            epoch_info:
+              title: epoch_info is the metadata of the last BTC-finalised epoch
+              type: object
+              properties:
+                epoch_number:
+                  type: string
+                  format: uint64
+                  title: epoch_number is the number of this epoch
+                current_epoch_interval:
+                  type: string
+                  format: uint64
+                  title: >-
+                    current_epoch_interval is the epoch interval at the time of
+                    this epoch
+                first_block_height:
+                  type: string
+                  format: uint64
+                  title: >-
+                    first_block_height is the height of the first block in this
+                    epoch
+                last_block_time:
+                  type: string
+                  format: date-time
+                  description: >-
+                    last_block_time is the time of the last block in this epoch.
+
+                    Babylon needs to remember the last header's time of each
+                    epoch to complete
+
+                    unbonding validators/delegations when a previous epoch's
+                    checkpoint is
+
+                    finalised. The last_block_time field is nil in the epoch's
+                    beginning, and
+
+                    is set upon the end of this epoch.
+                sealer_app_hash:
+                  type: string
+                  format: byte
+                  title: >-
+                    sealer is the last block of the sealed epoch
+
+                    sealer_app_hash points to the sealer but stored in the 1st
+                    header
+
+                    of the next epoch
+                sealer_block_hash:
+                  type: string
+                  format: byte
+                  title: |-
+                    sealer_block_hash is the hash of the sealer
+                    the validator set has generated a BLS multisig on the hash,
+                    i.e., hash of the last block in the epoch
+            raw_checkpoint:
+              title: raw_checkpoint is the raw checkpoint of this epoch
+              type: object
+              properties:
+                epoch_num:
+                  type: string
+                  format: uint64
+                  title: epoch_num defines the epoch number the raw checkpoint is for
+                block_hash:
+                  type: string
+                  format: byte
+                  title: |-
+                    block_hash defines the 'BlockID.Hash', which is the hash of
+                    the block that individual BLS sigs are signed on
+                bitmap:
+                  type: string
+                  format: byte
+                  title: >-
+                    bitmap defines the bitmap that indicates the signers of the
+                    BLS multi sig
+                bls_multi_sig:
+                  type: string
+                  format: byte
+                  title: >-
+                    bls_multi_sig defines the multi sig that is aggregated from
+                    individual BLS
+
+                    sigs
+            btc_submission_key:
+              title: >-
+                btc_submission_key is position of two BTC txs that include the
+                raw
+
+                checkpoint of this epoch
+              type: object
+              properties:
+                key:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      index:
+                        type: integer
+                        format: int64
+                      hash:
+                        type: string
+                        format: byte
+                    title: >-
+                      Each provided OP_RETURN transaction can be identified by
+                      hash of block in
+
+                      which transaction was included and transaction index in
+                      the block
+            proof:
+              title: proof is the proof that the chain info is finalized
+              type: object
+              properties:
+                proof_cz_header_in_epoch:
+                  title: >-
+                    proof_cz_header_in_epoch is the proof that the CZ header is
+                    timestamped
+
+                    within a certain epoch
+                  type: object
+                  properties:
+                    ops:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                          key:
+                            type: string
+                            format: byte
+                          data:
+                            type: string
+                            format: byte
+                        title: >-
+                          ProofOp defines an operation used for calculating
+                          Merkle root
+
+                          The data could be arbitrary format, providing
+                          nessecary data
+
+                          for example neighbouring node hash
+                proof_epoch_sealed:
+                  title: proof_epoch_sealed is the proof that the epoch is sealed
+                  type: object
+                  properties:
+                    validator_set:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          validator_address:
+                            type: string
+                            title: validator_address is the address of the validator
+                          bls_pub_key:
+                            type: string
+                            format: byte
+                            title: bls_pub_key is the BLS public key of the validator
+                          voting_power:
+                            type: string
+                            format: uint64
+                            title: >-
+                              voting_power is the voting power of the validator
+                              at the given epoch
+                        title: >-
+                          ValidatorWithBlsKey couples validator address, voting
+                          power, and its bls
+
+                          public key
+                      title: >-
+                        validator_set is the validator set of the sealed epoch
+
+                        This validator set has generated a BLS multisig on
+                        `app_hash` of
+
+                        the sealer header
+                    proof_epoch_info:
+                      title: >-
+                        proof_epoch_info is the Merkle proof that the epoch's
+                        metadata is committed
+
+                        to `app_hash` of the sealer header
+                      type: object
+                      properties:
+                        ops:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                              key:
+                                type: string
+                                format: byte
+                              data:
+                                type: string
+                                format: byte
+                            title: >-
+                              ProofOp defines an operation used for calculating
+                              Merkle root
+
+                              The data could be arbitrary format, providing
+                              nessecary data
+
+                              for example neighbouring node hash
+                    proof_epoch_val_set:
+                      title: >-
+                        proof_epoch_info is the Merkle proof that the epoch's
+                        validator set is
+
+                        committed to `app_hash` of the sealer header
+                      type: object
+                      properties:
+                        ops:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                              key:
+                                type: string
+                                format: byte
+                              data:
+                                type: string
+                                format: byte
+                            title: >-
+                              ProofOp defines an operation used for calculating
+                              Merkle root
+
+                              The data could be arbitrary format, providing
+                              nessecary data
+
+                              for example neighbouring node hash
+                proof_epoch_submitted:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: object
+                        properties:
+                          index:
+                            type: integer
+                            format: int64
+                          hash:
+                            type: string
+                            format: byte
+                        title: >-
+                          Each provided OP_RETURN transaction can be identified
+                          by hash of block in
+
+                          which transaction was included and transaction index
+                          in the block
+                        description: >-
+                          key is the position (txIdx, blockHash) of this tx on
+                          BTC blockchain
+
+                          Although it is already a part of SubmissionKey, we
+                          store it here again
+
+                          to make TransactionInfo self-contained.
+
+                          For example, storing the key allows TransactionInfo to
+                          not relay on
+
+                          the fact that TransactionInfo will be ordered in the
+                          same order as
+
+                          TransactionKeys in SubmissionKey.
+                      transaction:
+                        type: string
+                        format: byte
+                        title: transaction is the full transaction in bytes
+                      proof:
+                        type: string
+                        format: byte
+                        title: >-
+                          proof is the Merkle proof that this tx is included in
+                          the position in `key`
+
+                          TODO: maybe it could use here better format as we
+                          already processed and
+
+                          validated the proof?
+                    title: |-
+                      TransactionInfo is the info of a tx on Bitcoin,
+                      including
+                      - the position of the tx on BTC blockchain
+                      - the full tx content
+                      - the Merkle proof that this tx is on the above position
+                  title: >-
+                    proof_epoch_submitted is the proof that the epoch's
+                    checkpoint is included
+
+                    in BTC ledger It is the two TransactionInfo in the best
+                    (i.e., earliest)
+
+                    checkpoint submission
+          title: FinalizedChainInfo is the information of a CZ that is BTC-finalised
+    description: |-
+      QueryFinalizedChainsInfoResponse is response type for the
+      Query/FinalizedChainsInfo RPC method.
+  babylon.zoneconcierge.v1.QueryHeaderResponse:
+    type: object
+    properties:
+      header:
+        type: object
+        properties:
+          consumer_id:
+            type: string
+            title: consumer_id is the unique ID of the consumer
+          hash:
+            type: string
+            format: byte
+            title: hash is the hash of this header
+          height:
+            type: string
+            format: uint64
+            title: >-
+              height is the height of this header on CZ ledger
+
+              (hash, height) jointly provides the position of the header on CZ
+              ledger
+          time:
+            type: string
+            format: date-time
+            title: |-
+              time is the timestamp of this header on CZ ledger
+              it is needed for CZ to unbond all mature validators/delegations
+              before this timestamp when this header is BTC-finalised
+          babylon_header_hash:
+            type: string
+            format: byte
+            title: >-
+              babylon_header_hash is the hash of the babylon block that includes
+              this CZ
+
+              header
+          babylon_header_height:
+            type: string
+            format: uint64
+            title: >-
+              babylon_header_height is the height of the babylon block that
+              includes this CZ
+
+              header
+          babylon_epoch:
+            type: string
+            format: uint64
+            title: epoch is the epoch number of this header on Babylon ledger
+          babylon_tx_hash:
+            type: string
+            format: byte
+            title: >-
+              babylon_tx_hash is the hash of the tx that includes this header
+
+              (babylon_block_height, babylon_tx_hash) jointly provides the
+              position of
+
+              the header on Babylon ledger
+        title: IndexedHeader is the metadata of a CZ header
+      fork_headers:
+        type: object
+        properties:
+          headers:
+            type: array
+            items:
+              type: object
+              properties:
+                consumer_id:
+                  type: string
+                  title: consumer_id is the unique ID of the consumer
+                hash:
+                  type: string
+                  format: byte
+                  title: hash is the hash of this header
+                height:
+                  type: string
+                  format: uint64
+                  title: >-
+                    height is the height of this header on CZ ledger
+
+                    (hash, height) jointly provides the position of the header
+                    on CZ ledger
+                time:
+                  type: string
+                  format: date-time
+                  title: >-
+                    time is the timestamp of this header on CZ ledger
+
+                    it is needed for CZ to unbond all mature
+                    validators/delegations
+
+                    before this timestamp when this header is BTC-finalised
+                babylon_header_hash:
+                  type: string
+                  format: byte
+                  title: >-
+                    babylon_header_hash is the hash of the babylon block that
+                    includes this CZ
+
+                    header
+                babylon_header_height:
+                  type: string
+                  format: uint64
+                  title: >-
+                    babylon_header_height is the height of the babylon block
+                    that includes this CZ
+
+                    header
+                babylon_epoch:
+                  type: string
+                  format: uint64
+                  title: epoch is the epoch number of this header on Babylon ledger
+                babylon_tx_hash:
+                  type: string
+                  format: byte
+                  title: >-
+                    babylon_tx_hash is the hash of the tx that includes this
+                    header
+
+                    (babylon_block_height, babylon_tx_hash) jointly provides the
+                    position of
+
+                    the header on Babylon ledger
+              title: IndexedHeader is the metadata of a CZ header
+            title: >-
+              blocks is the list of non-canonical indexed headers at the same
+              height
+        description: >-
+          Forks is a list of non-canonical `IndexedHeader`s at the same height.
+
+          For example, assuming the following blockchain
+
+          ```
+
+          A <- B <- C <- D <- E
+                     \ -- D1
+                     \ -- D2
+          ```
+
+          Then the fork will be {[D1, D2]} where each item is in struct
+          `IndexedBlock`.
+
+
+          Note that each `IndexedHeader` in the fork should have a valid quorum
+
+          certificate. Such forks exist since Babylon considers CZs might have
+
+          dishonest majority. Also note that the IBC-Go implementation will only
+
+          consider the first header in a fork valid, since the subsequent
+          headers
+
+          cannot be verified without knowing the validator set in the previous
+          header.
+    description: QueryHeaderResponse is response type for the Query/Header RPC method.
+  babylon.zoneconcierge.v1.QueryListEpochHeadersResponse:
+    type: object
+    properties:
+      headers:
+        type: array
+        items:
+          type: object
+          properties:
+            consumer_id:
+              type: string
+              title: consumer_id is the unique ID of the consumer
+            hash:
+              type: string
+              format: byte
+              title: hash is the hash of this header
+            height:
+              type: string
+              format: uint64
+              title: >-
+                height is the height of this header on CZ ledger
+
+                (hash, height) jointly provides the position of the header on CZ
+                ledger
+            time:
+              type: string
+              format: date-time
+              title: |-
+                time is the timestamp of this header on CZ ledger
+                it is needed for CZ to unbond all mature validators/delegations
+                before this timestamp when this header is BTC-finalised
+            babylon_header_hash:
+              type: string
+              format: byte
+              title: >-
+                babylon_header_hash is the hash of the babylon block that
+                includes this CZ
+
+                header
+            babylon_header_height:
+              type: string
+              format: uint64
+              title: >-
+                babylon_header_height is the height of the babylon block that
+                includes this CZ
+
+                header
+            babylon_epoch:
+              type: string
+              format: uint64
+              title: epoch is the epoch number of this header on Babylon ledger
+            babylon_tx_hash:
+              type: string
+              format: byte
+              title: >-
+                babylon_tx_hash is the hash of the tx that includes this header
+
+                (babylon_block_height, babylon_tx_hash) jointly provides the
+                position of
+
+                the header on Babylon ledger
+          title: IndexedHeader is the metadata of a CZ header
+        title: headers is the list of headers
+    description: >-
+      QueryListEpochHeadersResponse is response type for the
+      Query/ListEpochHeaders
+
+      RPC method.
+  babylon.zoneconcierge.v1.QueryListHeadersResponse:
+    type: object
+    properties:
+      headers:
+        type: array
+        items:
+          type: object
+          properties:
+            consumer_id:
+              type: string
+              title: consumer_id is the unique ID of the consumer
+            hash:
+              type: string
+              format: byte
+              title: hash is the hash of this header
+            height:
+              type: string
+              format: uint64
+              title: >-
+                height is the height of this header on CZ ledger
+
+                (hash, height) jointly provides the position of the header on CZ
+                ledger
+            time:
+              type: string
+              format: date-time
+              title: |-
+                time is the timestamp of this header on CZ ledger
+                it is needed for CZ to unbond all mature validators/delegations
+                before this timestamp when this header is BTC-finalised
+            babylon_header_hash:
+              type: string
+              format: byte
+              title: >-
+                babylon_header_hash is the hash of the babylon block that
+                includes this CZ
+
+                header
+            babylon_header_height:
+              type: string
+              format: uint64
+              title: >-
+                babylon_header_height is the height of the babylon block that
+                includes this CZ
+
+                header
+            babylon_epoch:
+              type: string
+              format: uint64
+              title: epoch is the epoch number of this header on Babylon ledger
+            babylon_tx_hash:
+              type: string
+              format: byte
+              title: >-
+                babylon_tx_hash is the hash of the tx that includes this header
+
+                (babylon_block_height, babylon_tx_hash) jointly provides the
+                position of
+
+                the header on Babylon ledger
+          title: IndexedHeader is the metadata of a CZ header
+        title: headers is the list of headers
+      pagination:
+        title: pagination defines the pagination in the response
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
+    description: |-
+      QueryListHeadersResponse is response type for the Query/ListHeaders RPC
+      method.
+  babylon.zoneconcierge.v1.QueryParamsResponse:
+    type: object
+    properties:
+      params:
+        description: params holds all the parameters of this module.
+        type: object
+        properties:
+          ibc_packet_timeout_seconds:
+            type: integer
+            format: int64
+            title: >-
+              ibc_packet_timeout_seconds is the time period after which an
+              unrelayed 
+
+              IBC packet becomes timeout, measured in seconds
+    description: QueryParamsResponse is the response type for the Query/Params RPC method.
+  tendermint.crypto.ProofOp:
+    type: object
+    properties:
+      type:
+        type: string
+      key:
+        type: string
+        format: byte
+      data:
+        type: string
+        format: byte
+    title: |-
+      ProofOp defines an operation used for calculating Merkle root
+      The data could be arbitrary format, providing nessecary data
+      for example neighbouring node hash
+  tendermint.crypto.ProofOps:
+    type: object
+    properties:
+      ops:
+        type: array
+        items:
+          type: object
+          properties:
+            type:
+              type: string
+            key:
+              type: string
+              format: byte
+            data:
+              type: string
+              format: byte
+          title: |-
+            ProofOp defines an operation used for calculating Merkle root
+            The data could be arbitrary format, providing nessecary data
+            for example neighbouring node hash
+    title: ProofOps is Merkle proof defined by the list of ProofOps

--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -24,8 +24,8 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: ibc
-    commit: f3cb7e9a10ab4cd5a402b9913f65e38d
-    digest: shake256:aaa8a2a46a3ab5cb4c54f9f14920bc472e5e5f93453fa250de49f15c76dce7f82faa5615afd341967797ead8052306db6b1e6327cb1d8d94345bf07a22f8aebd
+    commit: baf134b1c13a45e9903beeba3b2a92ec
+    digest: shake256:0069c2b35e359966bfe3f30ec98bc76180f277eb6fe722cdc6d20e68257d9b888db3b801c9fdc8ae1014439d786420f21ba2147d8fee7b1dc1dc748ff84e1fe4
   - remote: buf.build
     owner: cosmos
     repository: ics23


### PR DESCRIPTION
All of our modules in proto have `/proto/babylon/<module-name>/v1/files` but incentives does not have `v1` it is defined as `/proto/babylon/incentive/files`

Future investigation to try to add `v1` to the incentive proto will be done at https://github.com/babylonlabs-io/babylon/issues/442
