### PR TITLE
ignore expire events when there is no covenant quorum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ cache if an old BTC delegation receives inclusion proof
 - [#585](https://github.com/babylonlabs-io/babylon/pull/585) fix: Proposal vote extensions' byte limit
 - [#594](https://github.com/babylonlabs-io/babylon/pull/594) Refund tx to correct recipient
 - [#599](https://github.com/babylonlabs-io/babylon/pull/599) check staker signature in `BTCUndelegate`
+- [#631](https://github.com/babylonlabs-io/babylon/pull/631) Ignore expired events
+if delegation was never activated
 
 ## v1.0.0-rc6
 

--- a/testutil/btcstaking-helper/keeper.go
+++ b/testutil/btcstaking-helper/keeper.go
@@ -84,6 +84,23 @@ func NewHelper(
 	return NewHelperWithStoreAndIncentive(t, db, stateStore, btclcKeeper, btccKeeper, ckptKeeper, iKeeper)
 }
 
+func NewHelperNoMocksCalls(
+	t testing.TB,
+	btclcKeeper *types.MockBTCLightClientKeeper,
+	btccKeeper *types.MockBtcCheckpointKeeper,
+) *Helper {
+	ctrl := gomock.NewController(t)
+
+	// mock refundable messages
+	iKeeper := ftypes.NewMockIncentiveKeeper(ctrl)
+	db := dbm.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db, log.NewTestLogger(t), storemetrics.NewNoOpMetrics())
+
+	ckptKeeper := ftypes.NewMockCheckpointingKeeper(ctrl)
+
+	return NewHelperWithStoreAndIncentive(t, db, stateStore, btclcKeeper, btccKeeper, ckptKeeper, iKeeper)
+}
+
 func NewHelperWithStoreAndIncentive(
 	t testing.TB,
 	db dbm.DB,

--- a/x/finality/keeper/power_dist_change_test.go
+++ b/x/finality/keeper/power_dist_change_test.go
@@ -1567,3 +1567,65 @@ func createAndCommitFinalityProvider(
 	_, err = finalityMsgServer.CommitPubRandList(ctx, msgCommitPubRandList)
 	require.NoError(t, err)
 }
+
+func TestIgnoreExpiredEventIfThereIsNoQuorum(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	// mock BTC light client and BTC checkpoint modules
+	btclcKeeper := btcstktypes.NewMockBTCLightClientKeeper(ctrl)
+	btccKeeper := btcstktypes.NewMockBtcCheckpointKeeper(ctrl)
+	h := testutil.NewHelperNoMocksCalls(t, btclcKeeper, btccKeeper)
+
+	// set all parameters
+	h.GenAndApplyParams(r)
+
+	// generate and insert new finality provider
+	_, fpPK, _ := h.CreateFinalityProvider(r)
+
+	// generate and insert new BTC delegation
+	stakingValue := int64(2 * 10e8)
+	delSK, _, err := datagen.GenRandomBTCKeyPair(r)
+	h.NoError(err)
+	stakingParams := h.BTCStakingKeeper.GetParamsWithVersion(h.Ctx).Params
+	expectedStakingTxHash, _, actualDel, _, _, _, err := h.CreateDelegationWithBtcBlockHeight(
+		r,
+		delSK,
+		[]*btcec.PublicKey{fpPK},
+		stakingValue,
+		1000,
+		0,
+		0,
+		false,
+		false,
+		10,
+		30,
+	)
+	h.NoError(err)
+
+	/*
+		at this point, there should be 1 event that BTC delegation
+		will become expired at end height - min_unbonding_time
+	*/
+	// there exists no event at the current BTC tip
+	btcTip := &btclctypes.BTCHeaderInfo{Height: 30}
+	events := h.BTCStakingKeeper.GetAllPowerDistUpdateEvents(h.Ctx, btcTip.Height, btcTip.Height)
+	require.Len(t, events, 0)
+
+	// the BTC delegation will be expired (unbonded) at end height - unbonding_time
+	unbondedHeight := actualDel.EndHeight - stakingParams.UnbondingTimeBlocks
+	events = h.BTCStakingKeeper.GetAllPowerDistUpdateEvents(h.Ctx, unbondedHeight, unbondedHeight)
+	require.Len(t, events, 1)
+	btcDelStateUpdate := events[0].GetBtcDelStateUpdate()
+	require.NotNil(t, btcDelStateUpdate)
+	require.Equal(t, expectedStakingTxHash, btcDelStateUpdate.StakingTxHash)
+	require.Equal(t, btcstktypes.BTCDelegationStatus_EXPIRED, btcDelStateUpdate.NewState)
+
+	// set it to the future
+	btcTip = &btclctypes.BTCHeaderInfo{Height: 1000}
+	// k.IncentiveKeeper.BtcDelegationUnbonded(ctx, fp, del, sats) won't be called
+	// as delegation does not have covenant quorum
+	h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(btcTip).AnyTimes()
+	h.BeginBlocker()
+}

--- a/x/finality/types/expected_keepers.go
+++ b/x/finality/types/expected_keepers.go
@@ -11,6 +11,7 @@ import (
 
 type BTCStakingKeeper interface {
 	GetParams(ctx context.Context) bstypes.Params
+	GetParamsByVersion(ctx context.Context, v uint32) *bstypes.Params
 	GetCurrentBTCHeight(ctx context.Context) uint32
 	GetBTCHeightAtBabylonHeight(ctx context.Context, babylonHeight uint64) uint32
 	GetFinalityProvider(ctx context.Context, fpBTCPK []byte) (*bstypes.FinalityProvider, error)

--- a/x/finality/types/mocked_keepers.go
+++ b/x/finality/types/mocked_keepers.go
@@ -136,6 +136,20 @@ func (mr *MockBTCStakingKeeperMockRecorder) GetParams(ctx interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParams", reflect.TypeOf((*MockBTCStakingKeeper)(nil).GetParams), ctx)
 }
 
+// GetParamsByVersion mocks base method.
+func (m *MockBTCStakingKeeper) GetParamsByVersion(ctx context.Context, v uint32) *types0.Params {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetParamsByVersion", ctx, v)
+	ret0, _ := ret[0].(*types0.Params)
+	return ret0
+}
+
+// GetParamsByVersion indicates an expected call of GetParamsByVersion.
+func (mr *MockBTCStakingKeeperMockRecorder) GetParamsByVersion(ctx, v interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParamsByVersion", reflect.TypeOf((*MockBTCStakingKeeper)(nil).GetParamsByVersion), ctx, v)
+}
+
 // HasFinalityProvider mocks base method.
 func (m *MockBTCStakingKeeper) HasFinalityProvider(ctx context.Context, fpBTCPK []byte) bool {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- We should ignore delegation event in case of lack of covenant quorum. If there was not covenant quorum it means delegaiton was never activated and sats were never counted towards fp