### PR TITLE
[Backport] add missing hook invocation (#539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - [#530](https://github.com/babylonlabs-io/babylon/pull/530) Add `ConflictingCheckpointReceived` flag in `x/checkpointing` module.
 
+### Bug fixes
+
+- - [#539](https://github.com/babylonlabs-io/babylon/pull/539) fix: add missing `x/checkpointing` hooks
+invocation
+
 ## v1.0.0-rc6
 
 ### Improvements

--- a/x/checkpointing/keeper/keeper.go
+++ b/x/checkpointing/keeper/keeper.go
@@ -373,6 +373,11 @@ func (k Keeper) SetCheckpointForgotten(ctx context.Context, epoch uint64) {
 	if err != nil {
 		k.Logger(sdkCtx).Error("failed to emit checkpoint forgotten event for epoch %v", ckpt.Ckpt.EpochNum)
 	}
+
+	// invoke hook
+	if err := k.AfterRawCheckpointForgotten(ctx, ckpt.Ckpt); err != nil {
+		k.Logger(sdkCtx).Error("failed to trigger checkpoint forgotten hook for epoch %v: %v", ckpt.Ckpt.EpochNum, err)
+	}
 }
 
 // setCheckpointStatus sets a ckptWithMeta to the given state,


### PR DESCRIPTION
- Add missing hook invocation which was marked in coinspect audit as security vuln .

Marked as consensus breaking as other module `x/monitor` depends on this hooks to clear its storage.