### PR TITLE
Reject forks if the first header is already known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ signature R verification`
 `CreateBTCDelegationWithParamsFromBtcHeight`
 - [#443](https://github.com/babylonlabs-io/babylon/pull/443) Fix swagger generation for incentive missing
 `v1` in path
+- [#445](https://github.com/babylonlabs-io/babylon/pull/445) Reject BTC headers
+forks starting with already known header
 
 ## v1.0.0-rc3
 

--- a/x/btclightclient/types/errors.go
+++ b/x/btclightclient/types/errors.go
@@ -16,4 +16,5 @@ var (
 	ErrChainWithNotEnoughWork   = errorsmod.Register(ModuleName, 1105, "provided chain has not enough work")
 	ErrUnauthorizedReporter     = errorsmod.Register(ModuleName, 1106, "unauthorized reporter")
 	ErrInvalidMessageFormat     = errorsmod.Register(ModuleName, 1107, "invalid message format")
+	ErrForkStartWithKnownHeader = errorsmod.Register(ModuleName, 1108, "fork start with known header")
 )


### PR DESCRIPTION
Fixes: https://github.com/babylonlabs-io/pm/issues/159

We will reject BTC forks, if the first header is already known. 

This is consensus breaking change, but on our testnet it should be non-breaking as our vigilante reporter always reports only new btc headers prefix/