### PR TITLE
(fix) ibc-relayer.md hermes example typo

### DIFF
--- a/docs/ibc-relayer.md
+++ b/docs/ibc-relayer.md
@@ -93,7 +93,7 @@ Example Hermes configuration:
 [[chains]]
 trusting_period = "33 hours"
 refresh = true
-client_refresh_rate = 1/5
+client_refresh_rate = "1/5"
 ```
 
 For complete setup instructions, including wallet configuration, connection

--- a/docs/ibc-relayer.md
+++ b/docs/ibc-relayer.md
@@ -90,9 +90,11 @@ parameters. The following values are specific to Babylon mainnet:
 Example Hermes configuration:
 
 ```
+[mode.clients]
+refresh = true
+
 [[chains]]
 trusting_period = "33 hours"
-refresh = true
 client_refresh_rate = "1/5"
 ```
 


### PR DESCRIPTION
This example will not work without the quotes around `client_refresh_rate` value