### PR TITLE
fix: emit double events in queued msgs at end epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ functions to `testutil`
 - [#683](https://github.com/babylonlabs-io/babylon/pull/683) crypto: fix eots signing timing attack
 - [#691](https://github.com/babylonlabs-io/babylon/pull/691) crypto: fix eots missing normalization in use of secp256k1.FieldVal
 - [#705](https://github.com/babylonlabs-io/babylon/pull/705) Add bls key length validation from the ERC-2335 keystore
+- [#712](https://github.com/babylonlabs-io/babylon/pull/712) fix: remove exponentially events emission at processing
+queued msgs at the end epoch.
 
 ## v1.0.0-rc7
 

--- a/x/epoching/abci.go
+++ b/x/epoching/abci.go
@@ -89,12 +89,12 @@ func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, e
 		queuedMsgs := k.GetCurrentEpochMsgs(ctx)
 		// forward each msg in the msg queue to the right keeper
 		for _, msg := range queuedMsgs {
-			_, err := k.HandleQueuedMsg(ctx, msg)
+			_, errQueuedMsg := k.HandleQueuedMsg(ctx, msg)
 			// skip this failed msg and emit and event signalling it
 			// we do not panic here as some users may wrap an invalid message
 			// (e.g., self-delegate coins more than its balance, wrong coding of addresses, ...)
 			// honest validators will have consistent execution results on the queued messages
-			if err != nil {
+			if errQueuedMsg != nil {
 				// emit an event signalling the failed execution
 				err := sdkCtx.EventManager().EmitTypedEvent(
 					&types.EventHandleQueuedMsg{
@@ -102,7 +102,7 @@ func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, e
 						Height:      msg.BlockHeight,
 						TxId:        msg.TxId,
 						MsgId:       msg.MsgId,
-						Error:       err.Error(),
+						Error:       errQueuedMsg.Error(),
 					},
 				)
 				if err != nil {

--- a/x/epoching/abci.go
+++ b/x/epoching/abci.go
@@ -111,21 +111,6 @@ func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, e
 				// skip this failed msg
 				continue
 			}
-			// for each event, emit an wrapped event EventTypeHandleQueuedMsg, which attaches the original attributes plus the original event type, the epoch number, txid and msgid to the event here
-			// for _, event := range res.Events {
-			// 	err := sdkCtx.EventManager().EmitTypedEvent(
-			// 		&types.EventHandleQueuedMsg{
-			// 			OriginalEventType:  event.Type,
-			// 			EpochNumber:        epoch.EpochNumber,
-			// 			TxId:               msg.TxId,
-			// 			MsgId:              msg.MsgId,
-			// 			OriginalAttributes: event.Attributes,
-			// 		},
-			// 	)
-			// 	if err != nil {
-			// 		return nil, err
-			// 	}
-			// }
 		}
 
 		// update validator set

--- a/x/epoching/abci.go
+++ b/x/epoching/abci.go
@@ -89,7 +89,7 @@ func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, e
 		queuedMsgs := k.GetCurrentEpochMsgs(ctx)
 		// forward each msg in the msg queue to the right keeper
 		for _, msg := range queuedMsgs {
-			res, err := k.HandleQueuedMsg(ctx, msg)
+			_, err := k.HandleQueuedMsg(ctx, msg)
 			// skip this failed msg and emit and event signalling it
 			// we do not panic here as some users may wrap an invalid message
 			// (e.g., self-delegate coins more than its balance, wrong coding of addresses, ...)
@@ -112,20 +112,20 @@ func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, e
 				continue
 			}
 			// for each event, emit an wrapped event EventTypeHandleQueuedMsg, which attaches the original attributes plus the original event type, the epoch number, txid and msgid to the event here
-			for _, event := range res.Events {
-				err := sdkCtx.EventManager().EmitTypedEvent(
-					&types.EventHandleQueuedMsg{
-						OriginalEventType:  event.Type,
-						EpochNumber:        epoch.EpochNumber,
-						TxId:               msg.TxId,
-						MsgId:              msg.MsgId,
-						OriginalAttributes: event.Attributes,
-					},
-				)
-				if err != nil {
-					return nil, err
-				}
-			}
+			// for _, event := range res.Events {
+			// 	err := sdkCtx.EventManager().EmitTypedEvent(
+			// 		&types.EventHandleQueuedMsg{
+			// 			OriginalEventType:  event.Type,
+			// 			EpochNumber:        epoch.EpochNumber,
+			// 			TxId:               msg.TxId,
+			// 			MsgId:              msg.MsgId,
+			// 			OriginalAttributes: event.Attributes,
+			// 		},
+			// 	)
+			// 	if err != nil {
+			// 		return nil, err
+			// 	}
+			// }
 		}
 
 		// update validator set

--- a/x/epoching/abci.go
+++ b/x/epoching/abci.go
@@ -108,8 +108,6 @@ func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, e
 				if err != nil {
 					return nil, err
 				}
-				// skip this failed msg
-				continue
 			}
 		}
 

--- a/x/epoching/keeper/msg_server_test.go
+++ b/x/epoching/keeper/msg_server_test.go
@@ -250,9 +250,10 @@ func FuzzMsgWrappedUpdateStakingParams(f *testing.F) {
 }
 
 func TestExponentiallyEventsEndEpochQueuedMessages(t *testing.T) {
+	t.Parallel()
+
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	h := testhelper.NewHelper(t)
-
 	ctx, k, stkK := h.Ctx, h.App.EpochingKeeper, h.App.StakingKeeper
 
 	vals, err := stkK.GetValidators(ctx, 1)

--- a/x/epoching/keeper/msg_server_test.go
+++ b/x/epoching/keeper/msg_server_test.go
@@ -8,7 +8,6 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 	abci "github.com/cometbft/cometbft/abci/types"
-	"github.com/cometbft/cometbft/crypto/tmhash"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/require"
@@ -279,7 +278,6 @@ func TestExponentiallyEventsEndEpochQueuedMessages(t *testing.T) {
 
 	var numDelMessages int = datagen.RandomInRange(r, 5, 25)
 	for i := 0; i < numDelMessages; i++ {
-		epochMsgs = k.GetCurrentEpochMsgs(ctx)
 		msgDel := types.NewMsgWrappedDelegate(
 			stakingtypes.NewMsgDelegate(
 				h.GenAccs[0].GetAddress().String(),
@@ -325,82 +323,4 @@ func TestExponentiallyEventsEndEpochQueuedMessages(t *testing.T) {
 
 	expEventsLen := (numDelMessages * eventsGeneratedByMsgDelegate) + eventsGeneratedByMsgEditValidator + eventsGeneratedHealthyEpochEndBlocker
 	require.Equal(t, expEventsLen, len(events))
-}
-
-func TestEpochFailedMsg(t *testing.T) {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	h := testhelper.NewHelper(t)
-
-	ctx, k, stkK := h.Ctx, h.App.EpochingKeeper, h.App.StakingKeeper
-
-	vals, err := stkK.GetValidators(ctx, 1)
-	h.NoError(err)
-	require.Len(t, vals, 1)
-
-	valBeforeChange := vals[0]
-	valAddr, err := sdk.ValAddressFromBech32(valBeforeChange.OperatorAddress)
-	h.NoError(err)
-
-	valI, err := h.App.StakingKeeper.GetValidator(ctx, valAddr)
-	require.NoError(t, err)
-
-	newDescription := datagen.GenRandomDescription(r)
-	// newBadCommissionRate := valI.Commission.MaxRate.Add(sdkmath.LegacyMustNewDecFromStr("0.01"))
-	newBadCommissionRate := sdkmath.LegacyMustNewDecFromStr("0.0015")
-	newMinSelfDel := valBeforeChange.MinSelfDelegation.AddRaw(r.Int63n(valBeforeChange.Tokens.Sub(valBeforeChange.MinSelfDelegation).Int64()))
-
-	msg := stakingtypes.NewMsgEditValidator(valAddr.String(), *newDescription, &newBadCommissionRate, &newMinSelfDel)
-	// wMsg := types.NewMsgWrappedEditValidator(msg)
-
-	// res, err := h.MsgSrvr.WrappedEditValidator(ctx, wMsg)
-	// h.NoError(err)
-	// require.NotNil(t, res)
-
-	blockHeight := uint64(ctx.HeaderInfo().Height)
-	blockTime := ctx.HeaderInfo().Time
-	txid := tmhash.Sum(ctx.TxBytes())
-
-	queuedMsg, err := types.NewQueuedMessage(blockHeight, blockTime, txid, msg)
-	require.NoError(t, err)
-	h.App.EpochingKeeper.EnqueueMsg(ctx, queuedMsg)
-
-	epochMsgs := k.GetCurrentEpochMsgs(ctx)
-	require.Len(t, epochMsgs, 1)
-
-	epochMsgs = k.GetCurrentEpochMsgs(ctx)
-
-	blkHeader := ctx.BlockHeader()
-	blkHeader.Time = valBeforeChange.Commission.UpdateTime.Add(time.Hour * 5)
-	ctx = ctx.WithBlockHeader(blkHeader)
-
-	epoch := k.GetEpoch(ctx)
-	info := ctx.HeaderInfo()
-	info.Height = int64(epoch.GetLastBlockHeight())
-	info.Time = blkHeader.Time
-
-	// update the commission to update the time and fail on the wrap execution
-	// _, err = h.App.StakingKeeper.UpdateValidatorCommission(ctx, valI, valI.Commission.Rate.Add(sdkmath.LegacyMustNewDecFromStr("0.001")))
-	// h.NoError(err)
-
-	// creates a new context to empty out the events from the manager
-	// which contained types.EventWrappedDelegate generated
-	// by the x/epoching msg server
-	ctx = sdk.NewContext(ctx.MultiStore(), ctx.BlockHeader(), ctx.IsCheckTx(), ctx.Logger()).WithHeaderInfo(info)
-
-	// with a clean context
-	valsetUpdate, err := epoching.EndBlocker(ctx, k)
-	h.NoError(err)
-	require.Len(t, valsetUpdate, 0)
-
-	var events []abci.Event
-	if evtMgr := ctx.EventManager(); evtMgr != nil {
-		events = evtMgr.ABCIEvents()
-	}
-
-	valI, err = h.App.StakingKeeper.GetValidator(ctx, valAddr)
-	require.NoError(t, err)
-
-	require.Equal(t, newDescription.Moniker, valI.Description.Moniker, "should not be equal, the commission update should fail the entire msg and not write the context")
-
-	fmt.Println(len(events))
 }


### PR DESCRIPTION
We might want to keep our events emitting `EventHandleQueuedMsg` in case of success, if that is needed further tests should be done 