### PR TITLE
chore: add `ParseV0StakingTxWithoutTag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#655](https://github.com/babylonlabs-io/babylon/pull/655) Add func `ParseV0StakingTxWithoutTag` to
+parse staking tx without verifying opreturn tag.
 - [#648](https://github.com/babylonlabs-io/babylon/pull/648) Add query to get all parameters
 from `x/btcstaking` module.
 - [#623](https://github.com/babylonlabs-io/babylon/pull/623) Add check for empty string in `bls` loading.


### PR DESCRIPTION
Helps btc-staker to get parse the tx without verifying the op return tag
