### PR TITLE
Backport: Reject forks if the first header is already known (#445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+- [#445](https://github.com/babylonlabs-io/babylon/pull/445) Reject BTC headers
+forks starting with already known header
+
 ## v1.0.0-rc4
 
 ### Improvements

--- a/x/btclightclient/types/errors.go
+++ b/x/btclightclient/types/errors.go
@@ -16,4 +16,5 @@ var (
 	ErrChainWithNotEnoughWork   = errorsmod.Register(ModuleName, 1105, "provided chain has not enough work")
 	ErrUnauthorizedReporter     = errorsmod.Register(ModuleName, 1106, "unauthorized reporter")
 	ErrInvalidMessageFormat     = errorsmod.Register(ModuleName, 1107, "invalid message format")
+	ErrForkStartWithKnownHeader = errorsmod.Register(ModuleName, 1108, "fork start with known header")
 )


### PR DESCRIPTION
Fixes: https://github.com/babylonlabs-io/pm/issues/159

We will reject BTC forks, if the first header is already known.

This is consensus breaking change, but on our testnet it should be non-breaking as our vigilante reporter always reports only new btc headers prefix/