### PR TITLE
add rc.5 tesnet upgrade handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ check of rewards
 - [#476](https://github.com/babylonlabs-io/babylon/pull/476) Bump cometbft to `v0.38.17`
 - [#491](https://github.com/babylonlabs-io/babylon/pull/491) Allow slashing rate
 to have 4 decimal places
+- [#493](https://github.com/babylonlabs-io/babylon/pull/493) Add v1rc5 testnet
+upgrade handler
 
 ### State Machine Breaking
 

--- a/app/include_upgrade_testnet.go
+++ b/app/include_upgrade_testnet.go
@@ -6,18 +6,22 @@ import (
 	"github.com/babylonlabs-io/babylon/app/upgrades"
 	v1 "github.com/babylonlabs-io/babylon/app/upgrades/v1"
 	"github.com/babylonlabs-io/babylon/app/upgrades/v1/testnet"
+	v1rc5 "github.com/babylonlabs-io/babylon/app/upgrades/v1rc5/testnet"
 )
 
 // init is used to include v1 upgrade testnet data
 // it is also used for e2e testing
 func init() {
-	Upgrades = []upgrades.Upgrade{v1.CreateUpgrade(v1.UpgradeDataString{
-		BtcStakingParamsStr:       testnet.BtcStakingParamsStr,
-		FinalityParamStr:          testnet.FinalityParamStr,
-		IncentiveParamStr:         testnet.IncentiveParamStr,
-		CosmWasmParamStr:          testnet.CosmWasmParamStr,
-		NewBtcHeadersStr:          testnet.NewBtcHeadersStr,
-		TokensDistributionStr:     testnet.TokensDistributionStr,
-		AllowedStakingTxHashesStr: testnet.AllowedStakingTxHashesStr,
-	}, testnet.TestnetParamUpgrade)}
+	Upgrades = []upgrades.Upgrade{
+		v1.CreateUpgrade(v1.UpgradeDataString{
+			BtcStakingParamsStr:       testnet.BtcStakingParamsStr,
+			FinalityParamStr:          testnet.FinalityParamStr,
+			IncentiveParamStr:         testnet.IncentiveParamStr,
+			CosmWasmParamStr:          testnet.CosmWasmParamStr,
+			NewBtcHeadersStr:          testnet.NewBtcHeadersStr,
+			TokensDistributionStr:     testnet.TokensDistributionStr,
+			AllowedStakingTxHashesStr: testnet.AllowedStakingTxHashesStr,
+		}, testnet.TestnetParamUpgrade),
+		v1rc5.CreateUpgrade(),
+	}
 }

--- a/app/upgrades/v1rc5/testnet/upgrade.go
+++ b/app/upgrades/v1rc5/testnet/upgrade.go
@@ -1,0 +1,39 @@
+package testnet
+
+import (
+	"context"
+	"fmt"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/babylonlabs-io/babylon/app/keepers"
+	"github.com/babylonlabs-io/babylon/app/upgrades"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+const (
+	UpgradeName = "v1rc5"
+)
+
+func CreateUpgrade() upgrades.Upgrade {
+	return upgrades.Upgrade{
+		UpgradeName:          UpgradeName,
+		CreateUpgradeHandler: CreateUpgradeHandler(),
+	}
+}
+
+// CreateUpgradeHandler upgrade handler for launch.
+func CreateUpgradeHandler() upgrades.UpgradeHandlerCreator {
+	return func(mm *module.Manager, cfg module.Configurator, keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
+		return func(context context.Context, _plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			ctx := sdk.UnwrapSDKContext(context)
+
+			migrations, err := mm.RunMigrations(ctx, cfg, fromVM)
+			if err != nil {
+				return nil, fmt.Errorf("failed to run migrations: %w", err)
+			}
+
+			return migrations, nil
+		}
+	}
+}


### PR DESCRIPTION
Adds testnet v1rc5 handler

Note: handler needs to live on main as later when we will be upgrading testnet to v2, the upgrade will need to be made from the latest upgrade on the testnet