### PR TITLE
crypto: fix missing secret zeroized

### DIFF
--- a/crypto/bls12381/bls.go
+++ b/crypto/bls12381/bls.go
@@ -25,6 +25,13 @@ func GenPrivKey() PrivateKey {
 func genPrivKey(rand io.Reader) PrivateKey {
 	seed := make([]byte, SeedSize)
 
+	// Ensure seed is zeroized before function returns, even on error
+	defer func() {
+		for i := range seed {
+			seed[i] = 0
+		}
+	}()
+
 	_, err := io.ReadFull(rand, seed)
 	if err != nil {
 		panic(err)

--- a/crypto/eots/eots.go
+++ b/crypto/eots/eots.go
@@ -80,6 +80,9 @@ func signHash(sk *PrivateKey, privateRand *PrivateRand, hash [32]byte) (*Signatu
 	isPyOdd := pubKeyBytes[0] == secp256k1.PubKeyFormatCompressedOdd
 
 	k := new(ModNScalar).Set(privateRand)
+	defer func() {
+		k.Zero()
+	}()
 
 	// R = kG (with blinding in order to prevent timing side channel attacks)
 	R, err := common.ScalarBaseMultWithBlinding(k)
@@ -94,6 +97,9 @@ func signHash(sk *PrivateKey, privateRand *PrivateRand, hash [32]byte) (*Signatu
 	// Note that R must be in affine coordinates for this check.
 	R.ToAffine()
 	kNegated := new(ModNScalar).Set(k).Negate()
+	defer func() {
+		kNegated.Zero()
+	}()
 	isRyOdd := R.Y.IsOdd()
 
 	// e = tagged_hash("BIP0340/challenge", bytes(R) || bytes(P) || m) mod n


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/pm/issues/293.

This PR added zeroization for secrets in operations of BLS and EOTS. Secret zerioization issues in common and adaptor signatures are handled in other PRs.