### PR TITLE
ignore unbonding when there is no covenant quorum

### DIFF
--- a/x/finality/keeper/power_dist_change.go
+++ b/x/finality/keeper/power_dist_change.go
@@ -229,8 +229,12 @@ func (k Keeper) ProcessAllPowerDistUpdateEvents(
 					k.MustProcessBtcDelegationActivated(ctx, fp, del, sats)
 				})
 			case types.BTCDelegationStatus_UNBONDED:
-				// add the unbonded BTC delegation to the map
-				k.processPowerDistUpdateEventUnbond(ctx, fpByBtcPkHex, btcDel, unbondedSatsByFpBtcPk)
+				// In case of delegation transtioning from phase-1 it is possible that
+				// somebody unbonds before receiving the required covenant signatures.
+				if btcDel.HasCovenantQuorums(delParams.CovenantQuorum) {
+					// add the unbonded BTC delegation to the map
+					k.processPowerDistUpdateEventUnbond(ctx, fpByBtcPkHex, btcDel, unbondedSatsByFpBtcPk)
+				}
 			case types.BTCDelegationStatus_EXPIRED:
 				types.EmitExpiredDelegationEvent(sdkCtx, delStkTxHash)
 				// We process expired event if:


### PR DESCRIPTION
In case of delegation transitioning from phase-1 to phase-2 it seems to be possible to receive unbonding before quorum is reached and delegation is activated