### PR TITLE
fix status field in rpc api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ This PR contains a series of PRs on multi-staking support and BTC staking integr
 
 - [#486](https://github.com/babylonlabs-io/babylon/pull/486) crypto: blinding base mult of nonce
 - [#443](https://github.com/babylonlabs-io/babylon/pull/443) Fix swagger generation for incentive missing `v1` in path
+- [#505](https://github.com/babylonlabs-io/babylon/pull/505) Fix `x/btcstaking`
+delegation queries
 
 ## v1.0.0-rc5
 

--- a/x/btcstaking/keeper/btc_consumer_delegations.go
+++ b/x/btcstaking/keeper/btc_consumer_delegations.go
@@ -55,7 +55,6 @@ func (k Keeper) GetBTCConsumerDelegatorDelegationsResponses(
 	fpBTCPK *bbn.BIP340PubKey,
 	pagination *query.PageRequest,
 	btcHeight uint32,
-	covenantQuorum uint32,
 ) ([]*bstypes.BTCDelegatorDelegationsResponse, *query.PageResponse, error) {
 	btcDelStore := k.btcConsumerDelegatorStore(ctx, fpBTCPK)
 
@@ -70,9 +69,11 @@ func (k Keeper) GetBTCConsumerDelegatorDelegationsResponses(
 
 		btcDelsResp := make([]*bstypes.BTCDelegationResponse, len(curBTCDels.Dels))
 		for i, btcDel := range curBTCDels.Dels {
+			params := k.GetParamsByVersion(ctx, btcDel.ParamsVersion)
+
 			status := btcDel.GetStatus(
 				btcHeight,
-				covenantQuorum,
+				params.CovenantQuorum,
 			)
 			btcDelsResp[i] = bstypes.NewBTCDelegationResponse(btcDel, status)
 		}

--- a/x/btcstaking/keeper/grpc_query_test.go
+++ b/x/btcstaking/keeper/grpc_query_test.go
@@ -457,6 +457,7 @@ func TestCorrectParamsVersionIsUsed(t *testing.T) {
 		slashingRate,
 		slashingChangeLockTime,
 	)
+	require.NoError(t, err)
 
 	err = keeper.AddBTCDelegation(ctx, btcDel)
 	require.NoError(t, err)
@@ -489,7 +490,7 @@ func TestCorrectParamsVersionIsUsed(t *testing.T) {
 
 	dp.BtcActivationHeight = 10
 	dp.CovenantPks = append(dp.CovenantPks, *bip340pk1, *bip340pk2, *bip340pk3)
-	dp.CovenantQuorum = dp.CovenantQuorum + 3
+	dp.CovenantQuorum += 3
 
 	err = keeper.SetParams(ctx, dp)
 	require.NoError(t, err)


### PR DESCRIPTION
fixes: https://github.com/babylonlabs-io/babylon/issues/503
Every query was using latest params to compute wheter delegation is active instead of params related to delegation version.

This could lead to not returnig certain results in case of updating covenant quorum.