### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/x/btccheckpoint/types/btcutils.go
+++ b/x/btccheckpoint/types/btcutils.go
@@ -36,13 +36,6 @@ func hashConcat(a []byte, b []byte) chainhash.Hash {
 	return chainhash.DoubleHashH(c)
 }
 
-func min(a, b uint) uint {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // createBranch takes as input flatenned representation of merkle tree i.e
 // for tree:
 //


### PR DESCRIPTION
Use the built-in min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#min