### PR TITLE
crypto: fix EOTS missing normalization in use of secp256k1.FieldVal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ This PR contains a series of PRs on multi-staking support and BTC staking integr
 - [#673](https://github.com/babylonlabs-io/babylon/pull/673) fix: move bip322 signing
 functions to `testutil`
 - [#683](https://github.com/babylonlabs-io/babylon/pull/683) crypto: fix eots signing timing attack
+- [#691](https://github.com/babylonlabs-io/babylon/pull/691) crypto: fix eots missing normalization in use of secp256k1.FieldVal
 
 ## v1.0.0-rc7
 

--- a/crypto/eots/eots.go
+++ b/crypto/eots/eots.go
@@ -134,6 +134,7 @@ func signHash(sk *PrivateKey, privateRand *PrivateRand, hash [32]byte) (*Signatu
 }
 
 // Verify verifies that the signature is valid for this message, public key and random value.
+// Precondition: r must be normalized
 func Verify(pubKey *PublicKey, r *PublicRand, message []byte, sig *Signature) error {
 	h := hash(message)
 	pubkeyBytes := schnorr.SerializePubKey(pubKey)
@@ -211,6 +212,7 @@ func verifyHash(pubKeyBytes []byte, r *PublicRand, hash [32]byte, sig *Signature
 }
 
 // Extract extracts the private key from a public key and signatures for two distinct hashes messages.
+// Precondition: r must be normalized
 func Extract(pubKey *PublicKey, r *PublicRand, message1 []byte, sig1 *Signature, message2 []byte, sig2 *Signature) (*PrivateKey, error) {
 	h1 := hash(message1)
 	h2 := hash(message2)

--- a/types/btc_schnorr_pub_rand.go
+++ b/types/btc_schnorr_pub_rand.go
@@ -4,9 +4,10 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/babylonlabs-io/babylon/crypto/eots"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+
+	"github.com/babylonlabs-io/babylon/crypto/eots"
 )
 
 type SchnorrPubRand []byte
@@ -40,9 +41,13 @@ func NewPubRandFromPrivRand(sr *eots.PrivateRand) *SchnorrPubRand {
 	return NewSchnorrPubRandFromFieldVal(&j.X)
 }
 
-func (pr SchnorrPubRand) ToFieldVal() *btcec.FieldVal {
+// ToFieldValNormalized converts bytes into btcec.FieldVal and ensures
+// it is normalized
+func (pr SchnorrPubRand) ToFieldValNormalized() *btcec.FieldVal {
 	var r btcec.FieldVal
-	r.SetByteSlice(pr)
+	if r.SetByteSlice(pr) {
+		r.Normalize()
+	}
 	return &r
 }
 

--- a/types/btc_schnorr_pub_rand_test.go
+++ b/types/btc_schnorr_pub_rand_test.go
@@ -4,10 +4,11 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/babylonlabs-io/babylon/testutil/datagen"
-	"github.com/babylonlabs-io/babylon/types"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/stretchr/testify/require"
+
+	"github.com/babylonlabs-io/babylon/testutil/datagen"
+	"github.com/babylonlabs-io/babylon/types"
 )
 
 func FuzzSchnorrPubRand(f *testing.F) {
@@ -22,7 +23,7 @@ func FuzzSchnorrPubRand(f *testing.F) {
 
 		// FieldVal -> SchnorrPubRand -> FieldVal
 		pubRand := types.NewSchnorrPubRandFromFieldVal(&fieldVal)
-		fieldVal2 := pubRand.ToFieldVal()
+		fieldVal2 := pubRand.ToFieldValNormalized()
 		require.True(t, fieldVal.Equals(fieldVal2))
 
 		// SchnorrPubRand -> bytes -> SchnorrPubRand

--- a/x/finality/types/finality.go
+++ b/x/finality/types/finality.go
@@ -109,7 +109,7 @@ func (e *Evidence) ExtractBTCSK() (*btcec.PrivateKey, error) {
 		return nil, err
 	}
 	return eots.Extract(
-		btcPK, e.PubRand.ToFieldVal(),
+		btcPK, e.PubRand.ToFieldValNormalized(),
 		e.canonicalMsgToSign(), e.CanonicalFinalitySig.ToModNScalar(), // msg and sig for canonical block
 		e.forkMsgToSign(), e.ForkFinalitySig.ToModNScalar(), // msg and sig for fork block
 	)

--- a/x/finality/types/msg.go
+++ b/x/finality/types/msg.go
@@ -76,7 +76,7 @@ func VerifyFinalitySig(m *MsgAddFinalitySig, prCommit *PubRandCommit) error {
 	if err != nil {
 		return err
 	}
-	return eots.Verify(pk, m.PubRand.ToFieldVal(), msgToSign, m.FinalitySig.ToModNScalar())
+	return eots.Verify(pk, m.PubRand.ToFieldValNormalized(), msgToSign, m.FinalitySig.ToModNScalar())
 }
 
 // HashToSign returns a 32-byte hash of (start_height || num_pub_rand || commitment)


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/pm/issues/291.

In current EOTS operations, normalized `secp256k1.FieldVal` is required, however, the input is not ensured to meet this condition. This PR fixed the issue by adding normalization in type conversion.