### PR TITLE
[backport] chore: fix bls pubkey format in bls_key.json (#558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#558](https://github.com/babylonlabs-io/babylon/pull/558) Change BLS public key format from hex to base64 in bls_key.json.
 - [#538](https://github.com/babylonlabs-io/babylon/pull/538) Upgrade to wasmd v0.54.x and wasmvm v2.2.x
 - [#527](https://github.com/babylonlabs-io/babylon/pull/527) Create BSL signer on start command with flags.
 - [#554](https://github.com/babylonlabs-io/babylon/pull/554) Improve vote extension logs

--- a/crypto/erc2335/erc2335.go
+++ b/crypto/erc2335/erc2335.go
@@ -1,6 +1,7 @@
 package erc2335
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -14,7 +15,7 @@ type Erc2335KeyStore struct {
 	Version     uint                   `json:"version"`     // Version of the keystore format (e.g., 4 for keystorev4).
 	UUID        string                 `json:"uuid"`        // Unique identifier for the keystore.
 	Path        string                 `json:"path"`        // File path where the keystore is stored.
-	Pubkey      string                 `json:"pubkey"`      // Public key associated with the keystore, stored as a hexadecimal string.
+	Pubkey      string                 `json:"pubkey"`      // Public key associated with the keystore, stored as a base64 encoded string.
 	Description string                 `json:"description"` // Optional description of the keystore, currently used to store the delegator address.
 }
 
@@ -33,7 +34,7 @@ func Encrypt(privKey, pubKey []byte, password string) ([]byte, error) {
 	keystoreJSON := Erc2335KeyStore{
 		Crypto:  cryptoFields,
 		Version: 4,
-		Pubkey:  fmt.Sprintf("%x", pubKey),
+		Pubkey:  base64.StdEncoding.EncodeToString(pubKey),
 	}
 
 	return json.Marshal(keystoreJSON)


### PR DESCRIPTION
This PR has a simple but necessary change to prevent user confusion when migrating the BLS key from an older version of
`priv_validator_key.json`, which contained both Comet and BLS keys.

Before this PR, the BLS public key was stored in `bls_key.json` in hexadecimal format. While this field was never actually used—since the BLS pubkey is derived from the private key rather than being read directly from a file—users may still want to verify that their key remains unchanged after the migration.

To address this, this PR updates the BLS pubkey format in `bls_key.json` to match the base64 format used in older versions of `priv_validator_key.json`.

In the previous version of `priv_validator_key.json`:

```json
{
  ...
  "bls_pub_key": "tiy+DpOVfQeqeJZsZuQmnshaX1QESo1/GTzNR1Pafo1obwcNQTEhpTVwJi6GupFMEoh0xixGbtt3yVEff9ZXFegKoOXMjC24Le4+X98JOK0XTODaJ9zRNzjzyq/cuWPs",
  ...
}
```

The contents of `bls_key.json` after running `migrate-bls-key,` as modified in this PR:

```json
{
  ...
  "pubkey": "tiy+DpOVfQeqeJZsZuQmnshaX1QESo1/GTzNR1Pafo1obwcNQTEhpTVwJi6GupFMEoh0xixGbtt3yVEff9ZXFegKoOXMjC24Le4+X98JOK0XTODaJ9zRNzjzyq/cuWPs",
}
```