### PR TITLE
chore(x/incentive): make keeper collections private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ check of rewards
 - [#575](https://github.com/babylonlabs-io/babylon/pull/575) Add `ConsumerId` field in `FinalityProviderResponse` in `x/btcstaking` module
 - [#589](https://github.com/babylonlabs-io/babylon/pull/589) Rename `btc_delegation` stakeholder type to `btc_staker` in `x/incentive` module
 - [#590](https://github.com/babylonlabs-io/babylon/pull/590) Add `DelegationRewards` query in `x/incentive` module
+- [#624](https://github.com/babylonlabs-io/babylon/pull/624) Make keeper's collections private in `x/incentive` module
 
 ### State Machine Breaking
 

--- a/x/incentive/keeper/genesis.go
+++ b/x/incentive/keeper/genesis.go
@@ -286,7 +286,7 @@ func (k Keeper) refundableMsgHashes(ctx context.Context) ([]string, error) {
 func (k Keeper) finalityProvidersCurrentRewards(ctx context.Context) ([]types.FinalityProviderCurrentRewardsEntry, error) {
 	entries := make([]types.FinalityProviderCurrentRewardsEntry, 0)
 
-	iter, err := k.FinalityProviderCurrentRewards.Iterate(ctx, nil)
+	iter, err := k.finalityProviderCurrentRewards.Iterate(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +320,7 @@ func (k Keeper) finalityProvidersCurrentRewards(ctx context.Context) ([]types.Fi
 func (k Keeper) finalityProvidersHistoricalRewards(ctx context.Context) ([]types.FinalityProviderHistoricalRewardsEntry, error) {
 	entries := make([]types.FinalityProviderHistoricalRewardsEntry, 0)
 
-	iter, err := k.FinalityProviderHistoricalRewards.Iterate(ctx, nil)
+	iter, err := k.finalityProviderHistoricalRewards.Iterate(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +357,7 @@ func (k Keeper) finalityProvidersHistoricalRewards(ctx context.Context) ([]types
 func (k Keeper) btcDelegationRewardsTrackers(ctx context.Context) ([]types.BTCDelegationRewardsTrackerEntry, error) {
 	entries := make([]types.BTCDelegationRewardsTrackerEntry, 0)
 
-	iter, err := k.BTCDelegationRewardsTracker.Iterate(ctx, nil)
+	iter, err := k.btcDelegationRewardsTracker.Iterate(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/x/incentive/keeper/keeper.go
+++ b/x/incentive/keeper/keeper.go
@@ -31,6 +31,7 @@ type (
 		feeCollectorName string
 
 		// Collections structures for rewards
+
 		// btcDelegationRewardsTracker maps (FpAddr, DelAddr) => btcDelegationRewardsTracker
 		btcDelegationRewardsTracker collections.Map[collections.Pair[[]byte, []byte], types.BTCDelegationRewardsTracker]
 		// finalityProviderHistoricalRewards maps (FpAddr, period) => finalityProviderHistoricalRewards

--- a/x/incentive/keeper/keeper.go
+++ b/x/incentive/keeper/keeper.go
@@ -31,14 +31,12 @@ type (
 		feeCollectorName string
 
 		// Collections structures for rewards
-
-		// Public for test reasons
-		// BTCDelegationRewardsTracker maps (FpAddr, DelAddr) => BTCDelegationRewardsTracker
-		BTCDelegationRewardsTracker collections.Map[collections.Pair[[]byte, []byte], types.BTCDelegationRewardsTracker]
-		// FinalityProviderHistoricalRewards maps (FpAddr, period) => FinalityProviderHistoricalRewards
-		FinalityProviderHistoricalRewards collections.Map[collections.Pair[[]byte, uint64], types.FinalityProviderHistoricalRewards]
-		// FinalityProviderCurrentRewards maps (FpAddr) => FinalityProviderCurrentRewards
-		FinalityProviderCurrentRewards collections.Map[[]byte, types.FinalityProviderCurrentRewards]
+		// btcDelegationRewardsTracker maps (FpAddr, DelAddr) => btcDelegationRewardsTracker
+		btcDelegationRewardsTracker collections.Map[collections.Pair[[]byte, []byte], types.BTCDelegationRewardsTracker]
+		// finalityProviderHistoricalRewards maps (FpAddr, period) => finalityProviderHistoricalRewards
+		finalityProviderHistoricalRewards collections.Map[collections.Pair[[]byte, uint64], types.FinalityProviderHistoricalRewards]
+		// finalityProviderCurrentRewards maps (FpAddr) => finalityProviderCurrentRewards
+		finalityProviderCurrentRewards collections.Map[[]byte, types.FinalityProviderCurrentRewards]
 	}
 )
 
@@ -67,7 +65,7 @@ func NewKeeper(
 		),
 
 		// Collections structures for rewards
-		BTCDelegationRewardsTracker: collections.NewMap(
+		btcDelegationRewardsTracker: collections.NewMap(
 			sb,
 			types.BTCDelegationRewardsTrackerKeyPrefix,
 			"btc_delegation_rewards_tracker",
@@ -75,7 +73,7 @@ func NewKeeper(
 			collections.PairKeyCodec(collections.BytesKey, collections.BytesKey),
 			codec.CollValue[types.BTCDelegationRewardsTracker](cdc),
 		),
-		FinalityProviderHistoricalRewards: collections.NewMap(
+		finalityProviderHistoricalRewards: collections.NewMap(
 			sb,
 			types.FinalityProviderHistoricalRewardsKeyPrefix,
 			"fp_historical_rewards",
@@ -83,7 +81,7 @@ func NewKeeper(
 			collections.PairKeyCodec(collections.BytesKey, collections.Uint64Key),
 			codec.CollValue[types.FinalityProviderHistoricalRewards](cdc),
 		),
-		FinalityProviderCurrentRewards: collections.NewMap(
+		finalityProviderCurrentRewards: collections.NewMap(
 			sb,
 			types.FinalityProviderCurrentRewardsKeyPrefix,
 			"fp_current_rewards",


### PR DESCRIPTION
This PR reverts the changes introduced [in this PR](https://github.com/babylonlabs-io/babylon/pull/604) that were needed to fix compilation in the `DelegationRewards` tests.

This PR does not need to be backported to the `release/v1.x` branch because the collections are already private there, and the [PR backporting the `DelegationRewards`](https://github.com/babylonlabs-io/babylon/pull/621) changes to the release branch already have the tests fixed