### PR TITLE
Backpor: fix flaky test `FuzzCreateBTCDelegationWithParamsFromBtcHeight`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 signature nonce generation to match reference implementation
 - [#413](https://github.com/babylonlabs-io/babylon/pull/413) Fix adaptor
 signature R verification
+- [#441](https://github.com/babylonlabs-io/babylon/pull/441) Fix fuzzing test for
+`CreateBTCDelegationWithParamsFromBtcHeight`
 
 ## v1.0.0-rc3
 


### PR DESCRIPTION
Fixes: https://github.com/babylonlabs-io/babylon/issues/407

Reason of failure: Some times delegation was created below not-deep enough below the tip to be sucessful accepted