### PR TITLE
[Backport] move bip322 signing functions to testutil package (#673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [#656](https://github.com/babylonlabs-io/babylon/pull/656) crypto: fix adaptor sig validity and typos
 - [#658](https://github.com/babylonlabs-io/babylon/pull/658) crypto: check if Z==1 in ToBTCPK
 - [#660](https://github.com/babylonlabs-io/babylon/pull/660) fix: ecdsa verification
+- [#673](https://github.com/babylonlabs-io/babylon/pull/673) fix: move bip322 signing
+functions to `testutil`
 
 ### Improvements
 

--- a/crypto/bip322/bip322_test.go
+++ b/crypto/bip322/bip322_test.go
@@ -79,7 +79,7 @@ func FuzzBip322ValidP2WPKHSignature(f *testing.F) {
 		require.NoError(t, err)
 		dataLen := r.Int31n(200) + 1
 		dataToSign := datagen.GenRandomByteArray(r, uint64(dataLen))
-		address, witness, err := bip322.SignWithP2WPKHAddress(dataToSign, privkey, net)
+		address, witness, err := datagen.SignWithP2WPKHAddress(dataToSign, privkey, net)
 		require.NoError(t, err)
 		witnessDecoded, err := bip322.SimpleSigToWitness(witness)
 		require.NoError(t, err)
@@ -102,7 +102,7 @@ func FuzzBip322ValidP2TrSpendSignature(f *testing.F) {
 		require.NoError(t, err)
 		dataLen := r.Int31n(200) + 1
 		dataToSign := datagen.GenRandomByteArray(r, uint64(dataLen))
-		address, witness, err := bip322.SignWithP2TrSpendAddress(dataToSign, privkey, net)
+		address, witness, err := datagen.SignWithP2TrSpendAddress(dataToSign, privkey, net)
 		require.NoError(t, err)
 		witnessDecoded, err := bip322.SimpleSigToWitness(witness)
 		require.NoError(t, err)


### PR DESCRIPTION
fixes: https://github.com/babylonlabs-io/pm/issues/299