### PR TITLE
improve checkpoint panic behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ check of rewards
 
 - [#402](https://github.com/babylonlabs-io/babylon/pull/402) **Babylon multi-staking support**.
 This PR contains a series of PRs on multi-staking support and BTC staking integration.
+- [#695](https://github.com/babylonlabs-io/babylon/pull/695) Improve checkpoint
+panicking behavior
 
 ### Bug fixes
 

--- a/x/btccheckpoint/keeper/msg_server.go
+++ b/x/btccheckpoint/keeper/msg_server.go
@@ -2,12 +2,14 @@ package keeper
 
 import (
 	"context"
+	"errors"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
 	"github.com/babylonlabs-io/babylon/x/btccheckpoint/types"
+	ckpttypes "github.com/babylonlabs-io/babylon/x/checkpointing/types"
 )
 
 var _ types.MsgServer = msgServer{}
@@ -47,25 +49,40 @@ func (ms msgServer) InsertBTCSpvProof(ctx context.Context, req *types.MsgInsertB
 		return nil, types.ErrInvalidHeader.Wrap(err.Error())
 	}
 
+	epochNum := rawSubmission.CheckpointData.Epoch
+
+	ed := ms.k.GetEpochData(sdkCtx, epochNum)
+
+	if ed == nil {
+		// we do not have any data saved yet
+		newEd := types.NewEmptyEpochData()
+		ed = &newEd
+	}
+
+	if ed.Status == types.Finalized {
+		// we have already finalized given epoch so we do not need any more submissions
+		return nil, types.ErrEpochAlreadyFinalized
+	}
+
 	// At this point:
 	// - every proof of inclusion is valid i.e every transaction is proved to be
 	// part of provided block and contains some OP_RETURN data
 	// - header is proved to be part of the chain we know about through BTCLightClient
+	// - epoch is not yet finalized
 	// - this is new checkpoint submission
 	// Verify if this is expected checkpoint
-	err = ms.k.checkpointingKeeper.VerifyCheckpoint(sdkCtx, rawSubmission.CheckpointData)
+	if err := ms.k.checkpointingKeeper.VerifyCheckpoint(sdkCtx, rawSubmission.CheckpointData); err != nil {
+		if errors.Is(err, ckpttypes.ErrConflictingCheckpoint) {
+			// We end such transaction with success to preserve setting of the conflict
+			// flag in the state. This flag will trigger halt of the chain in the
+			// EndBlocker call
+			return &types.MsgInsertBTCSpvProofResponse{}, nil
+		}
 
-	if err != nil {
 		return nil, err
 	}
 
-	// At this point we know this is a valid checkpoint for this epoch as this was validated
-	// by checkpointing module
-	epochNum := rawSubmission.CheckpointData.Epoch
-
-	err = ms.k.checkAncestors(sdkCtx, epochNum, newSubmissionOldestHeaderDepth)
-
-	if err != nil {
+	if err := ms.k.checkAncestors(sdkCtx, epochNum, newSubmissionOldestHeaderDepth); err != nil {
 		return nil, err
 	}
 
@@ -81,16 +98,13 @@ func (ms msgServer) InsertBTCSpvProof(ctx context.Context, req *types.MsgInsertB
 	submissionData := rawSubmission.GetSubmissionData(epochNum, txsInfo)
 
 	// Everything is fine, save new checkpoint and update Epoch data
-	err = ms.k.addEpochSubmission(
+	ms.k.addEpochSubmission(
 		sdkCtx,
 		epochNum,
+		ed,
 		submissionKey,
 		submissionData,
 	)
-
-	if err != nil {
-		return nil, err
-	}
 
 	// At this point, the BTC checkpoint is a valid submission and is
 	// not duplicated (first time seeing the pair of BTC txs)

--- a/x/btccheckpoint/keeper/msg_server_test.go
+++ b/x/btccheckpoint/keeper/msg_server_test.go
@@ -459,6 +459,51 @@ func TestLeaveOnlyBestSubmissionWhenEpochFinalized(t *testing.T) {
 	require.Equal(t, finalSubKey.Key[1].Hash, b2Hash(msg3))
 }
 
+func TestReturnErrorIfEpochAlreadyFinalized(t *testing.T) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	tk := InitTestKeepers(t)
+	defaultParams := btcctypes.DefaultParams()
+	wDeep := defaultParams.CheckpointFinalizationTimeout
+
+	require.False(t, tk.Checkpointing.VerifyCalled)
+	msg := dg.GenerateMessageWithRandomSubmitterForEpoch(r, 1)
+	tk.BTCLightClient.SetDepth(b1Hash(msg), uint32(1))
+	tk.BTCLightClient.SetDepth(b2Hash(msg), uint32(0))
+	_, err := tk.insertProofMsg(msg)
+	require.NoError(t, err, "failed to insert submission")
+	require.True(t, tk.Checkpointing.VerifyCalled)
+
+	ed := tk.GetEpochData(uint64(1))
+	require.NotNil(t, ed)
+	require.Len(t, ed.Keys, 1)
+
+	tk.BTCLightClient.SetDepth(b1Hash(msg), wDeep+4)
+	tk.BTCLightClient.SetDepth(b2Hash(msg), wDeep+5)
+
+	tk.onTipChange()
+
+	ed = tk.GetEpochData(uint64(1))
+	require.NotNil(t, ed)
+	require.Len(t, ed.Keys, 1)
+	require.Equal(t, ed.Status, btcctypes.Finalized)
+
+	finalSubKey := ed.Keys[0]
+
+	require.Equal(t, finalSubKey.Key[0].Hash, b1Hash(msg))
+	require.Equal(t, finalSubKey.Key[1].Hash, b2Hash(msg))
+
+	// set to false to simulate new transaction being processed
+	tk.Checkpointing.VerifyCalled = false
+	// new valid submission that is higher in btc chain should be rejected
+	msg1 := dg.GenerateMessageWithRandomSubmitterForEpoch(r, 1)
+	tk.BTCLightClient.SetDepth(b1Hash(msg1), uint32(1))
+	tk.BTCLightClient.SetDepth(b2Hash(msg1), uint32(0))
+	_, err = tk.insertProofMsg(msg1)
+	require.ErrorIs(t, err, btcctypes.ErrEpochAlreadyFinalized)
+	// It should still be falce as verify should not be called if epoch is already finalized
+	require.False(t, tk.Checkpointing.VerifyCalled)
+}
+
 func TestTxIdxShouldBreakTies(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	tk := InitTestKeepers(t)

--- a/x/btccheckpoint/types/mock_keepers.go
+++ b/x/btccheckpoint/types/mock_keepers.go
@@ -14,7 +14,8 @@ type MockBTCLightClientKeeper struct {
 }
 
 type MockCheckpointingKeeper struct {
-	returnError bool
+	returnError  bool
+	VerifyCalled bool
 }
 
 type MockIncentiveKeeper struct {
@@ -29,7 +30,8 @@ func NewMockBTCLightClientKeeper() *MockBTCLightClientKeeper {
 
 func NewMockCheckpointingKeeper() *MockCheckpointingKeeper {
 	mc := MockCheckpointingKeeper{
-		returnError: false,
+		returnError:  false,
+		VerifyCalled: false,
 	}
 	return &mc
 }
@@ -68,11 +70,11 @@ func (ck MockBTCLightClientKeeper) MainChainDepth(ctx context.Context, headerByt
 	}
 }
 
-func (ck MockCheckpointingKeeper) VerifyCheckpoint(ctx context.Context, checkpoint txformat.RawBtcCheckpoint) error {
+func (ck *MockCheckpointingKeeper) VerifyCheckpoint(ctx context.Context, checkpoint txformat.RawBtcCheckpoint) error {
 	if ck.returnError {
 		return errors.New("bad checkpoints")
 	}
-
+	ck.VerifyCalled = true
 	return nil
 }
 


### PR DESCRIPTION
Improves behaviour when receiving conflicting checkpoints:
- we do not panic if epoch is already finalized
- to preserve panicking behaviour we should succed the transactions which provided us conflicting chekcpoint