### PR TITLE
[backport] crypto: Add bls key length validation from the ERC-2335 keystore (#705)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ functions to `testutil`
 - [#683](https://github.com/babylonlabs-io/babylon/pull/683) crypto: fix eots signing timing attack
 - [#691](https://github.com/babylonlabs-io/babylon/pull/691) crypto: fix eots missing normalization in use of secp256k1.FieldVal
 - [#671](https://github.com/babylonlabs-io/babylon/pull/671) crypto: align adaptor sig impl with Blockstream spec
+- [#705](https://github.com/babylonlabs-io/babylon/pull/705) Add bls key length validation from the ERC-2335 keystore
 
 ### Improvements
 

--- a/app/signer/bls.go
+++ b/app/signer/bls.go
@@ -64,6 +64,11 @@ func NewBls(privKey bls12381.PrivateKey, keyFilePath, passwordFilePath string) *
 	if privKey == nil {
 		panic("BLS private key should not be nil")
 	}
+
+	if err := privKey.ValidateBasic(); err != nil {
+		panic(fmt.Errorf("invalid BLS private key: %w", err))
+	}
+
 	return &Bls{
 		Key: BlsKey{
 			PubKey:       privKey.PubKey(),
@@ -102,6 +107,10 @@ func LoadBls(keyFilePath, passwordFilePath string) *Bls {
 	}
 
 	blsPrivKey := bls12381.PrivateKey(privKey)
+	if err := blsPrivKey.ValidateBasic(); err != nil {
+		cmtos.Exit(fmt.Sprintf("invalid BLS private key: %v", err.Error()))
+	}
+
 	return &Bls{
 		Key: BlsKey{
 			PubKey:       blsPrivKey.PubKey(),

--- a/crypto/bls12381/types.go
+++ b/crypto/bls12381/types.go
@@ -3,6 +3,7 @@ package bls12381
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 
 	blst "github.com/supranational/blst/bindings/go"
 )
@@ -35,6 +36,8 @@ type PrivateKey []byte
 const (
 	// SignatureSize is the size, in bytes, of a compressed BLS signature
 	SignatureSize = 48
+	// PrivKeySize is the size, in bytes, of a BLS private key
+	PrivKeySize = 32
 	// PubKeySize is the size, in bytes, of a compressed BLS public key
 	PubKeySize = 96
 	// SeedSize is the size, in bytes, of private key seeds
@@ -43,10 +46,10 @@ const (
 
 func (sig Signature) ValidateBasic() error {
 	if sig == nil {
-		return errors.New("invalid BLS signature")
+		return errors.New("empty BLS signature")
 	}
 	if len(sig) != SignatureSize {
-		return errors.New("invalid BLS signature")
+		return fmt.Errorf("invalid BLS signature length, got %d, expected %d", len(sig), SignatureSize)
 	}
 
 	return nil
@@ -77,7 +80,7 @@ func (sig Signature) Size() int {
 
 func (sig *Signature) Unmarshal(data []byte) error {
 	if len(data) != SignatureSize {
-		return errors.New("Invalid signature length")
+		return fmt.Errorf("invalid BLS signature length, got %d, expected %d", len(data), SignatureSize)
 	}
 
 	*sig = data
@@ -138,7 +141,7 @@ func (pk PublicKey) Size() int {
 
 func (pk *PublicKey) Unmarshal(data []byte) error {
 	if len(data) != PubKeySize {
-		return errors.New("Invalid public key length")
+		return fmt.Errorf("invalid BLS public key length, got %d, expected %d", len(data), PubKeySize)
 	}
 
 	*pk = data
@@ -151,6 +154,14 @@ func (pk PublicKey) Equal(k PublicKey) bool {
 
 func (pk PublicKey) Bytes() []byte {
 	return pk
+}
+
+func (sk PrivateKey) ValidateBasic() error {
+	if len(sk) != PrivKeySize {
+		return fmt.Errorf("invalid BLS private key length, got %d, expected %d", len(sk), PrivKeySize)
+	}
+
+	return nil
 }
 
 func (sk PrivateKey) PubKey() PublicKey {


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/pm/issues/295. Closes https://github.com/babylonlabs-io/pm/issues/285. The recommendation is to ensure the BLS key loaded from ERC-2335 keystore is a fixed length, i.e., 32 bytes.