### PR TITLE
chore: upgrade parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#746](https://github.com/babylonlabs-io/babylon/pull/746) Add mainnet parameters to v1 upgrade handler.
 - [#675](https://github.com/babylonlabs-io/babylon/pull/675) Add no-retries option to babylon client send msg.
 - [#623](https://github.com/babylonlabs-io/babylon/pull/623) Add check for empty string in `bls` loading.
 - [#536](https://github.com/babylonlabs-io/babylon/pull/536) Improve protobuf vs. json error msgs / types

--- a/app/include_upgrade_mainnet.go
+++ b/app/include_upgrade_mainnet.go
@@ -18,5 +18,5 @@ func init() {
 		NewBtcHeadersStr:          mainnet.NewBtcHeadersStr,
 		TokensDistributionStr:     mainnet.TokensDistributionStr,
 		AllowedStakingTxHashesStr: mainnet.AllowedStakingTxHashesStr,
-	}, nil)}
+	}, mainnet.MainnetParamUpgrade)}
 }

--- a/app/include_upgrade_mainnet.go
+++ b/app/include_upgrade_mainnet.go
@@ -18,5 +18,5 @@ func init() {
 		NewBtcHeadersStr:          mainnet.NewBtcHeadersStr,
 		TokensDistributionStr:     mainnet.TokensDistributionStr,
 		AllowedStakingTxHashesStr: mainnet.AllowedStakingTxHashesStr,
-	}, mainnet.MainnetParamUpgrade)}
+	}, mainnet.ParamUpgrade)}
 }

--- a/app/include_upgrade_testnet.go
+++ b/app/include_upgrade_testnet.go
@@ -23,7 +23,7 @@ func init() {
 			NewBtcHeadersStr:          testnet.NewBtcHeadersStr,
 			TokensDistributionStr:     testnet.TokensDistributionStr,
 			AllowedStakingTxHashesStr: testnet.AllowedStakingTxHashesStr,
-		}, testnet.TestnetParamUpgrade),
+		}, testnet.ParamUpgrade),
 		v1rc5.CreateUpgrade(),
 		v1rc8.CreateUpgrade(),
 		v1rc9.CreateUpgrade(),

--- a/app/upgrades/v1/data_params_test.go
+++ b/app/upgrades/v1/data_params_test.go
@@ -24,10 +24,10 @@ func TestHardCodedBtcStakingParamsAreValid(t *testing.T) {
 		params, err := v1.LoadBtcStakingParamsFromData(upgradeData.BtcStakingParamsStr)
 		require.NoError(t, err)
 
-		for _, p := range params {
+		for i, p := range params {
 			// using set Params here makes sure the parameters in the upgrade string are consistent
 			err = k.SetParams(ctx, p)
-			require.NoError(t, err)
+			require.NoError(t, err, "error set params version %d to set params %+v", i, params)
 		}
 	}
 }

--- a/app/upgrades/v1/data_params_test.go
+++ b/app/upgrades/v1/data_params_test.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/store"
 	storemetrics "cosmossdk.io/store/metrics"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/btcsuite/btcd/txscript"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/stretchr/testify/require"
 
@@ -50,4 +51,24 @@ func TestHardCodedWasmParamsAreValid(t *testing.T) {
 		require.NotNil(t, params)
 		require.Equal(t, params.InstantiateDefaultPermission, wasmtypes.AccessTypeEverybody)
 	}
+}
+
+func TestSlashingScriptMainnet(t *testing.T) {
+	db := dbm.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db, log.NewTestLogger(t), storemetrics.NewNoOpMetrics())
+	k, ctx := testutilk.BTCStakingKeeperWithStore(t, db, stateStore, nil, nil, nil, nil)
+
+	params, err := v1.LoadBtcStakingParamsFromData(UpgradeV1DataMainnet.BtcStakingParamsStr)
+	require.NoError(t, err)
+
+	for i, p := range params {
+		// using set Params here makes sure the parameters in the upgrade string are consistent
+		err = k.SetParams(ctx, p)
+		require.NoError(t, err, "error set params version %d to set params %+v", i, params)
+	}
+
+	lastParam := k.GetParams(ctx)
+	slashScript, err := txscript.NullDataScript([]byte("babylon"))
+	require.NoError(t, err)
+	require.Equal(t, lastParam.SlashingPkScript, slashScript)
 }

--- a/app/upgrades/v1/data_token_distribution_test.go
+++ b/app/upgrades/v1/data_token_distribution_test.go
@@ -12,7 +12,6 @@ func TestCheckTokensDistributionFromData(t *testing.T) {
 	for _, upgradeData := range UpgradeV1Data {
 		d, err := v1.LoadTokenDistributionFromData(upgradeData.TokensDistributionStr)
 		require.NoError(t, err)
-		require.Greater(t, len(d.TokenDistribution), 1)
 
 		for _, td := range d.TokenDistribution {
 			sender, err := sdk.AccAddressFromBech32(td.AddressSender)

--- a/app/upgrades/v1/mainnet/btcstaking_params.go
+++ b/app/upgrades/v1/mainnet/btcstaking_params.go
@@ -1,28 +1,33 @@
 package mainnet
 
-// TODO Some default parameters
+// TBD
+// - btc_activation_height
 const BtcStakingParamsStr = `[
   {
     "covenant_pks": [
-      "43311589af63c2adda04fcd7792c038a05c12a4fe40351b3eb1612ff6b2e5a0e",
-      "d415b187c6e7ce9da46ac888d20df20737d6f16a41639e68ea055311e1535dd9",
-      "d27cd27dbff481bc6fc4aa39dd19405eb6010237784ecba13bab130a4a62df5d",
-      "a3e107fee8879f5cf901161dbf4ff61c252ba5fec6f6407fe81b9453d244c02c",
-      "c45753e856ad0abb06f68947604f11476c157d13b7efd54499eaa0f6918cf716"
+      "d45c70d28f169e1f0c7f4a78e2bc73497afe585b70aa897955989068f3350aaa",
+      "4b15848e495a3a62283daaadb3f458a00859fe48e321f0121ebabbdd6698f9fa",
+      "23b29f89b45f4af41588dcaf0ca572ada32872a88224f311373917f1b37d08d1",
+      "d3c79b99ac4d265c2f97ac11e3232c07a598b020cf56c6f055472c893c0967ae",
+      "8242640732773249312c47ca7bdb50ca79f15f2ecc32b9c83ceebba44fb74df7",
+      "e36200aaa8dce9453567bba108bdc51f7f1174b97a65e4dc4402fc5de779d41c",
+      "f178fcce82f95c524b53b077e6180bd2d779a9057fdff4255a0af95af918cee0",
+      "de13fc96ea6899acbdc5db3afaa683f62fe35b60ff6eb723dad28a11d2b12f8c",
+      "cbdd028cfe32c1c1f2d84bfec71e19f92df509bba7b8ad31ca6c1a134fe09204"
     ],
-    "covenant_quorum": 3,
-    "min_staking_value_sat": 10000,
-    "max_staking_value_sat": 10000000000,
-    "min_staking_time_blocks": 10,
-    "max_staking_time_blocks": 65535,
-    "slashing_pk_script": "dqkUAQEBAQEBAQEBAQEBAQEBAQEBAQGIrA==",
-    "min_slashing_tx_fee_sat": 1000,
-    "slashing_rate": "0.100000000000000000",
-    "unbonding_time_blocks": 101,
-    "unbonding_fee_sat": 1000,
+    "covenant_quorum": 6,
+    "min_staking_value_sat": 500000,
+    "max_staking_value_sat": 500000000000,
+    "min_staking_time_blocks": 64000,
+    "max_staking_time_blocks": 64000,
+    "slashing_pk_script": "agdiYWJ5bG9u",
+    "min_slashing_tx_fee_sat": 100000,
+    "slashing_rate": "0.001",
+    "unbonding_time_blocks": 1008,
+    "unbonding_fee_sat": 32000,
     "min_commission_rate": "0.03",
-    "delegation_creation_base_gas_fee": 1000,
-    "allow_list_expiration_height": 0,
-    "btc_activation_height": 100
+    "delegation_creation_base_gas_fee": 1095000,
+    "allow_list_expiration_height": 129800,
+    "btc_activation_height": 500
   }
 ]`

--- a/app/upgrades/v1/mainnet/btcstaking_params.go
+++ b/app/upgrades/v1/mainnet/btcstaking_params.go
@@ -70,8 +70,8 @@ const BtcStakingParamsStr = `[
       "de13fc96ea6899acbdc5db3afaa683f62fe35b60ff6eb723dad28a11d2b12f8c"
     ],
     "covenant_quorum": 6,
-    "min_staking_value_sat": 500000000000,
-    "max_staking_value_sat": 500000,
+    "min_staking_value_sat": 500000,
+    "max_staking_value_sat": 500000000000,
     "min_staking_time_blocks": 64000,
     "max_staking_time_blocks": 64000,
     "slashing_pk_script": "agdiYWJ5bG9u",

--- a/app/upgrades/v1/mainnet/btcstaking_params.go
+++ b/app/upgrades/v1/mainnet/btcstaking_params.go
@@ -1,8 +1,89 @@
 package mainnet
 
-// TBD
-// - btc_activation_height
+// TBD for last parameter version
+// - btc_activation_height, set as 893434 btc block as somewhere in mid april
 const BtcStakingParamsStr = `[
+  {
+    "covenant_pks": [
+      "d45c70d28f169e1f0c7f4a78e2bc73497afe585b70aa897955989068f3350aaa",
+      "4b15848e495a3a62283daaadb3f458a00859fe48e321f0121ebabbdd6698f9fa",
+      "23b29f89b45f4af41588dcaf0ca572ada32872a88224f311373917f1b37d08d1",
+      "d3c79b99ac4d265c2f97ac11e3232c07a598b020cf56c6f055472c893c0967ae",
+      "8242640732773249312c47ca7bdb50ca79f15f2ecc32b9c83ceebba44fb74df7",
+      "e36200aaa8dce9453567bba108bdc51f7f1174b97a65e4dc4402fc5de779d41c",
+      "cbdd028cfe32c1c1f2d84bfec71e19f92df509bba7b8ad31ca6c1a134fe09204",
+      "f178fcce82f95c524b53b077e6180bd2d779a9057fdff4255a0af95af918cee0",
+      "de13fc96ea6899acbdc5db3afaa683f62fe35b60ff6eb723dad28a11d2b12f8c"
+    ],
+    "covenant_quorum": 6,
+    "min_staking_value_sat": 500000,
+    "max_staking_value_sat": 5000000,
+    "min_staking_time_blocks": 64000,
+    "max_staking_time_blocks": 64000,
+    "slashing_pk_script": "agdiYWJ5bG9u",
+    "min_slashing_tx_fee_sat": 100000,
+    "slashing_rate": "0.001",
+    "unbonding_time_blocks": 1008,
+    "unbonding_fee_sat": 64000,
+    "min_commission_rate": "0.03",
+    "delegation_creation_base_gas_fee": 1095000,
+    "allow_list_expiration_height": 0,
+    "btc_activation_height": 857910
+  },
+  {
+    "covenant_pks": [
+      "d45c70d28f169e1f0c7f4a78e2bc73497afe585b70aa897955989068f3350aaa",
+      "4b15848e495a3a62283daaadb3f458a00859fe48e321f0121ebabbdd6698f9fa",
+      "23b29f89b45f4af41588dcaf0ca572ada32872a88224f311373917f1b37d08d1",
+      "d3c79b99ac4d265c2f97ac11e3232c07a598b020cf56c6f055472c893c0967ae",
+      "8242640732773249312c47ca7bdb50ca79f15f2ecc32b9c83ceebba44fb74df7",
+      "e36200aaa8dce9453567bba108bdc51f7f1174b97a65e4dc4402fc5de779d41c",
+      "cbdd028cfe32c1c1f2d84bfec71e19f92df509bba7b8ad31ca6c1a134fe09204",
+      "f178fcce82f95c524b53b077e6180bd2d779a9057fdff4255a0af95af918cee0",
+      "de13fc96ea6899acbdc5db3afaa683f62fe35b60ff6eb723dad28a11d2b12f8c"
+    ],
+    "covenant_quorum": 6,
+    "min_staking_value_sat": 500000,
+    "max_staking_value_sat": 50000000000,
+    "min_staking_time_blocks": 64000,
+    "max_staking_time_blocks": 64000,
+    "slashing_pk_script": "agdiYWJ5bG9u",
+    "min_slashing_tx_fee_sat": 100000,
+    "slashing_rate": "0.001",
+    "unbonding_time_blocks": 1008,
+    "unbonding_fee_sat": 32000,
+    "min_commission_rate": "0.03",
+    "delegation_creation_base_gas_fee": 1095000,
+    "allow_list_expiration_height": 0,
+    "btc_activation_height": 864790
+  },
+  {
+    "covenant_pks": [
+      "d45c70d28f169e1f0c7f4a78e2bc73497afe585b70aa897955989068f3350aaa",
+      "4b15848e495a3a62283daaadb3f458a00859fe48e321f0121ebabbdd6698f9fa",
+      "23b29f89b45f4af41588dcaf0ca572ada32872a88224f311373917f1b37d08d1",
+      "d3c79b99ac4d265c2f97ac11e3232c07a598b020cf56c6f055472c893c0967ae",
+      "8242640732773249312c47ca7bdb50ca79f15f2ecc32b9c83ceebba44fb74df7",
+      "e36200aaa8dce9453567bba108bdc51f7f1174b97a65e4dc4402fc5de779d41c",
+      "cbdd028cfe32c1c1f2d84bfec71e19f92df509bba7b8ad31ca6c1a134fe09204",
+      "f178fcce82f95c524b53b077e6180bd2d779a9057fdff4255a0af95af918cee0",
+      "de13fc96ea6899acbdc5db3afaa683f62fe35b60ff6eb723dad28a11d2b12f8c"
+    ],
+    "covenant_quorum": 6,
+    "min_staking_value_sat": 500000000000,
+    "max_staking_value_sat": 500000,
+    "min_staking_time_blocks": 64000,
+    "max_staking_time_blocks": 64000,
+    "slashing_pk_script": "agdiYWJ5bG9u",
+    "min_slashing_tx_fee_sat": 100000,
+    "slashing_rate": "0.001",
+    "unbonding_time_blocks": 1008,
+    "unbonding_fee_sat": 32000,
+    "min_commission_rate": "0.03",
+    "delegation_creation_base_gas_fee": 1095000,
+    "allow_list_expiration_height": 0,
+    "btc_activation_height": 874088
+  },
   {
     "covenant_pks": [
       "d45c70d28f169e1f0c7f4a78e2bc73497afe585b70aa897955989068f3350aaa",
@@ -28,6 +109,6 @@ const BtcStakingParamsStr = `[
     "min_commission_rate": "0.03",
     "delegation_creation_base_gas_fee": 1095000,
     "allow_list_expiration_height": 129800,
-    "btc_activation_height": 500
+    "btc_activation_height": 893434
   }
 ]`

--- a/app/upgrades/v1/mainnet/btcstaking_params.go
+++ b/app/upgrades/v1/mainnet/btcstaking_params.go
@@ -109,6 +109,6 @@ const BtcStakingParamsStr = `[
     "min_commission_rate": "0.03",
     "delegation_creation_base_gas_fee": 1095000,
     "allow_list_expiration_height": 129800,
-    "btc_activation_height": 893434
+    "btc_activation_height": 891842
   }
 ]`

--- a/app/upgrades/v1/mainnet/btcstaking_params.go
+++ b/app/upgrades/v1/mainnet/btcstaking_params.go
@@ -1,7 +1,7 @@
 package mainnet
 
 // TBD for last parameter version
-// - btc_activation_height, set as 893434 btc block as somewhere in mid april
+// - btc_activation_height
 const BtcStakingParamsStr = `[
   {
     "covenant_pks": [

--- a/app/upgrades/v1/mainnet/btcstaking_params.go
+++ b/app/upgrades/v1/mainnet/btcstaking_params.go
@@ -27,7 +27,7 @@ const BtcStakingParamsStr = `[
     "unbonding_fee_sat": 64000,
     "min_commission_rate": "0.03",
     "delegation_creation_base_gas_fee": 1095000,
-    "allow_list_expiration_height": 0,
+    "allow_list_expiration_height": 129800,
     "btc_activation_height": 857910
   },
   {
@@ -54,7 +54,7 @@ const BtcStakingParamsStr = `[
     "unbonding_fee_sat": 32000,
     "min_commission_rate": "0.03",
     "delegation_creation_base_gas_fee": 1095000,
-    "allow_list_expiration_height": 0,
+    "allow_list_expiration_height": 129800,
     "btc_activation_height": 864790
   },
   {
@@ -81,7 +81,7 @@ const BtcStakingParamsStr = `[
     "unbonding_fee_sat": 32000,
     "min_commission_rate": "0.03",
     "delegation_creation_base_gas_fee": 1095000,
-    "allow_list_expiration_height": 0,
+    "allow_list_expiration_height": 129800,
     "btc_activation_height": 874088
   },
   {

--- a/app/upgrades/v1/mainnet/finality_params.go
+++ b/app/upgrades/v1/mainnet/finality_params.go
@@ -7,5 +7,5 @@ const FinalityParamStr = `{
   "min_signed_per_window": "0.3",
   "min_pub_rand": 8192,
   "jail_duration": "600s",
-  "finality_activation_height": 17480
+  "finality_activation_height": 17500
 }`

--- a/app/upgrades/v1/mainnet/finality_params.go
+++ b/app/upgrades/v1/mainnet/finality_params.go
@@ -4,7 +4,7 @@ const FinalityParamStr = `{
   "max_active_finality_providers": 60,
   "signed_blocks_window": 10000,
   "finality_sig_timeout": 3,
-  "min_signed_per_window": "0.3",
+  "min_signed_per_window": "0.2",
   "min_pub_rand": 8192,
   "jail_duration": "600s",
   "finality_activation_height": 17500

--- a/app/upgrades/v1/mainnet/finality_params.go
+++ b/app/upgrades/v1/mainnet/finality_params.go
@@ -1,13 +1,11 @@
 package mainnet
 
-// TODO Some default parameters. Consider how to switch those depending on network:
-// mainnet, testnet, devnet etc.
 const FinalityParamStr = `{
-  "max_active_finality_providers": 100,
-  "signed_blocks_window": 100,
+  "max_active_finality_providers": 60,
+  "signed_blocks_window": 10000,
   "finality_sig_timeout": 3,
-  "min_signed_per_window": "0.1",
-  "min_pub_rand": 100,
-  "jail_duration": "86400s",
-  "finality_activation_height": 17500
+  "min_signed_per_window": "0.3",
+  "min_pub_rand": 8192,
+  "jail_duration": "600s",
+  "finality_activation_height": 17480
 }`

--- a/app/upgrades/v1/mainnet/incentive.go
+++ b/app/upgrades/v1/mainnet/incentive.go
@@ -1,5 +1,5 @@
 package mainnet
 
 const IncentiveParamStr = `{
-  "btc_staking_portion": "0.3"
+  "btc_staking_portion": "0.5"
 }`

--- a/app/upgrades/v1/mainnet/incentive.go
+++ b/app/upgrades/v1/mainnet/incentive.go
@@ -1,5 +1,5 @@
 package mainnet
 
 const IncentiveParamStr = `{
-  "btc_staking_portion": "0.6"
+  "btc_staking_portion": "0.3"
 }`

--- a/app/upgrades/v1/mainnet/params_update.go
+++ b/app/upgrades/v1/mainnet/params_update.go
@@ -24,13 +24,14 @@ var (
 	MainnetMinDeposit = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(50_000_000000))
 	// 200k BBN
 	MainnetMaxDepositPeriod      = 14 * 24 * time.Hour
-	MainnetExpeditedMinDeposit   = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(200_000_000000))
 	MainnetExpeditedVotingPeriod = 24 * time.Hour
+	MainnetExpeditedMinDeposit   = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(200_000_000000))
 
 	// Consensus params
-	TestnetBlockGasLimit = int64(250000000)
+	MainnetBlockGasLimit = int64(300000000)
 	// Staking params
-	TestnetMinCommissionRate, _ = sdkmath.LegacyNewDecFromStr("0.03")
+	MainnetMinCommissionRate, _ = sdkmath.LegacyNewDecFromStr("0.03")
+
 	// Distribution params
 	TestnetCommunityTax, _ = sdkmath.LegacyNewDecFromStr("0.001")
 	// BTC checkpoint params
@@ -41,7 +42,7 @@ var (
 
 // MainnetParamUpgrade make updates to specific params of specific modules
 func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
-
+	// update slashing params
 	slashingParams, err := k.SlashingKeeper.GetParams(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get slash params: %w", err)
@@ -77,7 +78,7 @@ func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 		return fmt.Errorf("failed to get consensus params: %w", err)
 	}
 
-	consensusParams.Block.MaxGas = TestnetBlockGasLimit
+	consensusParams.Block.MaxGas = MainnetBlockGasLimit
 
 	if err := k.ConsensusParamsKeeper.ParamsStore.Set(ctx, consensusParams); err != nil {
 		return fmt.Errorf("failed to set consensus params: %w", err)
@@ -89,7 +90,7 @@ func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 		return fmt.Errorf("failed to get staking params: %w", err)
 	}
 
-	stakingParams.MinCommissionRate = TestnetMinCommissionRate
+	stakingParams.MinCommissionRate = MainnetMinCommissionRate
 
 	if err := k.StakingKeeper.SetParams(ctx, stakingParams); err != nil {
 		return fmt.Errorf("failed to set staking params: %w", err)

--- a/app/upgrades/v1/mainnet/params_update.go
+++ b/app/upgrades/v1/mainnet/params_update.go
@@ -1,0 +1,129 @@
+package mainnet
+
+import (
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
+	"github.com/babylonlabs-io/babylon/app/keepers"
+	appparams "github.com/babylonlabs-io/babylon/app/params"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var (
+	// Slashing params
+	MainnetMinSignedBlocks, _    = sdkmath.LegacyNewDecFromStr("0.6")
+	MainnetSlashFractionDowntime = sdkmath.LegacyZeroDec()
+	MainnetDowntimeJailDuration  = 300 * time.Second
+
+	// Governance params
+	MainnetVotingPeriod = 3 * 24 * time.Hour
+	// 50k BBN
+	MainnetMinDeposit = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(50_000_000000))
+	// 200k BBN
+	MainnetMaxDepositPeriod      = 14 * 24 * time.Hour
+	MainnetExpeditedMinDeposit   = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(200_000_000000))
+	MainnetExpeditedVotingPeriod = 24 * time.Hour
+
+	// Consensus params
+	TestnetBlockGasLimit = int64(250000000)
+	// Staking params
+	TestnetMinCommissionRate, _ = sdkmath.LegacyNewDecFromStr("0.03")
+	// Distribution params
+	TestnetCommunityTax, _ = sdkmath.LegacyNewDecFromStr("0.001")
+	// BTC checkpoint params
+	TestnetBTCCheckpointTag = hex.EncodeToString([]byte("bbt5"))
+	// Additional allow address to BTC light client
+	TestnetReporterAllowAddress = "bbn1cferwuxd95mdnyh4qnptahmzym0xt9sp9asqnw"
+)
+
+// MainnetParamUpgrade make updates to specific params of specific modules
+func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
+
+	slashingParams, err := k.SlashingKeeper.GetParams(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get slash params: %w", err)
+	}
+
+	slashingParams.MinSignedPerWindow = MainnetMinSignedBlocks
+	slashingParams.DowntimeJailDuration = MainnetDowntimeJailDuration
+	slashingParams.SlashFractionDowntime = MainnetSlashFractionDowntime
+
+	// update gov params
+	govParams, err := k.GovKeeper.Params.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get gov params: %w", err)
+	}
+
+	govParams.VotingPeriod = &MainnetVotingPeriod
+	govParams.ExpeditedVotingPeriod = &MainnetExpeditedVotingPeriod
+	govParams.MaxDepositPeriod = &MainnetMaxDepositPeriod
+	govParams.MinDeposit = []sdk.Coin{
+		MainnetMinDeposit,
+	}
+	govParams.ExpeditedMinDeposit = []sdk.Coin{
+		MainnetExpeditedMinDeposit,
+	}
+
+	if err := k.GovKeeper.Params.Set(ctx, govParams); err != nil {
+		return fmt.Errorf("failed to set gov params: %w", err)
+	}
+
+	// update consensus params
+	consensusParams, err := k.ConsensusParamsKeeper.ParamsStore.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get consensus params: %w", err)
+	}
+
+	consensusParams.Block.MaxGas = TestnetBlockGasLimit
+
+	if err := k.ConsensusParamsKeeper.ParamsStore.Set(ctx, consensusParams); err != nil {
+		return fmt.Errorf("failed to set consensus params: %w", err)
+	}
+
+	// update staking params
+	stakingParams, err := k.StakingKeeper.GetParams(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get staking params: %w", err)
+	}
+
+	stakingParams.MinCommissionRate = TestnetMinCommissionRate
+
+	if err := k.StakingKeeper.SetParams(ctx, stakingParams); err != nil {
+		return fmt.Errorf("failed to set staking params: %w", err)
+	}
+
+	// update distribution params
+	distributionParams, err := k.DistrKeeper.Params.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get distribution params: %w", err)
+	}
+
+	distributionParams.CommunityTax = TestnetCommunityTax
+
+	if err := k.DistrKeeper.Params.Set(ctx, distributionParams); err != nil {
+		return fmt.Errorf("failed to set distribution params: %w", err)
+	}
+
+	// update btc checkpoint tag
+	btcCheckpointParams := k.BtcCheckpointKeeper.GetParams(ctx)
+
+	btcCheckpointParams.CheckpointTag = TestnetBTCCheckpointTag
+
+	if err := k.BtcCheckpointKeeper.SetParams(ctx, btcCheckpointParams); err != nil {
+		return fmt.Errorf("failed to set btc checkpoint params: %w", err)
+	}
+
+	// btc light client allow address
+	btcLCParams := k.BTCLightClientKeeper.GetParams(ctx)
+
+	btcLCParams.InsertHeadersAllowList = append(btcLCParams.InsertHeadersAllowList, TestnetReporterAllowAddress)
+
+	if err := k.BTCLightClientKeeper.SetParams(ctx, btcLCParams); err != nil {
+		return fmt.Errorf("failed to set btc light client params: %w", err)
+	}
+
+	return nil
+}

--- a/app/upgrades/v1/mainnet/params_update.go
+++ b/app/upgrades/v1/mainnet/params_update.go
@@ -52,6 +52,10 @@ func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 	slashingParams.DowntimeJailDuration = MainnetDowntimeJailDuration
 	slashingParams.SlashFractionDowntime = MainnetSlashFractionDowntime
 
+	if err := k.SlashingKeeper.SetParams(ctx, slashingParams); err != nil {
+		return fmt.Errorf("failed to set slashing params: %w", err)
+	}
+
 	// update gov params
 	govParams, err := k.GovKeeper.Params.Get(ctx)
 	if err != nil {

--- a/app/upgrades/v1/mainnet/params_update.go
+++ b/app/upgrades/v1/mainnet/params_update.go
@@ -14,44 +14,44 @@ import (
 
 var (
 	// Slashing params
-	MainnetMinSignedBlocks, _    = sdkmath.LegacyNewDecFromStr("0.6")
-	MainnetSlashFractionDowntime = sdkmath.LegacyZeroDec()
-	MainnetDowntimeJailDuration  = 300 * time.Second
+	MinSignedBlocks, _    = sdkmath.LegacyNewDecFromStr("0.6")
+	SlashFractionDowntime = sdkmath.LegacyZeroDec()
+	DowntimeJailDuration  = 300 * time.Second
 
 	// Governance params
-	MainnetVotingPeriod = 3 * 24 * time.Hour
+	VotingPeriod = 3 * 24 * time.Hour
 	// 50k BABY
-	MainnetMinDeposit = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(50_000_000000))
+	MinDeposit = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(50_000_000000))
 	// 200k BABY
-	MainnetMaxDepositPeriod      = 14 * 24 * time.Hour
-	MainnetExpeditedVotingPeriod = 24 * time.Hour
-	MainnetExpeditedMinDeposit   = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(200_000_000000))
+	MaxDepositPeriod      = 14 * 24 * time.Hour
+	ExpeditedVotingPeriod = 24 * time.Hour
+	ExpeditedMinDeposit   = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(200_000_000000))
 
 	// Consensus params
-	MainnetBlockGasLimit = int64(300000000)
+	BlockGasLimit = int64(300000000)
 	// Staking params
-	MainnetBabyMinCommissionRate, _ = sdkmath.LegacyNewDecFromStr("0.03")
+	BabyMinCommissionRate, _ = sdkmath.LegacyNewDecFromStr("0.03")
 
 	// BTC checkpoint params
-	MainnetBTCConfirmationDepth   = uint32(30)
-	MainnetBTCFinalizationTimeout = uint32(300)
+	BTCConfirmationDepth   = uint32(30)
+	BTCFinalizationTimeout = uint32(300)
 
 	// Distribution params
-	MainnetCommunityTax          = sdkmath.LegacyZeroDec()
-	MainnetWithdrawalAddrEnabled = true
+	CommunityTax          = sdkmath.LegacyZeroDec()
+	WithdrawalAddrEnabled = true
 )
 
-// MainnetParamUpgrade make updates to specific params of specific modules
-func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
+// ParamUpgrade make updates to specific params of specific modules
+func ParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 	// update slashing params
 	slashingParams, err := k.SlashingKeeper.GetParams(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get slash params: %w", err)
 	}
 
-	slashingParams.MinSignedPerWindow = MainnetMinSignedBlocks
-	slashingParams.DowntimeJailDuration = MainnetDowntimeJailDuration
-	slashingParams.SlashFractionDowntime = MainnetSlashFractionDowntime
+	slashingParams.MinSignedPerWindow = MinSignedBlocks
+	slashingParams.DowntimeJailDuration = DowntimeJailDuration
+	slashingParams.SlashFractionDowntime = SlashFractionDowntime
 
 	if err := slashingParams.Validate(); err != nil {
 		return fmt.Errorf("failed to validate slashing params: %w", err)
@@ -66,14 +66,14 @@ func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 		return fmt.Errorf("failed to get gov params: %w", err)
 	}
 
-	govParams.VotingPeriod = &MainnetVotingPeriod
-	govParams.ExpeditedVotingPeriod = &MainnetExpeditedVotingPeriod
-	govParams.MaxDepositPeriod = &MainnetMaxDepositPeriod
+	govParams.VotingPeriod = &VotingPeriod
+	govParams.ExpeditedVotingPeriod = &ExpeditedVotingPeriod
+	govParams.MaxDepositPeriod = &MaxDepositPeriod
 	govParams.MinDeposit = []sdk.Coin{
-		MainnetMinDeposit,
+		MinDeposit,
 	}
 	govParams.ExpeditedMinDeposit = []sdk.Coin{
-		MainnetExpeditedMinDeposit,
+		ExpeditedMinDeposit,
 	}
 
 	if err := govParams.ValidateBasic(); err != nil {
@@ -89,7 +89,7 @@ func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 		return fmt.Errorf("failed to get consensus params: %w", err)
 	}
 
-	consensusParams.Block.MaxGas = MainnetBlockGasLimit
+	consensusParams.Block.MaxGas = BlockGasLimit
 
 	consparams := cmttypes.ConsensusParamsFromProto(consensusParams)
 	if err := consparams.ValidateUpdate(&consensusParams, ctx.HeaderInfo().Height); err != nil {
@@ -105,7 +105,7 @@ func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 		return fmt.Errorf("failed to get staking params: %w", err)
 	}
 
-	stakingParams.MinCommissionRate = MainnetBabyMinCommissionRate
+	stakingParams.MinCommissionRate = BabyMinCommissionRate
 
 	if err := stakingParams.Validate(); err != nil {
 		return fmt.Errorf("failed to validate staking params: %w", err)
@@ -120,8 +120,8 @@ func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 		return fmt.Errorf("failed to get distribution params: %w", err)
 	}
 
-	distributionParams.CommunityTax = MainnetCommunityTax
-	distributionParams.WithdrawAddrEnabled = MainnetWithdrawalAddrEnabled
+	distributionParams.CommunityTax = CommunityTax
+	distributionParams.WithdrawAddrEnabled = WithdrawalAddrEnabled
 
 	if err := distributionParams.ValidateBasic(); err != nil {
 		return fmt.Errorf("failed to validate distribution params: %w", err)
@@ -133,8 +133,8 @@ func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 	// update btc checkpoint params
 	btcCheckpointParams := k.BtcCheckpointKeeper.GetParams(ctx)
 
-	btcCheckpointParams.BtcConfirmationDepth = MainnetBTCConfirmationDepth
-	btcCheckpointParams.CheckpointFinalizationTimeout = MainnetBTCFinalizationTimeout
+	btcCheckpointParams.BtcConfirmationDepth = BTCConfirmationDepth
+	btcCheckpointParams.CheckpointFinalizationTimeout = BTCFinalizationTimeout
 
 	if err := btcCheckpointParams.Validate(); err != nil {
 		return fmt.Errorf("failed to validate btc checkpoint params: %w", err)

--- a/app/upgrades/v1/mainnet/params_update.go
+++ b/app/upgrades/v1/mainnet/params_update.go
@@ -33,8 +33,8 @@ var (
 	MainnetBabyMinCommissionRate, _ = sdkmath.LegacyNewDecFromStr("0.03")
 
 	// BTC checkpoint params
-	MainnetBTCConfirmationDepth = uint32(30)
-	MainnetBTCFinalizationDepth = uint32(300)
+	MainnetBTCConfirmationDepth   = uint32(30)
+	MainnetBTCFinalizationTimeout = uint32(300)
 
 	// Distribution params
 	MainnetCommunityTax          = sdkmath.LegacyZeroDec()
@@ -134,7 +134,7 @@ func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 	btcCheckpointParams := k.BtcCheckpointKeeper.GetParams(ctx)
 
 	btcCheckpointParams.BtcConfirmationDepth = MainnetBTCConfirmationDepth
-	btcCheckpointParams.CheckpointFinalizationTimeout = MainnetBTCFinalizationDepth
+	btcCheckpointParams.CheckpointFinalizationTimeout = MainnetBTCFinalizationTimeout
 
 	if err := btcCheckpointParams.Validate(); err != nil {
 		return fmt.Errorf("failed to validate btc checkpoint params: %w", err)

--- a/app/upgrades/v1/mainnet/params_update.go
+++ b/app/upgrades/v1/mainnet/params_update.go
@@ -23,9 +23,10 @@ var (
 	// 50k BABY
 	MinDeposit = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(50_000_000000))
 	// 200k BABY
-	MaxDepositPeriod      = 14 * 24 * time.Hour
-	ExpeditedVotingPeriod = 24 * time.Hour
-	ExpeditedMinDeposit   = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(200_000_000000))
+	MaxDepositPeriod          = 14 * 24 * time.Hour
+	ExpeditedVotingPeriod     = 24 * time.Hour
+	ExpeditedMinDeposit       = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(200_000_000000))
+	MinInitialDepositRatio, _ = sdkmath.LegacyNewDecFromStr("0.1")
 
 	// Consensus params
 	BlockGasLimit = int64(300000000)
@@ -75,6 +76,7 @@ func ParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 	govParams.ExpeditedMinDeposit = []sdk.Coin{
 		ExpeditedMinDeposit,
 	}
+	govParams.MinInitialDepositRatio = MinInitialDepositRatio.String()
 
 	if err := govParams.ValidateBasic(); err != nil {
 		return fmt.Errorf("failed to validate gov params: %w", err)

--- a/app/upgrades/v1/mainnet/params_update.go
+++ b/app/upgrades/v1/mainnet/params_update.go
@@ -52,6 +52,10 @@ func MainnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 	slashingParams.DowntimeJailDuration = MainnetDowntimeJailDuration
 	slashingParams.SlashFractionDowntime = MainnetSlashFractionDowntime
 
+	if err := slashingParams.Validate(); err != nil {
+		return fmt.Errorf("failed to validate slashing params: %w", err)
+	}
+
 	if err := k.SlashingKeeper.SetParams(ctx, slashingParams); err != nil {
 		return fmt.Errorf("failed to set slashing params: %w", err)
 	}

--- a/app/upgrades/v1/mainnet/token_distribution.go
+++ b/app/upgrades/v1/mainnet/token_distribution.go
@@ -1,26 +1,5 @@
 package mainnet
 
 const TokensDistributionStr = `{
-  "token_distribution": [
-    {
-      "address_sender": "bbn14d97wthm9fqvvdd96ax8lnfppwknndxztevs7k",
-      "address_receiver": "bbn13t5cnqj6t0p4xa40cwhmgv4wju0zl6g8slk8rz",
-      "amount": 100000
-    },
-    {
-      "address_sender": "bbn10d07y265gmmuvt4z0w9aw880jnsr700jduz5f2",
-      "address_receiver": "bbn1yl6hdjhmkf37639730gffanpzndzdpmhep8cg6",
-      "amount": 1500000
-    },
-    {
-      "address_sender": "bbn10d07y265gmmuvt4z0w9aw880jnsr700jduz5f2",
-      "address_receiver": "bbn1k6u5pge8w6lavtmunp02smehr4qtazkw8clg04",
-      "amount": 700000
-    },
-    {
-      "address_sender": "bbn10d07y265gmmuvt4z0w9aw880jnsr700jduz5f2",
-      "address_receiver": "bbn1dj2c57fjv6md7pzykh9y6h407ln6xxcw090hre",
-      "amount": 100000
-    }
-  ]
+  "token_distribution": []
 }`

--- a/app/upgrades/v1/testnet/params_update.go
+++ b/app/upgrades/v1/testnet/params_update.go
@@ -14,39 +14,39 @@ import (
 
 var (
 	// Governance params
-	TestnetVotingPeriod          = 24 * time.Hour
-	TestnetExpeditedVotingPeriod = 12 * time.Hour
-	// 10 BBN
-	TestnetMinDeposit = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(10000000))
-	// 20 BBN
-	TestnetExpeditedMinDeposit = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(20000000))
+	VotingPeriod          = 24 * time.Hour
+	ExpeditedVotingPeriod = 12 * time.Hour
+	// 10 BABY
+	MinDeposit = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(10000000))
+	// 20 BABY
+	ExpeditedMinDeposit = sdk.NewCoin(appparams.DefaultBondDenom, math.NewInt(20000000))
 	// Consensus params
-	TestnetBlockGasLimit = int64(250000000)
+	BlockGasLimit = int64(250000000)
 	// Staking params
-	TestnetMinCommissionRate, _ = sdkmath.LegacyNewDecFromStr("0.03")
+	MinCommissionRate, _ = sdkmath.LegacyNewDecFromStr("0.03")
 	// Distribution params
-	TestnetCommunityTax, _ = sdkmath.LegacyNewDecFromStr("0.001")
+	CommunityTax, _ = sdkmath.LegacyNewDecFromStr("0.001")
 	// BTC checkpoint params
-	TestnetBTCCheckpointTag = hex.EncodeToString([]byte("bbt5"))
+	BTCCheckpointTag = hex.EncodeToString([]byte("bbt5"))
 	// Additional allow address to BTC light client
-	TestnetReporterAllowAddress = "bbn1cferwuxd95mdnyh4qnptahmzym0xt9sp9asqnw"
+	ReporterAllowAddress = "bbn1cferwuxd95mdnyh4qnptahmzym0xt9sp9asqnw"
 )
 
-// TestnetParamUpgrade make updates to specific params of specific modules
-func TestnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
+// ParamUpgrade make updates to specific params of specific modules
+func ParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 	// update gov params
 	govParams, err := k.GovKeeper.Params.Get(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get gov params: %w", err)
 	}
 
-	govParams.VotingPeriod = &TestnetVotingPeriod
-	govParams.ExpeditedVotingPeriod = &TestnetExpeditedVotingPeriod
+	govParams.VotingPeriod = &VotingPeriod
+	govParams.ExpeditedVotingPeriod = &ExpeditedVotingPeriod
 	govParams.MinDeposit = []sdk.Coin{
-		TestnetMinDeposit,
+		MinDeposit,
 	}
 	govParams.ExpeditedMinDeposit = []sdk.Coin{
-		TestnetExpeditedMinDeposit,
+		ExpeditedMinDeposit,
 	}
 
 	if err := k.GovKeeper.Params.Set(ctx, govParams); err != nil {
@@ -59,7 +59,7 @@ func TestnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 		return fmt.Errorf("failed to get consensus params: %w", err)
 	}
 
-	consensusParams.Block.MaxGas = TestnetBlockGasLimit
+	consensusParams.Block.MaxGas = BlockGasLimit
 
 	if err := k.ConsensusParamsKeeper.ParamsStore.Set(ctx, consensusParams); err != nil {
 		return fmt.Errorf("failed to set consensus params: %w", err)
@@ -71,7 +71,7 @@ func TestnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 		return fmt.Errorf("failed to get staking params: %w", err)
 	}
 
-	stakingParams.MinCommissionRate = TestnetMinCommissionRate
+	stakingParams.MinCommissionRate = MinCommissionRate
 
 	if err := k.StakingKeeper.SetParams(ctx, stakingParams); err != nil {
 		return fmt.Errorf("failed to set staking params: %w", err)
@@ -83,7 +83,7 @@ func TestnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 		return fmt.Errorf("failed to get distribution params: %w", err)
 	}
 
-	distributionParams.CommunityTax = TestnetCommunityTax
+	distributionParams.CommunityTax = CommunityTax
 
 	if err := k.DistrKeeper.Params.Set(ctx, distributionParams); err != nil {
 		return fmt.Errorf("failed to set distribution params: %w", err)
@@ -92,7 +92,7 @@ func TestnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 	// update btc checkpoint tag
 	btcCheckpointParams := k.BtcCheckpointKeeper.GetParams(ctx)
 
-	btcCheckpointParams.CheckpointTag = TestnetBTCCheckpointTag
+	btcCheckpointParams.CheckpointTag = BTCCheckpointTag
 
 	if err := k.BtcCheckpointKeeper.SetParams(ctx, btcCheckpointParams); err != nil {
 		return fmt.Errorf("failed to set btc checkpoint params: %w", err)
@@ -101,7 +101,7 @@ func TestnetParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 	// btc light client allow address
 	btcLCParams := k.BTCLightClientKeeper.GetParams(ctx)
 
-	btcLCParams.InsertHeadersAllowList = append(btcLCParams.InsertHeadersAllowList, TestnetReporterAllowAddress)
+	btcLCParams.InsertHeadersAllowList = append(btcLCParams.InsertHeadersAllowList, ReporterAllowAddress)
 
 	if err := k.BTCLightClientKeeper.SetParams(ctx, btcLCParams); err != nil {
 		return fmt.Errorf("failed to set btc light client params: %w", err)

--- a/app/upgrades/v1/upgrades.go
+++ b/app/upgrades/v1/upgrades.go
@@ -158,7 +158,7 @@ func upgradeParameters(
 		return fmt.Errorf("failed to upgrade finality parameters: %w", err)
 	}
 	if err := upgradeIncentiveParameters(ctx, cdc, iK, incentiveParam); err != nil {
-		return err
+		return fmt.Errorf("failed to upgrade incentive parameters: %w", err)
 	}
 
 	if err := upgradeCosmWasmParameters(ctx, cdc, wasmK, wasmParam); err != nil {

--- a/app/upgrades/v1/upgrades_test.go
+++ b/app/upgrades/v1/upgrades_test.go
@@ -285,7 +285,7 @@ func (s *UpgradeTestSuite) Upgrade() {
 	s.ctx = s.ctx.WithHeaderInfo(header.Info{Height: DummyUpgradeHeight, Time: s.ctx.BlockTime().Add(time.Second)}).WithBlockHeight(DummyUpgradeHeight)
 	s.NotPanics(func() {
 		_, err := s.preModule.PreBlock(s.ctx)
-		s.NoError(err)
+		s.Require().NoError(err)
 	})
 }
 

--- a/app/upgrades/v1/upgrades_test.go
+++ b/app/upgrades/v1/upgrades_test.go
@@ -141,7 +141,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 		{
 			"Test launch software upgrade v1 testnet",
 			UpgradeV1DataTestnet,
-			testnetdata.TestnetParamUpgrade,
+			testnetdata.ParamUpgrade,
 			s.PreUpgrade,
 			s.Upgrade,
 			func() {
@@ -160,33 +160,33 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 				// check that the gov params were updated
 				govParams, err := s.app.GovKeeper.Params.Get(s.ctx)
 				s.NoError(err)
-				s.EqualValues(testnetdata.TestnetVotingPeriod, *govParams.VotingPeriod)
-				s.EqualValues(testnetdata.TestnetExpeditedVotingPeriod, *govParams.ExpeditedVotingPeriod)
-				s.EqualValues([]sdk.Coin{testnetdata.TestnetMinDeposit}, govParams.MinDeposit)
-				s.EqualValues([]sdk.Coin{testnetdata.TestnetExpeditedMinDeposit}, govParams.ExpeditedMinDeposit)
+				s.EqualValues(testnetdata.VotingPeriod, *govParams.VotingPeriod)
+				s.EqualValues(testnetdata.ExpeditedVotingPeriod, *govParams.ExpeditedVotingPeriod)
+				s.EqualValues([]sdk.Coin{testnetdata.MinDeposit}, govParams.MinDeposit)
+				s.EqualValues([]sdk.Coin{testnetdata.ExpeditedMinDeposit}, govParams.ExpeditedMinDeposit)
 
 				// check that the consensus params were updated
 				consensusParams, err := s.app.ConsensusParamsKeeper.ParamsStore.Get(s.ctx)
 				s.NoError(err)
-				s.EqualValues(testnetdata.TestnetBlockGasLimit, consensusParams.Block.MaxGas)
+				s.EqualValues(testnetdata.BlockGasLimit, consensusParams.Block.MaxGas)
 
 				// check that the staking params were updated
 				stakingParams, err := s.app.StakingKeeper.GetParams(s.ctx)
 				s.NoError(err)
-				s.EqualValues(testnetdata.TestnetMinCommissionRate, stakingParams.MinCommissionRate)
+				s.EqualValues(testnetdata.MinCommissionRate, stakingParams.MinCommissionRate)
 
 				// check that the distribution params were updated
 				distributionParams, err := s.app.DistrKeeper.Params.Get(s.ctx)
 				s.NoError(err)
-				s.EqualValues(testnetdata.TestnetCommunityTax, distributionParams.CommunityTax)
+				s.EqualValues(testnetdata.CommunityTax, distributionParams.CommunityTax)
 
 				// check that the btc checkpoint params were updated
 				btcCheckpointParams := s.app.BtcCheckpointKeeper.GetParams(s.ctx)
-				s.EqualValues(testnetdata.TestnetBTCCheckpointTag, btcCheckpointParams.CheckpointTag)
+				s.EqualValues(testnetdata.BTCCheckpointTag, btcCheckpointParams.CheckpointTag)
 
 				// check that the btc light client params were updated
 				btcLCParams := s.app.BTCLightClientKeeper.GetParams(s.ctx)
-				s.True(slices.Contains(btcLCParams.InsertHeadersAllowList, testnetdata.TestnetReporterAllowAddress))
+				s.True(slices.Contains(btcLCParams.InsertHeadersAllowList, testnetdata.ReporterAllowAddress))
 			},
 		},
 	}


### PR DESCRIPTION
Add parameters in the upgrade handler as the spec and global parameters for `bbn-1`

Removed prefix `Testnet` and `Mainnet` in v1 upgrade data packages