### PR TITLE
Fix/datagen for consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#513](https://github.com/babylonlabs-io/babylon/pull/513) Suport datagen BTC delegation creation from Consumers
 - [#508](https://github.com/babylonlabs-io/babylon/pull/508) Move PoP constructor functiosn to datagen/
 - [#470](https://github.com/babylonlabs-io/babylon/pull/470) Return full consumer info and remove DB object
 usage in `x/btcstkconsumer` queries

--- a/testutil/datagen/account_balance.go
+++ b/testutil/datagen/account_balance.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	appparams "github.com/babylonlabs-io/babylon/app/params"
 	sec256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
-	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -15,34 +14,6 @@ import (
 func GenRandomAccount() *authtypes.BaseAccount {
 	senderPrivKey := sec256k1.GenPrivKey()
 	acc := authtypes.NewBaseAccount(senderPrivKey.PubKey().Address().Bytes(), senderPrivKey.PubKey(), 0, 0)
-	return acc
-}
-
-func GenRandomAccountWithPrefix(prefix string) *authtypes.BaseAccount {
-	senderPrivKey := sec256k1.GenPrivKey()
-	acc := MustNewBaseAccountWithPrefix(senderPrivKey.PubKey().Address().Bytes(), senderPrivKey.PubKey(), 0, 0, prefix)
-	return acc
-}
-
-// MustNewBaseAccountWithPrefix creates a new BaseAccount object for a given blockchain
-// Adapted from github.com/cosmos/cosmos-sdk@v0.50.11/x/auth/types/account.go
-func MustNewBaseAccountWithPrefix(address sdk.AccAddress, pubKey cryptotypes.PubKey, accountNumber, sequence uint64, prefix string) *authtypes.BaseAccount {
-	blockchainAddress, err := sdk.Bech32ifyAddressBytes(prefix, address.Bytes())
-	if err != nil {
-		panic(err)
-	}
-
-	acc := &authtypes.BaseAccount{
-		Address:       blockchainAddress,
-		AccountNumber: accountNumber,
-		Sequence:      sequence,
-	}
-
-	err = acc.SetPubKey(pubKey)
-	if err != nil {
-		panic(err)
-	}
-
 	return acc
 }
 

--- a/testutil/datagen/account_balance.go
+++ b/testutil/datagen/account_balance.go
@@ -2,12 +2,14 @@ package datagen
 
 import (
 	sdkmath "cosmossdk.io/math"
+	"errors"
 	appparams "github.com/babylonlabs-io/babylon/app/params"
 	sec256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"strings"
 )
 
 func GenRandomAccount() *authtypes.BaseAccount {
@@ -59,4 +61,36 @@ func GenRandomAccWithBalance(n int) ([]authtypes.GenesisAccount, []banktypes.Bal
 	}
 
 	return accs, balances
+}
+
+// MustAccAddressFromBech32WithPrefix calls AccAddressFromBech32WithPrefix and
+// panics on error.
+// Adapted from github.com/cosmos/cosmos-sdk@v0.50.11/types/address.go
+func MustAccAddressFromBech32WithPrefix(address, prefix string) sdk.AccAddress {
+	addr, err := AccAddressFromBech32WithPrefix(address, prefix)
+	if err != nil {
+		panic(err)
+	}
+
+	return addr
+}
+
+// AccAddressFromBech32WithPrefix creates an AccAddress from a Bech32 string.
+// Adapted from github.com/cosmos/cosmos-sdk@v0.50.11/types/address.go
+func AccAddressFromBech32WithPrefix(address, bech32PrefixAccAddr string) (addr sdk.AccAddress, err error) {
+	if len(strings.TrimSpace(address)) == 0 {
+		return sdk.AccAddress{}, errors.New("empty address string is not allowed")
+	}
+
+	bz, err := sdk.GetFromBech32(address, bech32PrefixAccAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	err = sdk.VerifyAddressFormat(bz)
+	if err != nil {
+		return nil, err
+	}
+
+	return bz, nil
 }

--- a/testutil/datagen/account_balance.go
+++ b/testutil/datagen/account_balance.go
@@ -4,6 +4,7 @@ import (
 	sdkmath "cosmossdk.io/math"
 	appparams "github.com/babylonlabs-io/babylon/app/params"
 	sec256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -12,6 +13,34 @@ import (
 func GenRandomAccount() *authtypes.BaseAccount {
 	senderPrivKey := sec256k1.GenPrivKey()
 	acc := authtypes.NewBaseAccount(senderPrivKey.PubKey().Address().Bytes(), senderPrivKey.PubKey(), 0, 0)
+	return acc
+}
+
+func GenRandomAccountWithPrefix(prefix string) *authtypes.BaseAccount {
+	senderPrivKey := sec256k1.GenPrivKey()
+	acc := MustNewBaseAccountWithPrefix(senderPrivKey.PubKey().Address().Bytes(), senderPrivKey.PubKey(), 0, 0, prefix)
+	return acc
+}
+
+// MustNewBaseAccountWithPrefix creates a new BaseAccount object for a given blockchain
+// Adapted from github.com/cosmos/cosmos-sdk@v0.50.11/x/auth/types/account.go
+func MustNewBaseAccountWithPrefix(address sdk.AccAddress, pubKey cryptotypes.PubKey, accountNumber, sequence uint64, prefix string) *authtypes.BaseAccount {
+	blockchainAddress, err := sdk.Bech32ifyAddressBytes(prefix, address.Bytes())
+	if err != nil {
+		panic(err)
+	}
+
+	acc := &authtypes.BaseAccount{
+		Address:       blockchainAddress,
+		AccountNumber: accountNumber,
+		Sequence:      sequence,
+	}
+
+	err = acc.SetPubKey(pubKey)
+	if err != nil {
+		panic(err)
+	}
+
 	return acc
 }
 

--- a/testutil/datagen/account_balance.go
+++ b/testutil/datagen/account_balance.go
@@ -11,6 +11,11 @@ import (
 	"strings"
 )
 
+func GenRandomSecp256k1Address() sdk.AccAddress {
+	senderPrivKey := sec256k1.GenPrivKey()
+	return senderPrivKey.PubKey().Address().Bytes()
+}
+
 func GenRandomAccount() *authtypes.BaseAccount {
 	senderPrivKey := sec256k1.GenPrivKey()
 	acc := authtypes.NewBaseAccount(senderPrivKey.PubKey().Address().Bytes(), senderPrivKey.PubKey(), 0, 0)

--- a/testutil/datagen/btcstaking.go
+++ b/testutil/datagen/btcstaking.go
@@ -1,6 +1,7 @@
 package datagen
 
 import (
+	sec256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"math/rand"
 	"testing"
 
@@ -122,7 +123,8 @@ func GenRandomBTCDelegation(
 	if err != nil {
 		return nil, err
 	}
-	staker := GenRandomAccountWithPrefix(appparams.Bech32PrefixAccAddr) // Staker address is always Babylon's
+
+	stakerAddress := sdk.AccAddress(sec256k1.GenPrivKey().PubKey().Address().Bytes())
 
 	// staking/slashing tx
 	stakingSlashingInfo := GenBTCStakingSlashingInfo(
@@ -166,11 +168,11 @@ func GenRandomBTCDelegation(
 	require.NoError(t, err)
 	w := uint16(100) // TODO: parameterise w
 
-	pop, err := NewPoPBTC(MustAccAddressFromBech32WithPrefix(staker.Address, appparams.Bech32PrefixAccAddr), delSK)
+	pop, err := NewPoPBTC(stakerAddress, delSK)
 	require.NoError(t, err)
 
 	del := &bstypes.BTCDelegation{
-		StakerAddr:       staker.Address,
+		StakerAddr:       sdk.MustBech32ifyAddressBytes(appparams.Bech32PrefixAccAddr, stakerAddress), // Staker address is always Babylon's
 		BtcPk:            delBTCPK,
 		Pop:              pop,
 		FpBtcPkList:      fpBTCPKs,

--- a/testutil/datagen/btcstaking.go
+++ b/testutil/datagen/btcstaking.go
@@ -165,7 +165,7 @@ func GenRandomBTCDelegation(
 	require.NoError(t, err)
 	w := uint16(100) // TODO: parameterise w
 
-	pop, err := NewPoPBTC(sdk.MustAccAddressFromBech32(staker.Address), delSK)
+	pop, err := NewPoPBTC(MustAccAddressFromBech32WithPrefix(staker.Address, "bbn"), delSK)
 	require.NoError(t, err)
 
 	del := &bstypes.BTCDelegation{

--- a/testutil/datagen/btcstaking.go
+++ b/testutil/datagen/btcstaking.go
@@ -121,7 +121,7 @@ func GenRandomBTCDelegation(
 	if err != nil {
 		return nil, err
 	}
-	staker := GenRandomAccount()
+	staker := GenRandomAccountWithPrefix("bbn") // Staker address is always Babylon's
 
 	// staking/slashing tx
 	stakingSlashingInfo := GenBTCStakingSlashingInfo(

--- a/testutil/datagen/btcstaking.go
+++ b/testutil/datagen/btcstaking.go
@@ -15,6 +15,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/require"
 
+	appparams "github.com/babylonlabs-io/babylon/app/params"
 	"github.com/babylonlabs-io/babylon/btcstaking"
 	bbn "github.com/babylonlabs-io/babylon/types"
 	bstypes "github.com/babylonlabs-io/babylon/x/btcstaking/types"
@@ -121,7 +122,7 @@ func GenRandomBTCDelegation(
 	if err != nil {
 		return nil, err
 	}
-	staker := GenRandomAccountWithPrefix("bbn") // Staker address is always Babylon's
+	staker := GenRandomAccountWithPrefix(appparams.Bech32PrefixAccAddr) // Staker address is always Babylon's
 
 	// staking/slashing tx
 	stakingSlashingInfo := GenBTCStakingSlashingInfo(
@@ -165,7 +166,7 @@ func GenRandomBTCDelegation(
 	require.NoError(t, err)
 	w := uint16(100) // TODO: parameterise w
 
-	pop, err := NewPoPBTC(MustAccAddressFromBech32WithPrefix(staker.Address, "bbn"), delSK)
+	pop, err := NewPoPBTC(MustAccAddressFromBech32WithPrefix(staker.Address, appparams.Bech32PrefixAccAddr), delSK)
 	require.NoError(t, err)
 
 	del := &bstypes.BTCDelegation{

--- a/testutil/datagen/btcstaking.go
+++ b/testutil/datagen/btcstaking.go
@@ -1,7 +1,6 @@
 package datagen
 
 import (
-	sec256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"math/rand"
 	"testing"
 
@@ -124,7 +123,7 @@ func GenRandomBTCDelegation(
 		return nil, err
 	}
 
-	stakerAddress := sdk.AccAddress(sec256k1.GenPrivKey().PubKey().Address().Bytes())
+	stakerAddress := GenRandomSecp256k1Address()
 
 	// staking/slashing tx
 	stakingSlashingInfo := GenBTCStakingSlashingInfo(

--- a/testutil/datagen/val_set.go
+++ b/testutil/datagen/val_set.go
@@ -29,6 +29,7 @@ func GenRandomValidatorAddress() sdk.ValAddress {
 	return sdk.ValAddress(ed25519.GenPrivKey().PubKey().Address())
 }
 
+// FIXME? Rename to GenRandomEd25519Address
 func GenRandomAddress() sdk.AccAddress {
 	return sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
 }


### PR DESCRIPTION
Generalises `datagen` utils / test helpers, so that they can be used from consumer networks that have a different address prefix.