### PR TITLE
[Backport] finality: avoid refunding finality signatures over forks (#592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ block bank send and still create BTC delegations
 
 - [#539](https://github.com/babylonlabs-io/babylon/pull/539) fix: add missing `x/checkpointing` hooks
 invocation
+- [#592](https://github.com/babylonlabs-io/babylon/pull/592) finality: avoid refunding finality signatures over forks
+- [#525](https://github.com/babylonlabs-io/babylon/pull/525) fix: add back `NewIBCHeaderDecorator` post handler
 - [#563](https://github.com/babylonlabs-io/babylon/pull/563) reject coinbase staking transactions
 - [#584](https://github.com/babylonlabs-io/babylon/pull/584) fix: Panic can be triggered in handling liveness
 

--- a/x/finality/keeper/msg_server.go
+++ b/x/finality/keeper/msg_server.go
@@ -208,6 +208,10 @@ func (ms msgServer) AddFinalitySig(goCtx context.Context, req *types.MsgAddFinal
 		// slash this finality provider, including setting its voting power to
 		// zero, extracting its BTC SK, and emit an event
 		ms.slashFinalityProvider(ctx, req.FpBtcPk, evidence)
+
+		// NOTE: we should NOT return error here, otherwise the state change triggered in this tx
+		// (including the evidence and slashing) will be rolled back
+		return &types.MsgAddFinalitySigResponse{}, nil
 	}
 
 	// at this point, the finality signature is 1) valid, 2) over a canonical block,

--- a/x/finality/keeper/power_dist_change_test.go
+++ b/x/finality/keeper/power_dist_change_test.go
@@ -1042,7 +1042,7 @@ func TestHandleLivenessPanic(t *testing.T) {
 		// Create FP externally and pass it when called
 		fpSK, _, err := datagen.GenRandomBTCKeyPair(r)
 		require.NoError(t, err)
-		fp, err := datagen.GenRandomFinalityProviderWithBTCSK(r, fpSK, "")
+		fp, err := datagen.GenRandomFinalityProviderWithBTCSK(r, fpSK)
 		require.NoError(t, err)
 		// Save when i is 5
 		if i == 1 {
@@ -1087,7 +1087,7 @@ func TestHandleLivenessPanic(t *testing.T) {
 			// Create FP externally and pass it when called
 			newfpSK, _, err := datagen.GenRandomBTCKeyPair(r)
 			require.NoError(t, err)
-			newfp, err := datagen.GenRandomFinalityProviderWithBTCSK(r, newfpSK, "")
+			newfp, err := datagen.GenRandomFinalityProviderWithBTCSK(r, newfpSK)
 			require.NoError(t, err)
 
 			createDelegationWithFinalityProvider(


### PR DESCRIPTION
Resolves https://github.com/babylonlabs-io/pm/issues/215