### PR TITLE
[backport] crypto: fix bls rogue attack (#680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [#658](https://github.com/babylonlabs-io/babylon/pull/658) crypto: check if Z==1 in ToBTCPK
 - [#667](https://github.com/babylonlabs-io/babylon/pull/667) crypto: enable groupcheck in BLS verification/aggregation
 - [#660](https://github.com/babylonlabs-io/babylon/pull/660) fix: ecdsa verification
+- [#680](https://github.com/babylonlabs-io/babylon/pull/680) crypto: fix bls rogue attack
 - [#673](https://github.com/babylonlabs-io/babylon/pull/673) fix: move bip322 signing
 functions to `testutil`
 - [#683](https://github.com/babylonlabs-io/babylon/pull/683) crypto: fix eots signing timing attack

--- a/app/signer/types.go
+++ b/app/signer/types.go
@@ -47,7 +47,10 @@ func BuildPoP(valPrivKey cmtcrypto.PrivKey, blsPrivkey bls12381.PrivateKey) (*ty
 	if err != nil {
 		return nil, fmt.Errorf("Error while building PoP: %w", err)
 	}
-	pop := bls12381.Sign(blsPrivkey, data)
+
+	msg := bls12381.GetPopSignMsg(blsPrivkey.PubKey(), data)
+	pop := bls12381.PopProve(blsPrivkey, msg)
+
 	return &types.ProofOfPossession{
 		Ed25519Sig: data,
 		BlsSig:     &pop,

--- a/crypto/bls12381/bls.go
+++ b/crypto/bls12381/bls.go
@@ -47,10 +47,35 @@ func Sign(sk PrivateKey, msg []byte) Signature {
 
 // Verify verifies a BLS sig over msg with a BLS public key
 // the sig and public key are all compressed
+// NOTE that the verification enables subgroupcheck
+// and pkvalidate for security with slight performance loss
 func Verify(sig Signature, pk PublicKey, msg []byte) (bool, error) {
 	dummySig := new(BlsSig)
 	// sigGroupcheck is always enabled for security
-	return dummySig.VerifyCompressed(sig, true, pk, false, msg, DST), nil
+	return dummySig.VerifyCompressed(sig, true, pk, true, msg, DST), nil
+}
+
+// PopProve signs on a msg using a BLS secret key for proof-of-possession
+// using DST_POP
+func PopProve(sk PrivateKey, msg []byte) Signature {
+	secretKey := new(blst.SecretKey)
+	secretKey.Deserialize(sk)
+	return new(BlsSig).Sign(secretKey, msg, DST_POP).Compress()
+}
+
+// PopVerify verifies a BLS sig generated from PopProve over msg with a
+// BLS public key. The sig and public key are all compressed
+// and pkvalidate for security with slight performance loss
+func PopVerify(sig Signature, pk PublicKey, msg []byte) (bool, error) {
+	dummySig := new(BlsSig)
+	return dummySig.VerifyCompressed(sig, true, pk, true, msg, DST_POP), nil
+}
+
+func GetPopSignMsg(blsPk PublicKey, data []byte) []byte {
+	result := make([]byte, 0, len(blsPk)+len(data))
+	result = append(result, blsPk...)
+	result = append(result, data...)
+	return result
 }
 
 // AggrSig aggregates BLS signatures in an accumulative manner
@@ -63,6 +88,7 @@ func AggrSig(existingSig Signature, newSig Signature) (Signature, error) {
 }
 
 // AggrSigList aggregates BLS sigs into a single BLS signature
+// Note that groupcheck is enabled for security with performance loss
 func AggrSigList(sigs []Signature) (Signature, error) {
 	aggSig := new(BlsMultiSig)
 	sigBytes := make([][]byte, len(sigs))
@@ -86,6 +112,7 @@ func AggrPK(existingPK PublicKey, newPK PublicKey) (PublicKey, error) {
 }
 
 // AggrPKList aggregates BLS public keys into a single BLS public key
+// Note that groupcheck is enabled for security with performance loss
 func AggrPKList(pks []PublicKey) (PublicKey, error) {
 	aggPk := new(BlsMultiPubKey)
 	pkBytes := make([][]byte, len(pks))

--- a/crypto/bls12381/types.go
+++ b/crypto/bls12381/types.go
@@ -3,6 +3,7 @@ package bls12381
 import (
 	"encoding/hex"
 	"errors"
+
 	blst "github.com/supranational/blst/bindings/go"
 )
 
@@ -23,6 +24,9 @@ type BlsMultiPubKey = blst.P2Aggregate
 
 // Domain Separation Tag for signatures on G1 (minimal-signature-size)
 var DST = []byte("BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_")
+
+// Domain Separation Tag specified for the PoP ciphersuite
+var DST_POP = []byte("BLS_POP_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_")
 
 type Signature []byte
 type PublicKey []byte

--- a/crypto/bls12381/types_bench_test.go
+++ b/crypto/bls12381/types_bench_test.go
@@ -16,15 +16,15 @@ func BenchmarkVerifyCompressed(b *testing.B) {
 	// Create a signature
 	sig := Sign(sk, msg)
 
-	b.Run("WithSigGroupCheck", func(b *testing.B) {
+	b.Run("WithSigGroupCheckAndPkValidate", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			dummySig := new(BlsSig)
-			dummySig.VerifyCompressed(sig, true, pk, false, msg, DST)
+			dummySig.VerifyCompressed(sig, true, pk, true, msg, DST)
 		}
 	})
 
-	b.Run("WithoutSigGroupCheck", func(b *testing.B) {
+	b.Run("WithoutSigGroupCheckOrPkValidate", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			dummySig := new(BlsSig)

--- a/x/checkpointing/types/pop.go
+++ b/x/checkpointing/types/pop.go
@@ -1,17 +1,19 @@
 package types
 
 import (
-	"github.com/babylonlabs-io/babylon/crypto/bls12381"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+
+	"github.com/babylonlabs-io/babylon/crypto/bls12381"
 )
 
 // IsValid verifies the validity of PoP
-// 1. verify(sig=bls_sig, pubkey=blsPubkey, msg=pop.ed25519_sig)?
+// 1. verify(sig=bls_sig, pubkey=blsPubkey, msg=blsPubkey||pop.ed25519_sig)?
 // 2. verify(sig=pop.ed25519_sig, pubkey=valPubkey, msg=blsPubkey)?
 // BLS_pk ?= decrypt(key = Ed25519_pk, data = decrypt(key = BLS_pk, data = PoP))
 func (pop ProofOfPossession) IsValid(blsPubkey bls12381.PublicKey, valPubkey cryptotypes.PubKey) bool {
-	ok, _ := bls12381.Verify(*pop.BlsSig, blsPubkey, pop.Ed25519Sig)
+	msg := bls12381.GetPopSignMsg(blsPubkey, pop.Ed25519Sig)
+	ok, _ := bls12381.PopVerify(*pop.BlsSig, blsPubkey, msg)
 	if !ok {
 		return false
 	}


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/pm/issues/289. Below is what is recomended to fix the issue which the reviewer should follow to check:
1. For signatures, use the domain separation tag specified for the PoP ciphersuite in the BLS specification:
BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_
2. Expose PopProve and PopVerify functions distinct from the standard Sign and Verify functions, and use them when creating all proofs of possession. For these functions, use the domain separation tag specified for PopProve and PopVerify in the BLS spec:
BLS_POP_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_
3. In the BuildPoP function in [app/signer/types.go](https://github.com/babylonlabs-io/babylon/blob/9b91aec647f158e6070ac51272dc6d16e9ed45a0/app/signer/types.go#L50), use the PopProve function described above in place of Sign. Instead of the current value, Sign(EdSk, BlsPubKey), use the message BlsPubKey || Sign(EdSk, BlsPubKey) in the PoP.