### PR TITLE
fix: bls key check for empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#623](https://github.com/babylonlabs-io/babylon/pull/623) Add check for empty string in `bls` loading.
 - [#544](https://github.com/babylonlabs-io/babylon/pull/544) Add `bls-config` to `app.toml` for custom bls key location.
 - [#466](https://github.com/babylonlabs-io/babylon/pull/466) Add e2e test to
 block bank send and still create BTC delegations

--- a/app/signer/bls.go
+++ b/app/signer/bls.go
@@ -213,7 +213,7 @@ func (k *BlsKey) BlsPubKey() (bls12381.PublicKey, error) {
 // If customKeyPath is provided, will use that path for the BLS key file instead of the default.
 func LoadBlsSignerIfExists(homeDir string, customKeyPath string) checkpointingtypes.BlsSigner {
 	blsKeyFile := customKeyPath
-	if blsKeyFile == defaultBlsKeyFilePath {
+	if blsKeyFile == defaultBlsKeyFilePath || blsKeyFile == "" {
 		blsKeyFile = DefaultBlsKeyFile(homeDir)
 	}
 	blsPasswordFile := DefaultBlsPasswordFile(homeDir)
@@ -229,7 +229,7 @@ func LoadBlsSignerIfExists(homeDir string, customKeyPath string) checkpointingty
 // CreateBlsSigner creates a new BLS signer with the given password
 func CreateBlsSigner(homeDir string, password string, customKeyPath string) (checkpointingtypes.BlsSigner, error) {
 	blsKeyFile := customKeyPath
-	if blsKeyFile == defaultBlsKeyFilePath {
+	if blsKeyFile == defaultBlsKeyFilePath || blsKeyFile == "" {
 		blsKeyFile = DefaultBlsKeyFile(homeDir)
 	}
 	blsPasswordFile := DefaultBlsPasswordFile(homeDir)


### PR DESCRIPTION
Already backported this change after noticing a failed e2e upgrade test in #610 just so main is up to date. Adding case where empty string is somehow inserted into the `app.toml` by mistake or intentionally. 