### PR TITLE
ci: fix backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,3 +1,4 @@
+# Adapted from https://github.com/sorenlouv/backport-github-action
 name: Automatic backport action
 
 on:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,10 @@
 # Adapted from https://github.com/sorenlouv/backport-github-action
 name: Automatic backport action
 
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+
 on:
   pull_request_target:
     types: ["labeled", "closed"]

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,4 +1,4 @@
-# Adapted from https://github.com/sorenlouv/backport-github-action 2
+# Adapted from https://github.com/sorenlouv/backport-github-action 3
 name: Automatic backport action
 
 permissions:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,4 +1,4 @@
-# Adapted from https://github.com/sorenlouv/backport-github-action 3
+# Adapted from https://github.com/sorenlouv/backport-github-action
 name: Automatic backport action
 
 permissions:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ jobs:
         uses: sorenlouv/backport-github-action@v9.5.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          auto_backport_label_prefix: "backport "
+          auto_backport_label_prefix: "backport-to-"
 
       - name: Info log
         if: ${{ success() }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,4 +1,4 @@
-# Adapted from https://github.com/sorenlouv/backport-github-action
+# Adapted from https://github.com/sorenlouv/backport-github-action 2
 name: Automatic backport action
 
 permissions:


### PR DESCRIPTION
This PR fixes the backport Github action. The problem is that the prefix cannot contain any space. Now changed to use prefix `backport-to-`

test plan: Tried on my own branch and there is a successful PR created by GH action https://github.com/babylonlabs-io/babylon/pull/548