### PR TITLE
[backport] crypto: Enable group check in BLS (#667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [#657](https://github.com/babylonlabs-io/babylon/pull/657) crypto: fix adaptor sig timing side channels
 - [#656](https://github.com/babylonlabs-io/babylon/pull/656) crypto: fix adaptor sig validity and typos
 - [#658](https://github.com/babylonlabs-io/babylon/pull/658) crypto: check if Z==1 in ToBTCPK
+- [#667](https://github.com/babylonlabs-io/babylon/pull/667) crypto: enable groupcheck in BLS verification/aggregation
 - [#660](https://github.com/babylonlabs-io/babylon/pull/660) fix: ecdsa verification
 
 ### Improvements

--- a/crypto/bls12381/bls.go
+++ b/crypto/bls12381/bls.go
@@ -56,7 +56,8 @@ func Sign(sk PrivateKey, msg []byte) Signature {
 // the sig and public key are all compressed
 func Verify(sig Signature, pk PublicKey, msg []byte) (bool, error) {
 	dummySig := new(BlsSig)
-	return dummySig.VerifyCompressed(sig, false, pk, false, msg, DST), nil
+	// sigGroupcheck is always enabled for security
+	return dummySig.VerifyCompressed(sig, true, pk, false, msg, DST), nil
 }
 
 // AggrSig aggregates BLS signatures in an accumulative manner
@@ -75,7 +76,8 @@ func AggrSigList(sigs []Signature) (Signature, error) {
 	for i := 0; i < len(sigs); i++ {
 		sigBytes[i] = sigs[i].Bytes()
 	}
-	if !aggSig.AggregateCompressed(sigBytes, false) {
+	// groupcheck is always enabled for security
+	if !aggSig.AggregateCompressed(sigBytes, true) {
 		return nil, errors.New("failed to aggregate bls signatures")
 	}
 	return aggSig.ToAffine().Compress(), nil
@@ -97,7 +99,8 @@ func AggrPKList(pks []PublicKey) (PublicKey, error) {
 	for i := 0; i < len(pks); i++ {
 		pkBytes[i] = pks[i].Bytes()
 	}
-	if !aggPk.AggregateCompressed(pkBytes, false) {
+	// groupcheck is always enabled for security
+	if !aggPk.AggregateCompressed(pkBytes, true) {
 		return nil, errors.New("failed to aggregate bls public keys")
 	}
 	return aggPk.ToAffine().Compress(), nil

--- a/crypto/bls12381/types_bench_test.go
+++ b/crypto/bls12381/types_bench_test.go
@@ -1,0 +1,60 @@
+package bls12381
+
+import (
+	"crypto/rand"
+	"testing"
+)
+
+func BenchmarkVerifyCompressed(b *testing.B) {
+	// Generate random messages, keys and signatures
+	msg := make([]byte, 32)
+	rand.Read(msg)
+
+	// Generate a random key pair
+	sk, pk := GenKeyPair()
+
+	// Create a signature
+	sig := Sign(sk, msg)
+
+	b.Run("WithSigGroupCheck", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			dummySig := new(BlsSig)
+			dummySig.VerifyCompressed(sig, true, pk, false, msg, DST)
+		}
+	})
+
+	b.Run("WithoutSigGroupCheck", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			dummySig := new(BlsSig)
+			dummySig.VerifyCompressed(sig, false, pk, false, msg, DST)
+		}
+	})
+}
+
+func BenchmarkAggregateCompressed(b *testing.B) {
+	// Generate random public keys
+	size := 100
+	pks := make([][]byte, 0, size)
+	for i := 0; i < size; i++ {
+		_, pk := GenKeyPair()
+		pks = append(pks, pk.Bytes())
+	}
+
+	b.Run("WithGroupCheck", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			aggPk := new(BlsMultiPubKey)
+			aggPk.AggregateCompressed(pks, true) // With groupcheck
+		}
+	})
+
+	b.Run("WithoutGroupCheck", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			aggPk := new(BlsMultiPubKey)
+			aggPk.AggregateCompressed(pks, false) // Without groupcheck
+		}
+	})
+}


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/pm/issues/288. Group check is necessary to ensure security in BLS verification and aggregation with light loss of performace. Benchmark is attatched in this PR. Bench march results show that the overhead of enabling group check in sig verification is negligible, while in aggregation the time is increased by 2 times (aggregating 100 public keys). Given that aggregation cost is not high and only happens at epoch bondary, the overhead is acceptable.

Benchmark results:

```
goos: darwin
goarch: arm64
pkg: github.com/babylonlabs-io/babylon/crypto/bls12381
cpu: Apple M1 Pro
BenchmarkVerifyCompressed
BenchmarkVerifyCompressed/WithSigGroupCheck
BenchmarkVerifyCompressed/WithSigGroupCheck-8         	    1892	    686257 ns/op
BenchmarkVerifyCompressed/WithoutSigGroupCheck
BenchmarkVerifyCompressed/WithoutSigGroupCheck-8      	    1945	    628146 ns/op

BenchmarkAggregateCompressed
BenchmarkAggregateCompressed/WithGroupCheck
BenchmarkAggregateCompressed/WithGroupCheck-8         	     626	   1971719 ns/op
BenchmarkAggregateCompressed/WithoutGroupCheck
BenchmarkAggregateCompressed/WithoutGroupCheck-8      	    1750	    626337 ns/op
```