### PR TITLE
chore: go releaser testnet + wasm statically

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,6 +8,16 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@v0.7.0
-    secrets: inherit
+  goreleaser:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Make release
+        run: |
+          make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,16 +1,30 @@
 version: 2
 project_name: babylon
 
+env:
+  - CGO_ENABLED=1
+  - CC=/opt/musl-cross/bin/x86_64-linux-musl-gcc
+  - LD=/opt/musl-cross/bin/x86_64-linux-musl-ld
+  - CGO_LDFLAGS=-L/lib
+
+before:
+  hooks:
+    - wget -nc https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.x86_64.a
+    - cp -n -u /lib/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.a
+    - curl -LO https://musl.cc/x86_64-linux-musl-cross.tgz
+    - tar xf x86_64-linux-musl-cross.tgz
+    - mv -n -u x86_64-linux-musl-cross /opt/musl-cross
+
 builds:
   - id: babylond-linux-amd64
     main: ./cmd/babylond/main.go
     binary: babylond
+    builder: go
+    gobinary: "go"
     goos:
       - linux
     goarch:
       - amd64
-    env:
-      - GO111MODULE=on
     flags:
       - -mod=readonly
       - -trimpath
@@ -19,11 +33,39 @@ builds:
       - -X github.com/cosmos/cosmos-sdk/version.AppName=babylond
       - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
       - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
-      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=ledger,muslc
+      - -linkmode=external
       - -w -s
+      - -extldflags "-Wl,-z,muldefs -static -z noexecstack"
     tags:
-      - netgo
       - ledger
+      - muslc
+
+  - id: babylond-testnet-linux-amd64
+    main: ./cmd/babylond/main.go
+    binary: babylond
+    builder: go
+    gobinary: "go"
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/cosmos/cosmos-sdk/version.Name=babylon
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=babylond
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=ledger,muslc,testnet
+      - -linkmode=external
+      - -w -s
+      - -extldflags "-Wl,-z,muldefs -static -z noexecstack"
+    tags:
+      - ledger
+      - muslc
+      - testnet
 
 archives:
   - id: zipped
@@ -31,6 +73,15 @@ archives:
       - babylond-linux-amd64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
+    wrap_in_directory: false
+    files:
+      - none*
+  - id: zipped-testnet
+    builds:
+      - babylond-testnet-linux-amd64
+    name_template: "{{.ProjectName}}-testnet-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: tar.gz
+    wrap_in_directory: false
     files:
       - none*
   - id: binaries
@@ -38,6 +89,15 @@ archives:
       - babylond-linux-amd64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: binary
+    wrap_in_directory: false
+    files:
+      - none*
+  - id: binaries-testnet
+    builds:
+      - babylond-testnet-linux-amd64
+    name_template: "{{.ProjectName}}-testnet-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: binary
+    wrap_in_directory: false
     files:
       - none*
 
@@ -55,3 +115,6 @@ changelog:
   disable: true
 
 dist: dist
+
+git:
+  prerelease_suffix: "-rc"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#757](https://github.com/babylonlabs-io/babylon/pull/757) Statically link wasm and add binaries
+with [`testnet`, `mainnet`] flags to release assets.
 - [#675](https://github.com/babylonlabs-io/babylon/pull/675) Add no-retries option to babylon client send msg.
 - [#623](https://github.com/babylonlabs-io/babylon/pull/623) Add check for empty string in `bls` loading.
 - [#536](https://github.com/babylonlabs-io/babylon/pull/536) Improve protobuf vs. json error msgs / types

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,13 @@ ifeq (boltdb,$(findstring boltdb,$(BABYLON_BUILD_OPTIONS)))
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=boltdb
 endif
 
+ifeq ($(LINK_STATICALLY),true)
 # To efectively statically link the binary is to manually wget the
 # libwasmvm_muslc.$(UNAME_S).a to libwasmvm.$(UNAME_S).a and
-# libwasmvm_muslc.a to libwasmvm.a.
+# libwasmvm_muslc.a to libwasmvm.a and also set the necessary env vars
+# [CGO_ENABLED=1, CC=/opt/musl-cross/bin/x86_64-linux-musl-gcc,
+# LD=/opt/musl-cross/bin/x86_64-linux-musl-ld, CGO_LDFLAGS=-L/lib]
 # Example wget https://github.com/CosmWasm/wasmvm/releases/download/$COSMWASM_VERSION/libwasmvm_muslc."$(uname -m)".a
-ifeq ($(LINK_STATICALLY),true)
 	ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,13 @@ endif
 
 export GO111MODULE = on
 
+# process linker flags
+
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=babylon \
+		  -X github.com/cosmos/cosmos-sdk/version.AppName=babylond \
+		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
+		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT)
+
 # process build tags
 
 build_tags = netgo
@@ -68,27 +75,14 @@ endif
 
 # Handles the inclusion of upgrade in binary
 ifeq (testnet,$(findstring testnet,$(BABYLON_BUILD_OPTIONS)))
-  build_tags += testnet
+  BUILD_TAGS += testnet
 else
-  build_tags += mainnet
+  BUILD_TAGS += mainnet
 endif
-
-whitespace :=
-whitespace := $(whitespace) $(whitespace)
-comma := ,
-build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
-
-# process linker flags
-
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=babylon \
-		  -X github.com/cosmos/cosmos-sdk/version.AppName=babylond \
-		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
-		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
-		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
 
 # Handles the inclusion of e2e upgrade in binary
 ifeq (e2e_upgrade,$(findstring e2e_upgrade,$(BABYLON_BUILD_OPTIONS)))
-  build_tags += e2e_upgrade
+  BUILD_TAGS += e2e_upgrade
 endif
 
 # DB backend selection
@@ -97,17 +91,17 @@ ifeq (cleveldb,$(findstring cleveldb,$(BABYLON_BUILD_OPTIONS)))
 endif
 ifeq (badgerdb,$(findstring badgerdb,$(BABYLON_BUILD_OPTIONS)))
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=badgerdb
-  build_tags += badgerdb
+  BUILD_TAGS += badgerdb
 endif
 # handle rocksdb
 ifeq (rocksdb,$(findstring rocksdb,$(BABYLON_BUILD_OPTIONS)))
   CGO_ENABLED=1
-  build_tags += rocksdb
+  BUILD_TAGS += rocksdb
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=rocksdb
 endif
 # handle boltdb
 ifeq (boltdb,$(findstring boltdb,$(BABYLON_BUILD_OPTIONS)))
-  build_tags += boltdb
+  BUILD_TAGS += boltdb
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=boltdb
 endif
 
@@ -121,7 +115,15 @@ endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
+build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
+
+whitespace :=
+whitespace := $(whitespace) $(whitespace)
+comma := ,
+build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
+
+ldflags += -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
 
 BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 # check for nostrip option

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ ifeq (boltdb,$(findstring boltdb,$(BABYLON_BUILD_OPTIONS)))
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=boltdb
 endif
 
+# To efectively statically link the binary is to manually wget the
+# libwasmvm_muslc.$(UNAME_S).a to libwasmvm.$(UNAME_S).a and
+# libwasmvm_muslc.a to libwasmvm.a.
+# Example wget https://github.com/CosmWasm/wasmvm/releases/download/$COSMWASM_VERSION/libwasmvm_muslc."$(uname -m)".a
 ifeq ($(LINK_STATICALLY),true)
 	ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"
 endif

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,13 @@ ifeq (secp,$(findstring secp,$(BABYLON_BUILD_OPTIONS)))
   build_tags += libsecp256k1_sdk
 endif
 
+# Handles the inclusion of upgrade in binary
+ifeq (testnet,$(findstring testnet,$(BABYLON_BUILD_OPTIONS)))
+  build_tags += testnet
+else
+  build_tags += mainnet
+endif
+
 whitespace :=
 whitespace := $(whitespace) $(whitespace)
 comma := ,
@@ -79,16 +86,9 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=babylon \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
 
-# Handles the inclusion of upgrade in binary
-ifeq (testnet,$(findstring testnet,$(BABYLON_BUILD_OPTIONS)))
-  BUILD_TAGS += testnet
-else
-  BUILD_TAGS += mainnet
-endif
-
 # Handles the inclusion of e2e upgrade in binary
 ifeq (e2e_upgrade,$(findstring e2e_upgrade,$(BABYLON_BUILD_OPTIONS)))
-  BUILD_TAGS += e2e_upgrade
+  build_tags += e2e_upgrade
 endif
 
 # DB backend selection
@@ -97,17 +97,17 @@ ifeq (cleveldb,$(findstring cleveldb,$(BABYLON_BUILD_OPTIONS)))
 endif
 ifeq (badgerdb,$(findstring badgerdb,$(BABYLON_BUILD_OPTIONS)))
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=badgerdb
-  BUILD_TAGS += badgerdb
+  build_tags += badgerdb
 endif
 # handle rocksdb
 ifeq (rocksdb,$(findstring rocksdb,$(BABYLON_BUILD_OPTIONS)))
   CGO_ENABLED=1
-  BUILD_TAGS += rocksdb
+  build_tags += rocksdb
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=rocksdb
 endif
 # handle boltdb
 ifeq (boltdb,$(findstring boltdb,$(BABYLON_BUILD_OPTIONS)))
-  BUILD_TAGS += boltdb
+  build_tags += boltdb
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=boltdb
 endif
 
@@ -121,7 +121,6 @@ endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
-build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
 BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'


### PR DESCRIPTION
- Fix build tag in version, now it appears testnet or mainnet with `version --long`

```shell
build_tags: netgo,ledger,testnet
commit: 931c61a1d39ef1adbdaf671be72cd367694f0b08
cosmos_sdk_version: v0.50.12
go: go version go1.23.1 linux/amd64
name: babylon
server_name: babylond
version: rafilx/go-releaser-test-931c61a1d39ef1adbdaf671be72cd367694f0b08
```

- Statically links wasm in release assets
- Creates one binary with testnet build tag and another for mainnet