### PR TITLE
[Backport] fix: emit double events in queued msgs at end epoch (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ functions to `testutil`
 - [#683](https://github.com/babylonlabs-io/babylon/pull/683) crypto: fix eots signing timing attack
 - [#691](https://github.com/babylonlabs-io/babylon/pull/691) crypto: fix eots missing normalization in use of secp256k1.FieldVal
 - [#671](https://github.com/babylonlabs-io/babylon/pull/671) crypto: align adaptor sig impl with Blockstream spec
+- [#712](https://github.com/babylonlabs-io/babylon/pull/712) fix: remove exponentially events emission at processing
+queued msgs at the end epoch.
 
 ### Improvements
 

--- a/x/epoching/abci.go
+++ b/x/epoching/abci.go
@@ -89,12 +89,12 @@ func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, e
 		queuedMsgs := k.GetCurrentEpochMsgs(ctx)
 		// forward each msg in the msg queue to the right keeper
 		for _, msg := range queuedMsgs {
-			res, err := k.HandleQueuedMsg(ctx, msg)
+			_, errQueuedMsg := k.HandleQueuedMsg(ctx, msg)
 			// skip this failed msg and emit and event signalling it
 			// we do not panic here as some users may wrap an invalid message
 			// (e.g., self-delegate coins more than its balance, wrong coding of addresses, ...)
 			// honest validators will have consistent execution results on the queued messages
-			if err != nil {
+			if errQueuedMsg != nil {
 				// emit an event signalling the failed execution
 				err := sdkCtx.EventManager().EmitTypedEvent(
 					&types.EventHandleQueuedMsg{
@@ -102,24 +102,7 @@ func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, e
 						Height:      msg.BlockHeight,
 						TxId:        msg.TxId,
 						MsgId:       msg.MsgId,
-						Error:       err.Error(),
-					},
-				)
-				if err != nil {
-					return nil, err
-				}
-				// skip this failed msg
-				continue
-			}
-			// for each event, emit an wrapped event EventTypeHandleQueuedMsg, which attaches the original attributes plus the original event type, the epoch number, txid and msgid to the event here
-			for _, event := range res.Events {
-				err := sdkCtx.EventManager().EmitTypedEvent(
-					&types.EventHandleQueuedMsg{
-						OriginalEventType:  event.Type,
-						EpochNumber:        epoch.EpochNumber,
-						TxId:               msg.TxId,
-						MsgId:              msg.MsgId,
-						OriginalAttributes: event.Attributes,
+						Error:       errQueuedMsg.Error(),
 					},
 				)
 				if err != nil {

--- a/x/epoching/keeper/msg_server_test.go
+++ b/x/epoching/keeper/msg_server_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/require"
@@ -245,4 +246,81 @@ func FuzzMsgWrappedUpdateStakingParams(f *testing.F) {
 		require.Equal(t, newBondDenom, stakingParamsAfterChange.BondDenom)
 		require.Equal(t, newMinCommissionRate.String(), stakingParamsAfterChange.MinCommissionRate.String())
 	})
+}
+
+func TestExponentiallyEventsEndEpochQueuedMessages(t *testing.T) {
+	t.Parallel()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	h := testhelper.NewHelper(t)
+	ctx, k, stkK := h.Ctx, h.App.EpochingKeeper, h.App.StakingKeeper
+
+	vals, err := stkK.GetValidators(ctx, 1)
+	h.NoError(err)
+	require.Len(t, vals, 1)
+
+	valBeforeChange := vals[0]
+	valAddr, err := sdk.ValAddressFromBech32(valBeforeChange.OperatorAddress)
+	h.NoError(err)
+
+	newDescription := datagen.GenRandomDescription(r)
+	newCommissionRate := sdkmath.LegacyMustNewDecFromStr(fmt.Sprintf("0.%d", r.Int31n(5)+1))
+	newMinSelfDel := valBeforeChange.MinSelfDelegation.AddRaw(r.Int63n(valBeforeChange.Tokens.Sub(valBeforeChange.MinSelfDelegation).Int64()))
+
+	msg := stakingtypes.NewMsgEditValidator(valAddr.String(), *newDescription, &newCommissionRate, &newMinSelfDel)
+	wMsg := types.NewMsgWrappedEditValidator(msg)
+	res, err := h.MsgSrvr.WrappedEditValidator(ctx, wMsg)
+	h.NoError(err)
+	require.NotNil(t, res)
+
+	epochMsgs := k.GetCurrentEpochMsgs(ctx)
+	require.Len(t, epochMsgs, 1)
+
+	var numDelMessages int = datagen.RandomInRange(r, 5, 25)
+	for i := 0; i < numDelMessages; i++ {
+		msgDel := types.NewMsgWrappedDelegate(
+			stakingtypes.NewMsgDelegate(
+				h.GenAccs[0].GetAddress().String(),
+				valAddr.String(),
+				sdk.NewCoin("ubbn", sdkmath.NewInt(100000)),
+			),
+		)
+
+		res, err := h.MsgSrvr.WrappedDelegate(ctx, msgDel)
+		h.NoError(err)
+		require.NotNil(t, res)
+	}
+
+	epochMsgs = k.GetCurrentEpochMsgs(ctx)
+	require.Len(t, epochMsgs, numDelMessages+1)
+
+	blkHeader := ctx.BlockHeader()
+	blkHeader.Time = valBeforeChange.Commission.UpdateTime.Add(time.Hour * 25)
+	ctx = ctx.WithBlockHeader(blkHeader)
+
+	epoch := k.GetEpoch(ctx)
+	info := ctx.HeaderInfo()
+	info.Height = int64(epoch.GetLastBlockHeight())
+	info.Time = blkHeader.Time
+
+	// cleans out the msg server envents
+	// which contained types.EventWrappedDelegate generated
+	// by the x/epoching msg server in WrappedDelegate
+	ctx = sdk.NewContext(ctx.MultiStore(), ctx.BlockHeader(), ctx.IsCheckTx(), ctx.Logger()).WithHeaderInfo(info)
+
+	// with a clean context
+	_, err = epoching.EndBlocker(ctx, k)
+	h.NoError(err)
+
+	var events []abci.Event
+	if evtMgr := ctx.EventManager(); evtMgr != nil {
+		events = evtMgr.ABCIEvents()
+	}
+
+	eventsGeneratedByMsgEditValidator := 1
+	eventsGeneratedByMsgDelegate := 4
+	eventsGeneratedHealthyEpochEndBlocker := 1
+
+	expEventsLen := (numDelMessages * eventsGeneratedByMsgDelegate) + eventsGeneratedByMsgEditValidator + eventsGeneratedHealthyEpochEndBlocker
+	require.Equal(t, expEventsLen, len(events))
 }


### PR DESCRIPTION
We might want to keep our events emitting `EventHandleQueuedMsg` in case of success, if that is needed further tests should be done

---------