### PR TITLE
fix: Add bls signer to start command with password options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#527](https://github.com/babylonlabs-io/babylon/pull/527) Create BSL signer on start command with flags.
 - [#513](https://github.com/babylonlabs-io/babylon/pull/513) Suport datagen BTC delegation creation from Consumers
 - [#508](https://github.com/babylonlabs-io/babylon/pull/508) Move PoP constructor functiosn to datagen/
 - [#470](https://github.com/babylonlabs-io/babylon/pull/470) Return full consumer info and remove DB object

--- a/app/signer/bls.go
+++ b/app/signer/bls.go
@@ -207,3 +207,31 @@ func (k *BlsKey) BlsPubKey() (bls12381.PublicKey, error) {
 	}
 	return k.PubKey, nil
 }
+
+// LoadBlsSignerIfExists attempts to load an existing BLS signer from the specified home directory
+// Returns the signer if files exist and can be loaded, or nil if files don't exist
+func LoadBlsSignerIfExists(homeDir string) checkpointingtypes.BlsSigner {
+	blsKeyFile := DefaultBlsKeyFile(homeDir)
+	blsPasswordFile := DefaultBlsPasswordFile(homeDir)
+
+	if !cmtos.FileExists(blsKeyFile) || !cmtos.FileExists(blsPasswordFile) {
+		return nil
+	}
+
+	bls := LoadBls(blsKeyFile, blsPasswordFile)
+	return &bls.Key
+}
+
+// CreateBlsSigner creates a new BLS signer with the given password
+func CreateBlsSigner(homeDir string, password string) (checkpointingtypes.BlsSigner, error) {
+	blsKeyFile := DefaultBlsKeyFile(homeDir)
+	blsPasswordFile := DefaultBlsPasswordFile(homeDir)
+
+	if err := EnsureDirs(blsKeyFile, blsPasswordFile); err != nil {
+		return nil, fmt.Errorf("failed to ensure dirs exist: %w", err)
+	}
+
+	// Generate a new BLS key with the provided password
+	bls := GenBls(blsKeyFile, blsPasswordFile, password)
+	return &bls.Key, nil
+}

--- a/app/signer/bls.go
+++ b/app/signer/bls.go
@@ -235,3 +235,28 @@ func CreateBlsSigner(homeDir string, password string) (checkpointingtypes.BlsSig
 	bls := GenBls(blsKeyFile, blsPasswordFile, password)
 	return &bls.Key, nil
 }
+
+// LoadOrGenBlsKey attempts to load an existing BLS signer or creates a new one if none exists.
+// If noPassword is true, creates key without password protection.
+// If password is empty and noPassword is false, will prompt for password.
+func LoadOrGenBlsKey(homeDir string, noPassword bool, password string) (checkpointingtypes.BlsSigner, error) {
+	// Try to load existing BLS signer first
+	blsSigner := LoadBlsSignerIfExists(homeDir)
+
+	// If no existing signer, create new one with password based on flags
+	if blsSigner == nil {
+		if !noPassword {
+			if password == "" {
+				password = NewBlsPassword()
+			}
+		}
+
+		var err error
+		blsSigner, err = CreateBlsSigner(homeDir, password)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create new BLS signer: %w", err)
+		}
+	}
+
+	return blsSigner, nil
+}

--- a/app/signer/bls_test.go
+++ b/app/signer/bls_test.go
@@ -56,3 +56,81 @@ func TestNewBls(t *testing.T) {
 		})
 	})
 }
+
+func TestLoadOrGenBlsKey(t *testing.T) {
+	t.Run("generate new key without password", func(t *testing.T) {
+		tempDir := t.TempDir()
+		defer os.RemoveAll(tempDir)
+
+		blsSigner, err := LoadOrGenBlsKey(tempDir, true, "")
+		assert.NoError(t, err)
+		assert.NotNil(t, blsSigner)
+
+		_, err = os.Stat(DefaultBlsKeyFile(tempDir))
+		assert.NoError(t, err, "BLS key file should exist")
+		_, err = os.Stat(DefaultBlsPasswordFile(tempDir))
+		assert.NoError(t, err, "BLS password file should exist")
+
+		loadedSigner, err := LoadOrGenBlsKey(tempDir, true, "")
+		assert.NoError(t, err)
+		assert.NotNil(t, loadedSigner)
+
+		origPubKey, err := blsSigner.BlsPubKey()
+		assert.NoError(t, err)
+		loadedPubKey, err := loadedSigner.BlsPubKey()
+		assert.NoError(t, err)
+		assert.Equal(t, origPubKey.Bytes(), loadedPubKey.Bytes())
+	})
+
+	t.Run("generate new key with password", func(t *testing.T) {
+		tempDir := t.TempDir()
+		defer os.RemoveAll(tempDir)
+
+		testPassword := "testpassword123"
+
+		blsSigner, err := LoadOrGenBlsKey(tempDir, false, testPassword)
+		assert.NoError(t, err)
+		assert.NotNil(t, blsSigner)
+
+		_, err = os.Stat(DefaultBlsKeyFile(tempDir))
+		assert.NoError(t, err, "BLS key file should exist")
+		_, err = os.Stat(DefaultBlsPasswordFile(tempDir))
+		assert.NoError(t, err, "BLS password file should exist")
+
+		loadedSigner, err := LoadOrGenBlsKey(tempDir, false, testPassword)
+		assert.NoError(t, err)
+		assert.NotNil(t, loadedSigner)
+
+		origPubKey, err := blsSigner.BlsPubKey()
+		assert.NoError(t, err)
+		loadedPubKey, err := loadedSigner.BlsPubKey()
+		assert.NoError(t, err)
+		assert.Equal(t, origPubKey.Bytes(), loadedPubKey.Bytes())
+	})
+
+	t.Run("load existing key", func(t *testing.T) {
+		tempDir := t.TempDir()
+		defer os.RemoveAll(tempDir)
+
+		password := "existingpassword"
+		originalSigner, err := CreateBlsSigner(tempDir, password)
+		assert.NoError(t, err)
+		assert.NotNil(t, originalSigner)
+
+		loadedSigner, err := LoadOrGenBlsKey(tempDir, false, "different_password") // Password doesn't matter for loading
+		assert.NoError(t, err)
+		assert.NotNil(t, loadedSigner)
+
+		origPubKey, err := originalSigner.BlsPubKey()
+		assert.NoError(t, err)
+		loadedPubKey, err := loadedSigner.BlsPubKey()
+		assert.NoError(t, err)
+		assert.Equal(t, origPubKey.Bytes(), loadedPubKey.Bytes())
+	})
+
+	t.Run("invalid directory path", func(t *testing.T) {
+		blsSigner, err := LoadOrGenBlsKey("/random-non-existent/path/that/should/not/exist", true, "")
+		assert.Error(t, err)
+		assert.Nil(t, blsSigner)
+	})
+}

--- a/cmd/babylond/cmd/cmd_test.go
+++ b/cmd/babylond/cmd/cmd_test.go
@@ -2,14 +2,23 @@ package cmd_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/babylonlabs-io/babylon/app"
+	"github.com/babylonlabs-io/babylon/app/signer"
 	"github.com/babylonlabs-io/babylon/cmd/babylond/cmd"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
+	stakingcli "github.com/cosmos/cosmos-sdk/x/staking/client/cli"
 )
 
 func TestInitCmd(t *testing.T) {
@@ -22,4 +31,123 @@ func TestInitCmd(t *testing.T) {
 	})
 
 	require.NoError(t, svrcmd.Execute(rootCmd, app.BabylonAppEnvPrefix, app.DefaultNodeHome))
+}
+
+func TestStartCmd(t *testing.T) {
+	err := os.RemoveAll(app.DefaultNodeHome)
+	require.NoError(t, err)
+
+	tempApp := app.NewTmpBabylonApp()
+
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{
+		"init",
+		"app-test",
+		fmt.Sprintf("--%s=%s", cli.FlagOverwrite, "true"),
+		fmt.Sprintf("--%s=%s", "bls-password", "testpassword"),
+	})
+
+	require.NoError(t, svrcmd.Execute(rootCmd, app.BabylonAppEnvPrefix, app.DefaultNodeHome))
+
+	blsKeyFile := signer.DefaultBlsKeyFile(app.DefaultNodeHome)
+	blsPasswordFile := signer.DefaultBlsPasswordFile(app.DefaultNodeHome)
+	require.FileExists(t, blsKeyFile, "BLS key file should exist after init")
+	require.FileExists(t, blsPasswordFile, "BLS password file should exist after init")
+
+	keyringDir := filepath.Join(app.DefaultNodeHome, "keyring-test")
+	err = os.MkdirAll(keyringDir, 0o755)
+	require.NoError(t, err)
+
+	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, app.DefaultNodeHome, nil, tempApp.AppCodec())
+	require.NoError(t, err)
+
+	keyInfo, _, err := kb.NewMnemonic(
+		"validator",
+		keyring.English,
+		sdk.FullFundraiserPath,
+		keyring.DefaultBIP39Passphrase,
+		hd.Secp256k1,
+	)
+	require.NoError(t, err)
+
+	addr, err := keyInfo.GetAddress()
+	require.NoError(t, err)
+
+	prepareCmd := cmd.NewRootCmd()
+	prepareCmd.SetArgs([]string{
+		"prepare-genesis",
+		"testnet",
+		"test-1",
+	})
+	require.NoError(t, svrcmd.Execute(prepareCmd, app.BabylonAppEnvPrefix, app.DefaultNodeHome))
+
+	addAccountCmd := cmd.NewRootCmd()
+	addAccountCmd.SetArgs([]string{
+		"add-genesis-account",
+		addr.String(),
+		"2000000000000ubbn",
+	})
+	require.NoError(t, svrcmd.Execute(addAccountCmd, app.BabylonAppEnvPrefix, app.DefaultNodeHome))
+
+	createValidatorCmd := cmd.NewRootCmd()
+	createValidatorCmd.SetArgs([]string{
+		"gentx",
+		"validator",
+		"1500000000000ubbn",
+		fmt.Sprintf("--%s=%s", flags.FlagChainID, "test-1"),
+		fmt.Sprintf("--%s=%s", flags.FlagKeyringBackend, keyring.BackendTest),
+		fmt.Sprintf("--%s=%s", stakingcli.FlagMoniker, "test-validator"),
+		fmt.Sprintf("--%s=%s", flags.FlagHome, app.DefaultNodeHome),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, "2000ubbn"),
+	})
+	require.NoError(t, svrcmd.Execute(createValidatorCmd, app.BabylonAppEnvPrefix, app.DefaultNodeHome))
+
+	collectGentxsCmd := cmd.NewRootCmd()
+	collectGentxsCmd.SetArgs([]string{
+		"collect-gentxs",
+	})
+	require.NoError(t, svrcmd.Execute(collectGentxsCmd, app.BabylonAppEnvPrefix, app.DefaultNodeHome))
+
+	// Now that we have the validator setup complete, delete the BLS files
+	// to test that they get recreated
+	err = os.Remove(blsKeyFile)
+	require.NoError(t, err)
+	err = os.Remove(blsPasswordFile)
+	require.NoError(t, err)
+
+	require.NoFileExists(t, blsKeyFile, "BLS key file should be deleted")
+	require.NoFileExists(t, blsPasswordFile, "BLS password file should be deleted")
+
+	startCmd := cmd.NewRootCmd()
+	startCmd.SetArgs([]string{
+		"start",
+		"--wasm.skip_wasmvm_version_check=true",
+	})
+
+	done := make(chan struct{})
+
+	go func() {
+		err = svrcmd.Execute(startCmd, app.BabylonAppEnvPrefix, app.DefaultNodeHome)
+		require.NoError(t, err)
+		close(done)
+	}()
+
+	time.Sleep(3 * time.Second)
+
+	require.FileExists(t, blsKeyFile, "BLS key file should be recreated by start command")
+	require.FileExists(t, blsPasswordFile, "BLS password file should be recreated by start command")
+
+	blsSigner := signer.LoadBlsSignerIfExists(app.DefaultNodeHome)
+	require.NotNil(t, blsSigner, "Should be able to load BLS signer after start")
+
+	p, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, p.Signal(os.Interrupt))
+
+	select {
+	case <-done:
+		// Chain has stopped
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for chain to stop")
+	}
 }


### PR DESCRIPTION
- Adds `--bls-password` and `--bls-no-password` to start command.
- Default behaviour is to provide a password before node starts for bls signer.