### PR TITLE
docs: BTC eligibility Document

### DIFF
--- a/docs/btc-transactions-validity.md
+++ b/docs/btc-transactions-validity.md
@@ -1,0 +1,23 @@
+## Introduction
+
+##  Prerequisites
+
+## Taproot outputs
+
+## Types of transactions
+
+## Staking
+
+### Sending a TX
+
+## Unbonding
+
+### Sending a TX
+
+## Spending taproot outputs
+
+## Slashing
+
+### Sending a TX
+
+## Spending taproot outputs


### PR DESCRIPTION
This document is a combination of https://github.com/babylonlabs-io/babylon/blob/main/docs/staking-script.md and https://github.com/babylonlabs-io/babylon/blob/main/docs/transaction-impl-spec.md

- [ ] [Introduction](https://github.com/babylonlabs-io/babylon/pull/561)

- [ ] [Prerequisites](https://github.com/babylonlabs-io/babylon/pull/561)

- [ ] [Actors](https://github.com/babylonlabs-io/babylon/pull/568)

- [ ] [Taproot outputs](https://github.com/babylonlabs-io/babylon/pull/564)

- [ ] [spending scripts](https://github.com/babylonlabs-io/babylon/pull/569)

- [ ] [Building Transactions: Staking TX](https://github.com/babylonlabs-io/babylon/pull/577)

- [ ] [Building Transactions: Unbonding TX](https://github.com/babylonlabs-io/babylon/pull/580)

- [ ] [slashing](https://github.com/babylonlabs-io/babylon/pull/720)

For spending taproots I think we can still use https://github.com/babylonlabs-io/babylon/blob/main/docs/transaction-impl-spec.md#spending-taproot-outputs ? As its still relevant
