### PR TITLE
docs: relayer guide

### DIFF
--- a/docs/ibc-relayer.md
+++ b/docs/ibc-relayer.md
@@ -7,7 +7,8 @@ configurations needed
 when relaying with Babylon, particularly around its unique unbonding period
 mechanism.
 
-> **Note**: Babylon supports IBC Transfer and IBC-Wasm. It does not support ICA, ICQ, IBC Hooks, or IBC Middleware yet.
+> **Note**: Babylon supports IBC Transfer and IBC-Wasm. It does not support ICA,
+> ICQ, IBC Hooks, or IBC Middleware yet.
 
 ## Important Note on Babylon's Unbonding Period
 


### PR DESCRIPTION
Add IBC relayer guide focusing on Babylon's unique configuration requirements.

This guide:
- Explains Babylon's Bitcoin timestamp-assisted unbonding mechanism (~300 BTC blocks, ~50 hours)
- Clarifies why the default 21-day unbonding period from x/staking module should be ignored
- Provides recommended trusting period (33 hours) and client refresh rate (1/5)
- Removes generic relayer setup instructions in favor of linking to existing guides
- Includes instructions for handling expired/frozen IBC clients