### PR TITLE
chore: add BTC headers from `854785` to `890123`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#760](https://github.com/babylonlabs-io/babylon/pull/760) Add mainnet BTC headers
+height from `854785` to `890123`.
 - [#746](https://github.com/babylonlabs-io/babylon/pull/746) Add mainnet parameters to v1 upgrade handler.
 - [#675](https://github.com/babylonlabs-io/babylon/pull/675) Add no-retries option to babylon client send msg.
 - [#623](https://github.com/babylonlabs-io/babylon/pull/623) Add check for empty string in `bls` loading.

--- a/app/upgrades/v1/mainnet/params_update.go
+++ b/app/upgrades/v1/mainnet/params_update.go
@@ -8,6 +8,7 @@ import (
 	sdkmath "cosmossdk.io/math"
 	"github.com/babylonlabs-io/babylon/app/keepers"
 	appparams "github.com/babylonlabs-io/babylon/app/params"
+	"github.com/cometbft/cometbft/proto/tendermint/types"
 	cmttypes "github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -92,7 +93,11 @@ func ParamUpgrade(ctx sdk.Context, k *keepers.AppKeepers) error {
 	}
 
 	consensusParams.Block.MaxGas = BlockGasLimit
-
+	if consensusParams.Version == nil {
+		consensusParams.Version = &types.VersionParams{
+			App: 1,
+		}
+	}
 	consparams := cmttypes.ConsensusParamsFromProto(consensusParams)
 	if err := consparams.ValidateUpdate(&consensusParams, ctx.HeaderInfo().Height); err != nil {
 		return fmt.Errorf("failed to validate consensus params: %w", err)

--- a/testutil/sample/sample.go
+++ b/testutil/sample/sample.go
@@ -42,3 +42,27 @@ func SignetBtcHeader195552(t *testing.T) *btclighttypes.BTCHeaderInfo {
 
 	return &btcHeader
 }
+
+// MainnetBtcHeader854784 returns the BTC Header block 854784 from mainnet.
+func MainnetBtcHeader854784(t *testing.T) *btclighttypes.BTCHeaderInfo {
+	var btcHeader btclighttypes.BTCHeaderInfo
+
+	// mainnet btc header of height 854784
+	btcHeaderHash, err := types.NewBTCHeaderBytesFromHex("0000c020f382af1f6d228721b49f3da2f5b831587803b16597b301000000000000000000e4f76aae64d8316d195a92424871b74168b58d1c3c6988548e0e9890b15fc2fc3c00aa66be1a0317082e4bc7")
+	require.NoError(t, err)
+
+	wireHeaders := btclightck.BtcHeadersBytesToBlockHeader([]types.BTCHeaderBytes{btcHeaderHash})
+	wireHeader := wireHeaders[0]
+
+	blockHash := wireHeader.BlockHash()
+	headerHash := bbn.NewBTCHeaderHashBytesFromChainhash(&blockHash)
+	work := btclighttypes.CalcWork(&btcHeaderHash)
+	btcHeader = btclighttypes.BTCHeaderInfo{
+		Header: &btcHeaderHash,
+		Height: uint32(854784),
+		Hash:   &headerHash,
+		Work:   &work,
+	}
+
+	return &btcHeader
+}


### PR DESCRIPTION
- Base BTC header in v0.9.3 is height [`854784`](https://mempool.space/block/0000000000000000000289d41c5b01a89982a510f9c49d730eaa328d0abbfbcb) header: `0000c020f382af1f6d228721b49f3da2f5b831587803b16597b301000000000000000000e4f76aae64d8316d195a92424871b74168b58d1c3c6988548e0e9890b15fc2fc3c00aa66be1a0317082e4bc7`
- The BTC headers inserted in the upgrade are from [`854785`](https://mempool.space/block/0000000000000000000118c1e53554dac0d9da7717587d3cdb72d458df9dbb12) to [`890123`](https://mempool.space/block/00000000000000000001fd463e1125fd67db97fd9e52cb3efe532f9b170ad658)

