### PR TITLE
limit number of finalized and rewarded blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ check of rewards
 - [#624](https://github.com/babylonlabs-io/babylon/pull/624) Make keeper's collections private in `x/incentive` module
 - [#643](https://github.com/babylonlabs-io/babylon/pull/643) Fix flaky test `FuzzBTCDelegation`
 - [#696](https://github.com/babylonlabs-io/babylon/pull/696) Restore zoneconcierge queries in query client
+- [#745](https://github.com/babylonlabs-io/babylon/pull/745) Hard limit of the number of finalized
+and rewarded blocks
 
 ### State Machine Breaking
 

--- a/x/finality/abci.go
+++ b/x/finality/abci.go
@@ -27,7 +27,7 @@ func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, e
 		// index the current block
 		k.IndexBlock(ctx)
 		// tally all non-finalised blocks
-		k.TallyBlocks(ctx)
+		k.TallyBlocks(ctx, types.MaxFinalizedRewardedBlocksPerEndBlock)
 
 		// detect sluggish finality providers if there are any
 		// heightToExamine is determined by the current height - params.FinalitySigTimeout
@@ -40,7 +40,7 @@ func EndBlocker(ctx context.Context, k keeper.Keeper) ([]abci.ValidatorUpdate, e
 		if heightToExamine >= 1 {
 			k.HandleLiveness(ctx, heightToExamine)
 
-			k.HandleRewarding(ctx, heightToExamine)
+			k.HandleRewarding(ctx, heightToExamine, types.MaxFinalizedRewardedBlocksPerEndBlock)
 		}
 	}
 

--- a/x/finality/keeper/gov.go
+++ b/x/finality/keeper/gov.go
@@ -8,6 +8,7 @@ import (
 
 	bbntypes "github.com/babylonlabs-io/babylon/types"
 	bstypes "github.com/babylonlabs-io/babylon/x/btcstaking/types"
+	"github.com/babylonlabs-io/babylon/x/finality/types"
 )
 
 // HandleResumeFinalityProposal handles the resume finality proposal in the following steps:
@@ -85,7 +86,7 @@ func (k Keeper) HandleResumeFinalityProposal(ctx sdk.Context, fpPksHex []string,
 		k.SetVotingPowerDistCache(ctx, h, distCache)
 	}
 
-	k.TallyBlocks(ctx)
+	k.TallyBlocks(ctx, types.MaxFinalizedRewardedBlocksPerEndBlock)
 
 	return nil
 }

--- a/x/finality/keeper/gov_test.go
+++ b/x/finality/keeper/gov_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -60,7 +59,7 @@ func TestHandleResumeFinalityProposal(t *testing.T) {
 	// tally blocks and none of them should be finalised
 	iKeeper.EXPECT().RewardBTCStaking(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return().AnyTimes()
 	ctx = datagen.WithCtxHeight(ctx, currentHeight)
-	fKeeper.TallyBlocks(ctx, math.MaxUint64)
+	fKeeper.TallyBlocks(ctx, uint64(10000))
 	for i := haltingHeight; i < currentHeight; i++ {
 		ib, err := fKeeper.GetBlock(ctx, i)
 		require.NoError(t, err)

--- a/x/finality/keeper/gov_test.go
+++ b/x/finality/keeper/gov_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -59,7 +60,7 @@ func TestHandleResumeFinalityProposal(t *testing.T) {
 	// tally blocks and none of them should be finalised
 	iKeeper.EXPECT().RewardBTCStaking(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return().AnyTimes()
 	ctx = datagen.WithCtxHeight(ctx, currentHeight)
-	fKeeper.TallyBlocks(ctx)
+	fKeeper.TallyBlocks(ctx, math.MaxUint64)
 	for i := haltingHeight; i < currentHeight; i++ {
 		ib, err := fKeeper.GetBlock(ctx, i)
 		require.NoError(t, err)

--- a/x/finality/keeper/rewarding.go
+++ b/x/finality/keeper/rewarding.go
@@ -25,7 +25,8 @@ func (k Keeper) HandleRewarding(ctx context.Context, targetHeight int64, maxRewa
 	}
 
 	maxHeightToReward := min(
-		nextHeightToReward+maxRewardedBlocks,
+		// need to add minus 1, as the rewarding loop is inclucive of [start, end]
+		nextHeightToReward+maxRewardedBlocks-1,
 		uint64(targetHeight),
 	)
 

--- a/x/finality/keeper/rewarding.go
+++ b/x/finality/keeper/rewarding.go
@@ -10,7 +10,7 @@ import (
 )
 
 // HandleRewarding calls the reward to stakers if the block is finalized
-func (k Keeper) HandleRewarding(ctx context.Context, targetHeight int64) {
+func (k Keeper) HandleRewarding(ctx context.Context, targetHeight int64, maxRewardedBlocks uint64) {
 	// rewarding is executed in a range of [nextHeightToReward, heightToExamine]
 	// this is we don't know when a block will be finalized and we need ensure
 	// every finalized block will be processed to reward
@@ -23,9 +23,15 @@ func (k Keeper) HandleRewarding(ctx context.Context, targetHeight int64) {
 		}
 		nextHeightToReward = activatedHeight
 	}
+
+	maxHeightToReward := min(
+		nextHeightToReward+maxRewardedBlocks,
+		uint64(targetHeight),
+	)
+
 	copiedNextHeightToReward := nextHeightToReward
 
-	for height := nextHeightToReward; height <= uint64(targetHeight); height++ {
+	for height := nextHeightToReward; height <= maxHeightToReward; height++ {
 		block, err := k.GetBlock(ctx, height)
 		if err != nil {
 			panic(err)

--- a/x/finality/keeper/rewarding_test.go
+++ b/x/finality/keeper/rewarding_test.go
@@ -165,3 +165,88 @@ func TestHandleRewardingWithGapsOfUnfinalizedBlocks(t *testing.T) {
 	actNextBlockToBeRewarded := fKeeper.GetNextHeightToReward(ctx)
 	require.Equal(t, uint64(4), actNextBlockToBeRewarded)
 }
+
+func FuzzHandleRewardingLimits(f *testing.F) {
+	datagen.AddRandomSeedsToFuzzer(f, 10)
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// Setup keepers
+		bsKeeper := types.NewMockBTCStakingKeeper(ctrl)
+		iKeeper := types.NewMockIncentiveKeeper(ctrl)
+		cKeeper := types.NewMockCheckpointingKeeper(ctrl)
+		fKeeper, ctx := keepertest.FinalityKeeper(t, bsKeeper, iKeeper, cKeeper)
+
+		// Activate BTC staking protocol at a random height
+		activatedHeight := datagen.RandomInt(r, 10) + 1
+		fpPK, err := datagen.GenRandomBIP340PubKey(r)
+		require.NoError(t, err)
+		fKeeper.SetVotingPower(ctx, fpPK.MustMarshal(), activatedHeight, 1)
+
+		totalBlocks := uint64(100)
+		targetHeight := activatedHeight + totalBlocks - 1
+
+		// First phase: Index blocks with none finalized
+		for i := activatedHeight; i <= targetHeight; i++ {
+			fKeeper.SetBlock(ctx, &types.IndexedBlock{
+				Height:    i,
+				AppHash:   datagen.GenRandomByteArray(r, 32),
+				Finalized: false,
+			})
+
+			// Set voting power distribution cache for each height
+			dc := types.NewVotingPowerDistCache()
+			dc.AddFinalityProviderDistInfo(&types.FinalityProviderDistInfo{
+				BtcPk:          fpPK,
+				TotalBondedSat: 1,
+			})
+			fKeeper.SetVotingPowerDistCache(ctx, i, dc)
+		}
+
+		nextHeight := fKeeper.GetNextHeightToReward(ctx)
+		require.Zero(t, nextHeight,
+			"next height is not updated when no blocks finalized. Act: %d", nextHeight)
+
+		// Second phase: Finalize some blocks
+		limit := uint64(10)
+		firstBatchFinalized := uint64(50)
+		for i := activatedHeight; i < activatedHeight+firstBatchFinalized; i++ {
+			block, err := fKeeper.GetBlock(ctx, i)
+			require.NoError(t, err)
+			block.Finalized = true
+			fKeeper.SetBlock(ctx, block)
+		}
+
+		// Expect rewards for first batch of finalized blocks
+		iKeeper.EXPECT().
+			RewardBTCStaking(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return().
+			Times(int(limit))
+
+		// Second call to HandleRewarding
+		fKeeper.HandleRewarding(ctx, int64(targetHeight), limit)
+
+		nextHeight = fKeeper.GetNextHeightToReward(ctx)
+		expectedNextHeight := activatedHeight + limit
+		require.Equal(t, expectedNextHeight, nextHeight,
+			"next height should be after first batch of finalized blocks. Exp: %d, Act: %d", expectedNextHeight, nextHeight)
+
+		// Expect rewards for second batch of finalized blocks
+		iKeeper.EXPECT().
+			RewardBTCStaking(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return().
+			Times(int(limit))
+
+		// Final call to HandleRewarding
+		fKeeper.HandleRewarding(ctx, int64(targetHeight), limit)
+
+		// Verify final state
+		finalNextHeight := fKeeper.GetNextHeightToReward(ctx)
+		expectedFinalHeight := expectedNextHeight + limit
+		require.Equal(t, expectedFinalHeight, finalNextHeight,
+			"next height should be after second batch of finalized blocks")
+	})
+}

--- a/x/finality/keeper/rewarding_test.go
+++ b/x/finality/keeper/rewarding_test.go
@@ -55,7 +55,7 @@ func FuzzHandleRewarding(f *testing.F) {
 
 		// First call to HandleRewarding - expect no rewards
 		ctx = datagen.WithCtxHeight(ctx, targetHeight)
-		fKeeper.HandleRewarding(ctx, int64(targetHeight))
+		fKeeper.HandleRewarding(ctx, int64(targetHeight), uint64(10000))
 
 		nextHeight := fKeeper.GetNextHeightToReward(ctx)
 		require.Zero(t, nextHeight,
@@ -77,7 +77,7 @@ func FuzzHandleRewarding(f *testing.F) {
 			Times(int(firstBatchFinalized))
 
 		// Second call to HandleRewarding
-		fKeeper.HandleRewarding(ctx, int64(targetHeight))
+		fKeeper.HandleRewarding(ctx, int64(targetHeight), uint64(10000))
 
 		nextHeight = fKeeper.GetNextHeightToReward(ctx)
 		expectedNextHeight := activatedHeight + firstBatchFinalized
@@ -100,7 +100,7 @@ func FuzzHandleRewarding(f *testing.F) {
 			Times(int(secondBatchFinalized))
 
 		// Final call to HandleRewarding
-		fKeeper.HandleRewarding(ctx, int64(targetHeight))
+		fKeeper.HandleRewarding(ctx, int64(targetHeight), uint64(10000))
 
 		// Verify final state
 		finalNextHeight := fKeeper.GetNextHeightToReward(ctx)
@@ -160,7 +160,7 @@ func TestHandleRewardingWithGapsOfUnfinalizedBlocks(t *testing.T) {
 		Return().
 		Times(2) // number of finalized blocks processed
 
-	fKeeper.HandleRewarding(ctx, 3)
+	fKeeper.HandleRewarding(ctx, 3, uint64(10000))
 
 	actNextBlockToBeRewarded := fKeeper.GetNextHeightToReward(ctx)
 	require.Equal(t, uint64(4), actNextBlockToBeRewarded)

--- a/x/finality/keeper/tallying.go
+++ b/x/finality/keeper/tallying.go
@@ -17,7 +17,7 @@ import (
 // - finalised blocks (i.e., block with finality provider set AND QC of this finality provider set)
 // - non-finalisable blocks (i.e., block with no active finality providers)
 // but without block that has finality providers set AND does not receive QC
-func (k Keeper) TallyBlocks(ctx context.Context) {
+func (k Keeper) TallyBlocks(ctx context.Context, maxFinalizedBlocks uint64) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	activatedHeight, err := k.GetBTCStakingActivatedHeight(ctx)
 	if err != nil {
@@ -32,6 +32,9 @@ func (k Keeper) TallyBlocks(ctx context.Context) {
 		startHeight = activatedHeight
 	}
 
+	lastBlockHeight := uint64(sdkCtx.HeaderInfo().Height)
+	maxHeightToFinalize := min(startHeight+maxFinalizedBlocks, lastBlockHeight)
+
 	// find all blocks that are non-finalised AND have finality provider set since max(activatedHeight, lastFinalizedHeight+1)
 	// There are 4 different scenarios as follows
 	// - has finality providers, non-finalised: tally and try to finalise
@@ -40,7 +43,7 @@ func (k Keeper) TallyBlocks(ctx context.Context) {
 	// - does not have finality providers, finalised: impossible to happen, panic
 	// After this for loop, the blocks since earliest activated height are either finalised or non-finalisable
 finalizationLoop:
-	for i := startHeight; i <= uint64(sdkCtx.HeaderInfo().Height); i++ {
+	for i := startHeight; i <= maxHeightToFinalize; i++ {
 		ib, err := k.GetBlock(ctx, i)
 		if err != nil {
 			panic(err) // failing to get an existing block is a programming error

--- a/x/finality/keeper/tallying.go
+++ b/x/finality/keeper/tallying.go
@@ -32,8 +32,9 @@ func (k Keeper) TallyBlocks(ctx context.Context, maxFinalizedBlocks uint64) {
 		startHeight = activatedHeight
 	}
 
-	lastBlockHeight := uint64(sdkCtx.HeaderInfo().Height)
-	maxHeightToFinalize := min(startHeight+maxFinalizedBlocks, lastBlockHeight)
+	currentLastBlockHeight := uint64(sdkCtx.HeaderInfo().Height)
+	// need to add minus 1, as the tallying loop is inclucive of [start, end]
+	maxHeightToFinalize := min(startHeight+maxFinalizedBlocks-1, currentLastBlockHeight)
 
 	// find all blocks that are non-finalised AND have finality provider set since max(activatedHeight, lastFinalizedHeight+1)
 	// There are 4 different scenarios as follows

--- a/x/finality/keeper/tallying_bench_test.go
+++ b/x/finality/keeper/tallying_bench_test.go
@@ -2,7 +2,6 @@ package keeper_test
 
 import (
 	"fmt"
-	"math"
 	"math/rand"
 	"os"
 	"runtime/pprof"
@@ -83,7 +82,7 @@ func benchmarkTallyBlocks(b *testing.B, numFPs int) {
 
 		b.StartTimer()
 
-		fKeeper.TallyBlocks(ctx, math.MaxUint64)
+		fKeeper.TallyBlocks(ctx, uint64(10000))
 	}
 }
 

--- a/x/finality/keeper/tallying_bench_test.go
+++ b/x/finality/keeper/tallying_bench_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"runtime/pprof"
@@ -82,7 +83,7 @@ func benchmarkTallyBlocks(b *testing.B, numFPs int) {
 
 		b.StartTimer()
 
-		fKeeper.TallyBlocks(ctx)
+		fKeeper.TallyBlocks(ctx, math.MaxUint64)
 	}
 }
 

--- a/x/finality/keeper/tallying_test.go
+++ b/x/finality/keeper/tallying_test.go
@@ -48,7 +48,7 @@ func FuzzTallying_FinalizingNoBlock(f *testing.F) {
 		fKeeper.SetVotingPower(ctx, datagen.GenRandomByteArray(r, 32), activatedHeight, 1)
 		// tally blocks and none of them should be finalised
 		ctx = datagen.WithCtxHeight(ctx, activatedHeight+10-1)
-		fKeeper.TallyBlocks(ctx)
+		fKeeper.TallyBlocks(ctx, uint64(10000))
 		for i := activatedHeight; i < activatedHeight+10; i++ {
 			ib, err := fKeeper.GetBlock(ctx, i)
 			require.NoError(t, err)
@@ -95,7 +95,7 @@ func FuzzTallying_FinalizingSomeBlocks(f *testing.F) {
 		}
 		// tally blocks and none of them should be finalised
 		ctx = datagen.WithCtxHeight(ctx, activatedHeight+10-1)
-		fKeeper.TallyBlocks(ctx)
+		fKeeper.TallyBlocks(ctx, uint64(10000))
 		for i := activatedHeight; i < activatedHeight+10; i++ {
 			ib, err := fKeeper.GetBlock(ctx, i)
 			require.NoError(t, err)
@@ -208,7 +208,7 @@ func FuzzConsecutiveFinalization(f *testing.F) {
 		}
 
 		ctx = datagen.WithCtxHeight(ctx, activatedHeight+numBlockToInspect-1)
-		fKeeper.TallyBlocks(ctx)
+		fKeeper.TallyBlocks(ctx, uint64(10000))
 
 		// all blocks up to firstNonFinalizedBlock must be finalised
 		for i := activatedHeight; i < firstNonFinalizedBlock; i++ {

--- a/x/finality/keeper/tallying_test.go
+++ b/x/finality/keeper/tallying_test.go
@@ -108,6 +108,81 @@ func FuzzTallying_FinalizingSomeBlocks(f *testing.F) {
 	})
 }
 
+func FuzzTallying_FinalizingAtMostMaxFinalizedBlocks(f *testing.F) {
+	datagen.AddRandomSeedsToFuzzer(f, 10)
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		bsKeeper := types.NewMockBTCStakingKeeper(ctrl)
+		iKeeper := types.NewMockIncentiveKeeper(ctrl)
+		cKeeper := types.NewMockCheckpointingKeeper(ctrl)
+		fKeeper, ctx := keepertest.FinalityKeeper(t, bsKeeper, iKeeper, cKeeper)
+
+		// activate BTC staking protocol at a random height
+		activatedHeight := datagen.RandomInt(r, 10) + 1
+
+		// index a list of blocks, give some of them QCs, and tally them.
+		// Expect they are all finalised
+		limit := uint64(datagen.RandomInRange(r, 10, 20))
+		numWithQCs := uint64(datagen.RandomInRange(r, 50, 100))
+		totalBlocks := uint64(datagen.RandomInRange(r, 100, 200))
+		for i := activatedHeight; i < activatedHeight+totalBlocks; i++ {
+			// index blocks
+			fKeeper.SetBlock(ctx, &types.IndexedBlock{
+				Height:    i,
+				AppHash:   datagen.GenRandomByteArray(r, 32),
+				Finalized: false,
+			})
+			if i < activatedHeight+numWithQCs {
+				// this block has QC
+				err := giveQCToHeight(r, ctx, fKeeper, i)
+				require.NoError(t, err)
+			} else {
+				// this block does not have QC
+				err := giveNoQCToHeight(r, ctx, fKeeper, i)
+				require.NoError(t, err)
+			}
+		}
+
+		for i := activatedHeight; i < activatedHeight+totalBlocks; i++ {
+			ib, err := fKeeper.GetBlock(ctx, i)
+			require.NoError(t, err)
+			require.False(t, ib.Finalized)
+		}
+
+		// tally blocks and only blocks up to limit should be finalised
+		ctx = datagen.WithCtxHeight(ctx, activatedHeight+totalBlocks-1)
+		fKeeper.TallyBlocks(ctx, limit)
+		for i := activatedHeight; i < activatedHeight+totalBlocks; i++ {
+			ib, err := fKeeper.GetBlock(ctx, i)
+			require.NoError(t, err)
+			// only limit blocks should be finalised
+			if i < activatedHeight+limit {
+				require.True(t, ib.Finalized)
+			} else {
+				require.False(t, ib.Finalized)
+			}
+		}
+
+		// next limit batch of blocks should be finalised
+		ctx = datagen.WithCtxHeight(ctx, activatedHeight+totalBlocks-1)
+		fKeeper.TallyBlocks(ctx, limit)
+		for i := activatedHeight + limit; i < activatedHeight+totalBlocks; i++ {
+			ib, err := fKeeper.GetBlock(ctx, i)
+			require.NoError(t, err)
+			// only limit blocks should be finalised
+			if i < activatedHeight+2*limit {
+				require.True(t, ib.Finalized)
+			} else {
+				require.False(t, ib.Finalized)
+			}
+		}
+	})
+}
+
 func giveQCToHeight(r *rand.Rand, ctx sdk.Context, fKeeper *keeper.Keeper, height uint64) error {
 	dc := types.NewVotingPowerDistCache()
 	// 3 votes

--- a/x/finality/types/constants.go
+++ b/x/finality/types/constants.go
@@ -1,0 +1,8 @@
+package types
+
+const (
+	// Setting max amount of finalized and rewarded blocks per EndBlock to 10000,
+	// with this setting, block processing times are <1s, even if BTC finality
+	// stalls a lot
+	MaxFinalizedRewardedBlocksPerEndBlock = uint64(10000)
+)

--- a/x/finality/types/finality.go
+++ b/x/finality/types/finality.go
@@ -10,6 +10,11 @@ import (
 	"github.com/babylonlabs-io/babylon/crypto/eots"
 )
 
+const (
+	// Maximal amount of block that can be finalized and rewarded in one EndBlocker
+	MaxFinalizedRewardedBlocksPerEndBlock = uint64(15000)
+)
+
 func (c *PubRandCommit) IsInRange(height uint64) bool {
 	start, end := c.Range()
 	return start <= height && height <= end

--- a/x/finality/types/finality.go
+++ b/x/finality/types/finality.go
@@ -10,11 +10,6 @@ import (
 	"github.com/babylonlabs-io/babylon/crypto/eots"
 )
 
-const (
-	// Maximal amount of block that can be finalized and rewarded in one EndBlocker
-	MaxFinalizedRewardedBlocksPerEndBlock = uint64(15000)
-)
-
 func (c *PubRandCommit) IsInRange(height uint64) bool {
 	start, end := c.Range()
 	return start <= height && height <= end


### PR DESCRIPTION
Add limit to number of finalized and rewarded blocks per call. This is needed to limit unbounded block processing times in case of finality stalling