### PR TITLE
chore: fix block timeout in Babylon client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This PR contains a series of PRs on multi-staking support and BTC staking integr
 
 ### Bug fixes
 
+- [#731](https://github.com/babylonlabs-io/babylon/pull/731) chore: fix block timeout in Babylon client
 - [#525](https://github.com/babylonlabs-io/babylon/pull/525) fix: add back `NewIBCHeaderDecorator` post handler
 
 ## v1.0.0-rc8

--- a/client/config/babylon_config.go
+++ b/client/config/babylon_config.go
@@ -2,11 +2,12 @@ package config
 
 import (
 	"fmt"
-	"github.com/babylonlabs-io/babylon/client/babylonclient"
 	"net/url"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/babylonlabs-io/babylon/client/babylonclient"
 )
 
 // BabylonConfig defines configuration for the Babylon client
@@ -36,8 +37,8 @@ func (cfg *BabylonConfig) Validate() error {
 	if cfg.Timeout <= 0 {
 		return fmt.Errorf("timeout must be positive")
 	}
-	if cfg.BlockTimeout < 0 {
-		return fmt.Errorf("block-timeout can't be negative")
+	if cfg.BlockTimeout <= 0 {
+		return fmt.Errorf("block-timeout must be positive")
 	}
 	return nil
 }
@@ -77,6 +78,7 @@ func DefaultBabylonConfig() BabylonConfig {
 		KeyDirectory:     defaultBabylonHome(),
 		Debug:            true,
 		Timeout:          20 * time.Second,
+		BlockTimeout:     10 * time.Minute,
 		OutputFormat:     "json",
 		SignModeStr:      "direct",
 		SubmitterAddress: "bbn1v6k7k9s8md3k29cu9runasstq5zaa0lpznk27w", // this is currently a placeholder, will not recognized by Babylon


### PR DESCRIPTION
- Default value of `BlockTimeout` was `0` and this makes any tx broadcasted in block mode fail immediately. This was found when debugging https://github.com/babylonlabs-io/babylon-sdk/pull/95
- The `Validate()` function only ensured `BlockTimeout` is not negative. Rather it should be positive and cannot be 0