### PR TITLE
Fix: typo register-bitcoin-stake.md edits

### DIFF
--- a/docs/register-bitcoin-stake.md
+++ b/docs/register-bitcoin-stake.md
@@ -21,13 +21,13 @@
 ## 1. Introduction
 
 This document walks through the communication protocol
-with the Babylon chain in order to register Bitcoin stakes.
+with the Babylon Genesis chain in order to register Bitcoin stakes.
 The document is structured as follows:
 - [Section 2](#2-bitcoin-stake-registration-methods) provides an overview
-    of the two flows for registering stakes on the Babylon chain.
+    of the two flows for registering stakes on the Babylon Genesis chain.
 - [Section 3](#3-bitcoin-stake-registration) describes the data required for stake registration,
     the registration process itself, and the `MsgCreateBTCDelegation` message used
-    to communicate staking transactions to the Babylon chain.
+    to communicate staking transactions to the Babylon Genesis chain.
 - [Section 4](#4-managing-your-bitcoin-stake) details stake management, including
     on-demand unbonding and withdrawal.
 - [Section 5](#5-bitcoin-staking-rewards) focuses on the Bitcoin staking rewards
@@ -36,36 +36,34 @@ The document is structured as follows:
 **Target Audience**: This document is intended as a reference for technical
 readers that intend to implement their own methods for registering Bitcoin stakes
 (either ones already on Bitcoin or new ones). Alternative methods of staking
-including (or hosting a staking platform) include using the front-end CLI
+(or hosting a staking platform) include using the front-end CLI
 (running the [simple staking](https://github.com/babylonlabs-io/simple-staking)
 reference implementation) or using the
 [Staker CLI program](https://github.com/babylonlabs-io/btc-staker).
 
 ## 2. Bitcoin Stake Registration Methods
 
-Bitcoin stakes must be registered on the Babylon blockchain
-to gain voting power and earn rewards.
-This registration process involves
-submitting a registration transaction
-followed by the validation of the staking operation by key
-network components including the Babylon chain CometBFT validators
+Bitcoin stakes must be registered on the Babylon Genesis blockchain
+to gain voting power and earn rewards. This registration process involves
+submitting a registration transaction followed by the validation of the staking operation by key
+network components including the Babylon Genesis chain CometBFT Validators
 and the covenant committee.
 
-There are two main methods for registering Bitcoin stakes on the Babylon blockchain:
+There are two main methods for registering Bitcoin stakes on the Babylon Genesis chain:
 * **Post-staking registration**: This applies to stakers who have already submitted
-  their BTC Staking transaction on the Bitcoin network and then register it on Babylon
-  (e.g., phase-1 stakers).
-* **Pre-staking registration**: This is for stakers who seek validation from the Babylon
-  chain before submitting their staking transaction on Bitcoin and locking their funds,
-  ensuring acceptance guarantees (e.g., newly created stakes after the Babylon chain launch).
+  their BTC Staking transaction on the Bitcoin network and then register it on Babylon Genesis
+  (e.g., Phase-1 stakers).
+* **Pre-staking registration**: This is for stakers who seek validation from the Babylon Genesis
+  chain before submitting their staking transaction to Bitcoin and locking their funds,
+  ensuring acceptance guarantees (e.g., newly created stakes after the Babylon Genesis chain launch).
 
 Each approach is designed to accommodate different staking preferences and
 circumstances. In the following sections, we will explore the approaches in more detail.
 
 > **⚡ A Note on `k`-depth**: In the following sections,
-> we frequently refer to `k`-depth. The Babylon chain
+> we frequently refer to `k`-depth. The Babylon Genesis chain
 > only activates staking transactions if they reach `k`-depth,
-> where `k` is a Babylon chain parameter defined in the
+> where `k` is a Babylon Genesis chain parameter defined in the
 > [x/btccheckpoint](../x/btccheckpoint) module (as `btc_confirmation_depth`)
 > and controlled by governance.
 >
@@ -81,8 +79,8 @@ circumstances. In the following sections, we will explore the approaches in more
 
 This flow applies to stakers whose BTC staking transaction has already
 been confirmed in a Bitcoin block that is `k`-deep
-and is subsequently registered on the Babylon chain.
-For example, this includes participants from a Babylon phase-1 network.
+and is subsequently registered on the Babylon Genesis chain.
+For example, this includes participants from the Babylon Phase-1 network.
 
 The following diagram illustrates the post-staking registration flow:
 ![stake-registration-post-staking-flow](./static/postregistration.png)
@@ -90,9 +88,9 @@ The following diagram illustrates the post-staking registration flow:
 Steps:
 1. **Generate staking metadata**: Retrieve the staking transaction
    from its included Bitcoin block and generate the proof of inclusion.
-2. **Fill the `MsgCreateBTCDelegation` message** with the  unbonding transaction,
-  signed slashing transactions and proof of possession (POP) and broadcast it to
-  the Babylon blockchain (details on how to do this will be provided in
+2. **Fill the `MsgCreateBTCDelegation` message** with the unbonding transaction,
+  signed slashing transactions and Proof of Possession (POP) and broadcast it to
+  the Babylon Genesis blockchain (details on how to do this will be provided in
   [Section 3.4.](#34-the-msgcreatebtcdelegation-babylon-message))
 3. **Await Covenant Verification**: The stake will remain in a `PENDING` state until the covenants
    provide their verification signatures.
@@ -108,27 +106,27 @@ Steps:
 > In those cases, the stake will have to be unbonded and staked again.
 >
 > **⚠️ Important Warning about Finality Providers**: Be cautious when selecting a
-> finality provider for your stake. If the finality provider you delegate to gets
+> Finality Provider for your stake. If the Finality Provider you delegate to gets
 > slashed before your stake is registered, your stake may become stuck. This is
-> particularly important for Phase-1 stake that is in the process of being
->registered.
+> particularly important for Phase-1 stakes that are in the process of being
+> registered.
 
 ### 2.2. Pre-Staking Registration
 
-The Pre-staking registration flow  is for stakers who seek
+The Pre-staking registration flow is for stakers who seek
 verification from the Babylon chain before submitting their
 BTC staking transaction to the Bitcoin ledger. By doing so,
 they gain assurance that their stake will be accepted before
 locking their funds on Bitcoin.
 
 The process begins with the staker submitting all relevant staking data
-to the Babylon chain. Subsequently, the covenant committee provides
+to the Babylon Genesis chain. Subsequently, the covenant committee provides
 verification signatures for on-demand unbonding and slashing,
 giving the staker the required assurance for moving on with broadcasting
 their BTC staking transaction. After the transaction is confirmed in
 a Bitcoin block that is `k`-deep, the staker
 (or an automated service like the
-[vigilante watcher](https://github.com/babylonlabs-io/vigilante))
+[Vigilante Watcher](https://github.com/babylonlabs-io/vigilante))
 submits a proof of inclusion to finalize the registration
 and lead to stake activation.
 
@@ -137,7 +135,7 @@ The following diagram illustrates the pre-staking registration flow:
 
 Steps:
 1. **Fill the `MsgCreateBTCDelegation` message** with necessary metadata and
-   broadcast it to the Babylon blockchain.
+   broadcast it to the Babylon Genesis blockchain.
    (details on how to do this
    will be provided in [Section 3.4.](#34-the-msgcreatebtcdelegation-babylon-message))
    > **⚡ Note**: As the staking transaction is not on the Bitcoin ledger yet,
@@ -154,14 +152,14 @@ Steps:
    [Vigilante Watcher](https://github.com/babylonlabs-io/vigilante) (or the staker)
    monitors Bitcoin for transaction confirmation and `k`-deep inclusion.
 6. **Confirm `k`-deep Inclusion**:
-   The vigilante watcher will identify that the transaction is k-deep in the Bitcoin chain.
+   The Vigilante Watcher will identify that the transaction is k-deep in the Bitcoin chain.
 7. **Submit Proof of Inclusion**:
-   Once the transaction is `k`-deep, the vigilante watcher (or the staker) submits
+   Once the transaction is `k`-deep, the Vigilante Watcher (or the staker) submits
    `MsgAddBTCDelegationInclusionProof`.
    > **⚡ Note**: If you prefer not to rely on the Vigilante Watcher, you can manually track
    > Bitcoin depth and submit this message yourself. Details on the message
    > construction can be found on the [x/btcstaking](../x/btcstaking) module documentation.
-   > For the rest of the document, we will assume reliance on the vigilante watcher service
+   > For the rest of the document, we will assume reliance on the Vigilante Watcher service
    > for simplicity.
 8. **Activation**:
    Upon receiving the proof of inclusion, the stake is marked as active.
@@ -169,54 +167,54 @@ Steps:
 > **⚠️ Critical Warning**: After your transaction is confirmed in a Bitcoin block,
 > remember to submit the proof of inclusion to complete the registration process.
 >
-> **⚠️ Important**: Gas Requirements for Pre-staking registration
+> **⚠️ Important**: Gas Requirements for Pre-staking Registration
 >
 > Since pre-staking registration does not require prior fund commitment
-> on Bitcoin, it could be exploited for chain spamming, especially
-> due to the multiple covenant signature submissions it triggers.
+> on Bitcoin, it could be exploited for chain spamming. This is especially
+> due to the multiple covenant signature submissions that it triggers.
 >
 > To mitigate this, submitting a `MsgCreateBTCDelegation` via
 > the pre-staking registration flow requires an increased
-> minimum gas fees that covers the gas for the staking,
+> minimum gas fee that covers the gas for the staking,
 > covenant signatures, and proof of inclusion submissions.
-> This mimimum gas is defined by the `delegation_creation_base_gas_fee`
-> staking parameter of the Babylon chain
+> This minimum gas is defined by the `delegation_creation_base_gas_fee`
+> staking parameter of the Babylon Genesis chain
 > (this parameter will be detailed in
 > [Section 3.2.](#32-babylon-chain-btc-staking-parameters)).
 >
 > **⚠️ Important Warning about Finality Providers**: Be cautious when selecting a
-> finality provider for your stake. If the finality provider you delegate to gets
+> Finality Provider for your stake. If the Finality Provider you delegate to gets
 > slashed before your stake is registered, your stake may become stuck. This is
-> particularly important for Phase-1 stake that is in the process of being
+> particularly important for Phase-1 stakes that are in the process of being
 >registered.
 
 ## 3. Bitcoin Stake Registration
 
 ### 3.1. Overview of Registration Data
 
-Registering a Bitcoin stake on the Babylon chain requires submitting the
+Registering a Bitcoin stake on the Babylon Genesis chain requires submitting the
 staking transaction along with essential metadata.
 This section provides an overview of the required data,
 while later sections detail how to create and package it into a
-Babylon registration transaction.
+Babylon Genesis registration transaction.
 
 **Key Registration Data**:
 * **BTC Staking Transaction**: The Bitcoin transaction that locks the Bitcoin stake
   in the self-custodial Bitcoin staking script. It can be submitted signed or unsigned,
   depending on the staking flow and UTXO inputs.
 * **Unbonding Transaction**: An *unsigned* unbonding transaction allowing
-  the staker to on-demand unbond their stake. It is submitted to the Babylon chain
+  the staker to on-demand unbond their stake. It is submitted to the Babylon Genesis chain
   and co-signed by the covenants upon verification.
 * **Slashing Transactions**: Two staker pre-signed slashing transactions
   (one for staking, one for unbonding) that ensure enforcement
-  of slashing if the finality provider to which the stake is delegated to
-  double-signs. They are submitted to the Babylon chain and co-signed
+  of slashing if the Finality Provider to which the stake is delegated to
+  double-signs. They are submitted to the Babylon Genesis chain and co-signed
   by the covenants upon verification.
 * **Proof of Possession**: Confirms ownership of the Bitcoin key
   by the Babylon account used for stake registration.
 * **Merkle Proof of Inclusion**: Verifies transaction inclusion in a Bitcoin
   block that is `k`-deep. Submitted during initial registration in the post-staking
-  registration flow or later in the pre-staking registration flow.
+  registration flow, or later in the pre-staking registration flow.
 
 > **⚠️ Critical Warning**: The proof of inclusion is a vital part of your
 > registration data.
@@ -229,31 +227,31 @@ Babylon registration transaction.
 > [Bitcoin Staking script specification](./staking-script.md).
 >
 > **⚠️ Important Warning about Finality Providers**: Be cautious when selecting a
-> finality provider for your stake. If the finality provider you delegate to gets
+> Finality Provider for your stake. If the Finality Provider you delegate to gets
 > slashed before your stake is registered, your stake may become stuck. This is
-> particularly important for Phase-1 stake that is in the process of being
+> particularly important for Phase-1 stakes that are in the process of being
 > registered.
 
-Once assembled, this data is packaged into a Babylon chain transaction and
+Once assembled, this data is packaged into a Babylon Genesis chain transaction and
 broadcast to the network. The process differs based on whether the staker
 follows the pre-staking or post-staking registration flow.
 
 **Upcoming Sections**:
 * Required parameters for BTC Staking transactions.
 * Construction of Bitcoin transactions for staking.
-* Building the Babylon chain transaction with required staking data.
-* Submitting the registration transaction to the Babylon chain.
+* Building the Babylon Genesis chain transaction with required staking data.
+* Submitting the registration transaction to Babylon Genesis.
 
-### 3.2. Babylon Chain BTC Staking Parameters
+### 3.2. Babylon Genesis Chain BTC Staking Parameters
 
-BTC Staking transactions must adhere to parameters defined by the Babylon chain,
-which vary based on Bitcoin block heights. Each parameters version
+BTC Staking transactions must adhere to parameters defined by the Babylon Genesis chain,
+which vary based on Bitcoin block heights. Each parameter version
 is defined by a `btc_activation_height`, determining the Bitcoin height
-from which the parameters version takes effect.
+from which the parameter version takes effect.
 To determine the applicable parameter version for a staking taking
 effect at Bitcoin block height `lookup_btc_height`:
-1. Sort all parameters versions by `btc_activation_height` in ascending order.
-2. The first parameters version with `lookup_btc_height >= btc_activation_height`
+1. Sort all parameter versions by `btc_activation_height` in ascending order.
+2. The first parameter version with `lookup_btc_height >= btc_activation_height`
    applies to the staking.
 
 Below is an overview of the key staking parameters contained in the different
@@ -277,27 +275,27 @@ versions managed by the [x/btcstaking](../x/btcstaking) module:
   The minimum transaction fee (in satoshis) required for the pre-signed slashing
   transaction.
 * `slashing_rate`: A scalar specifying the percentage of stake
-  slashed if the finality provider double-signs.
+  slashed if the Finality Provider double-signs.
 * `unbonding_time_blocks`:
   The on-demand unbonding time in Bitcoin blocks.
 * `unbonding_fee_sat`:
   The Bitcoin fee in satoshis required for unbonding transactions.
 * `min_commission_rate`: A scalar defining the minimum commission rate
-  for finality providers.
+  for Finality Providers.
 * `delegation_creation_base_gas_fee`: Defines the minimum
   gas fee to be paid when registering a stake through the pre-staking
   registration flow.
 * `allow_list_expiration_height`: The Babylon block height
-  on which the initial staking transaction allow-list expires.
+  at which the initial staking transaction allow-list expires.
   More details on the allow list can be found [here](./phase1-stake-registration-eligibility.md).
-* `btc_activation_height`: The Bitcoin block height on which this parameters version
+* `btc_activation_height`: The Bitcoin block height at which the parameter version
   takes effect.
 
 
 > **⚡ Retrieving Staking Parameters**
 >
 > These parameters are part of the [x/btcstaking](../x/btcstaking)
-> module parameters can be queried via a Babylon node using
+> module parameters that can be queried via a Babylon node using
 > RPC/LCD endpoints or the CLI.
 >
 > **⚠️  Warning**: Make sure that you are retrieving the BTC Staking parameters
@@ -318,7 +316,7 @@ versions managed by the [x/btcstaking](../x/btcstaking) module:
 > * **Pre-staking registration flow**: Use the parameters matching the
 >   **Babylon on-chain Bitcoin light client** at the time of pre-staking
 >   registration. This ensures that the transaction commits to be validated
->   against the current staking parameters version (as observed by the Babylon chain).
+>   against the current staking parameters version (as observed by Babylon Genesis).
 >   This ensures that the pre-staking registered transaction will remain valid even if
 >   it is later included
 >   in a Bitcoin block for which different parameters take effect,
@@ -326,11 +324,11 @@ versions managed by the [x/btcstaking](../x/btcstaking) module:
 >   the [x/btclightclient](../x/btclightclient) module using RPC/LCD endpoints
 >   or the CLI.
 
-### 3.3. Creating the Bitcoin transactions
+### 3.3. Creating Bitcoin Transactions
 
 The Bitcoin staking parameters from the previous section are used
 to create the necessary Bitcoin transactions for registering
-a Bitcoin stake on the Babylon and Bitcoin ledgers.
+a Bitcoin stake on the Babylon Genesis and Bitcoin ledgers.
 These transactions include:
 * **BTC Staking Transaction**: The Bitcoin transaction that locks
   the stake in the self-custodial Bitcoin staking script.
@@ -350,13 +348,13 @@ You can create these transactions using:
 > **⚡ Note**: Ensure you use the valid Babylon parameters when creating
 > the Bitcoin transactions.
 
-### 3.4. The `MsgCreateBTCDelegation` Babylon message
+### 3.4. The `MsgCreateBTCDelegation` Babylon Message
 
 Cosmos SDK transactions are used for registering
-BTC delegations on the Babylon chain.
+BTC delegations on Babylon Genesis.
 The `MsgCreateBTCDelegation` message
 bundles the necessary staking data and registers
-the Bitcoin stake on the Babylon blockchain.
+the Bitcoin stake on the Babylon Genesis blockchain.
 
 #### Key Fields in `MsgCreateBTCDelegation`
 
@@ -472,7 +470,7 @@ message MsgCreateBTCDelegation {
   >
   > Whether the staking transaction should include signed or unsigned
   > UTXO inputs depends on the type of inputs used.
-  > Since the Babylon chain tracks staking transactions based on
+  > Since the Babylon Genesis chain tracks staking transactions based on
   > their transaction hash, it's crucial for the staker to submit
   > the staking transaction in a format that contains all the
   > necessary data to generate the full hash corresponding
@@ -480,7 +478,7 @@ message MsgCreateBTCDelegation {
   >
   > For legacy inputs that require the `script_sig` field to be filled,
   > the signature **must** be included when submitting the
-  > transaction to Babylon, as this field directly influences
+  > transaction to Babylon Genesis, as this field directly influences
   > the transaction hash.
   >
   > On the other hand, for inputs that require the `witness` field
@@ -508,12 +506,12 @@ message MsgCreateBTCDelegation {
   > on Bitcoin before receiving covenant verification).
   > However, some stakers might still choose the pre-staking
   > registration flow, as it requires less waiting time
-  > (if the staker chooses to rely on the vigilante watcher)
+  > (if the staker chooses to rely on the Vigilante Watcher)
   > compared to the post-staking registration flow.
 * `staking_tx_inclusion_proof` (Optional):
   A merkle proof showing the staking transaction's inclusion in `k`-deep
   Bitcoin block. This field should be filled in when going through
-  the post-staking registration flow and left empty when going through
+  the post-staking registration flow and left empty when going through the pre-staking registration flow.
   The field is defined as an `InclusionProof` protobuf data type (specified below)
   with the following fields:
   ```proto
@@ -551,12 +549,11 @@ message MsgCreateBTCDelegation {
   slashing path and the staker's BIP-340 (Schnorr) signature for it.
   Both are in hex format.
   This transaction is considered fully signed once it has signatures
-  from the staker, a quorum of the covenants, and the finality provider.
+  from the staker, a quorum of the covenants, and the Finality Provider.
   Upon transaction verification, the covenant signatures are added,
-  meaning that only the finality provider's signature is missing.
-  According to the BTC Staking protocol,
-  if the finality provider double-signs,
-  its private key is exposed, leading to the full signature set.
+  meaning that only the Finality Provider's signature is missing.
+  According to the BTC Staking protocol, this means if the Finality Provider double-signs,
+  and its private key is exposed, leading to the full signature set.
 * `unbonding_time`:
   The on-demand unbonding period measured in Bitcoin blocks.
   This is the same as the timelock used when constructing
@@ -601,7 +598,7 @@ message to the Babylon network:
 > * Phase-1 staking transactions using the post-staking registration flow will
 >   only be accepted if they meet
 >   [these eligibility criteria](./phase1-stake-registration-eligibility.md).
-> * New phase-2 staking registration, whether created
+> * New Phase-2 staking registration, whether created
 >   through the pre-staking or post-staking registration flow,
 >   will only be accepted once the allow-list expires.
 
@@ -640,13 +637,13 @@ refer to:
 * [the TypeScript library documentation](https://github.com/babylonlabs-io/btc-staking-ts?tab=readme-ov-file#create-unbonding-transaction)
 * [the Golang staking library utils](../btcstaking/witness_utils.go)
 
-> **⚡ Note: Unbonding notification on the Babylon chain**
+> **⚡ Note: Unbonding Notification on the Babylon Genesis Chain**
 >
 > The Babylon system employs
 > the [Vigilante Unbonding Watcher](https://github.com/babylonlabs-io/vigilante),
 > a service that monitors the Bitcoin ledger for **on-demand unbonding transactions**
-> and reports them back to the Babylon chain. Once the unbonding transaction
-> is included Bitcoin, the vigilante detects it and notifies Babylon,
+> and reports them back to the Babylon Genesis chain. Once the unbonding transaction
+> is included Bitcoin, the Vigilante detects it and notifies the Babylon Genesis chain,
 > causing the stake to lose its voting power.
 
 ### 4.2. Withdrawing Expired/Unbonded Bitcoin Stake
@@ -669,20 +666,20 @@ refer to:
 
 ### 4.3. Withdrawing Remaining Funds after Slashing
 
-Bitcoin stake is slashed if the finality provider to
+A Bitcoin stake is slashed if the Finality Provider to
 which it was delegated to double-signs. Slashing involves
 broadcasting a [slashing transaction](./staking-script.md)
 that sends a portion of the slashed funds to a burn address
-(as defined in the staking params in [Section 3.2.](#32-babylon-chain-btc-staking-parameters)),
+(as defined in the staking parameters in [Section 3.2.](#32-babylon-chain-btc-staking-parameters)),
 while the remaining funds are transfered to a timelock script,
 which can later be withdrawn using the same withdrawal process
 defined in the previous section.
 
 To determine the slashing timelock, refer to the `unbonding_time_blocks`
-parameter in the [Babylon Chain BTC Staking Parameters](32-babylon-chain-btc-staking-parameters). Babylon ensures that the timelock on the change output of a slashing
+parameter in the [Babylon Chain BTC Staking Parameters](32-babylon-chain-btc-staking-parameters). Babylon Genesis ensures that the timelock on the change output of a slashing
 transaction matches the unbonding time. Therefore, the unbonding time
 parameter effectively represents your slashing timelock. The reasoning behind
-the timelock is that we want to avoid situation in which some finality providers
+the timelock is that we want to avoid situations in which some Finality Providers
 could use slashing as a way to unbond instantly.
 
 ## 5. Bitcoin Staking Rewards
@@ -703,15 +700,15 @@ The rewards are distributed as follows:
   The allocation is controlled by specific parameters:
   * **Bitcoin Stakers Portion**: Defined by the `btc_staking_portion` parameter,
     which specifies the portion of rewards allocated to Bitcoin stakers. This is
-    calculated based on the voting power and commission rate of the finality
-    provider the stake has been delegated to.
+    calculated based on the voting power and commission rate of the Finality
+    Provider the stake has been delegated to.
   * **Community Pool Portion**: Typically defined in the `x/distribution`
     module of the Cosmos SDK, often referred to as the community tax.
   * **Native Stakers Portion**: The remaining rewards, after allocations to
     Bitcoin stakers and the community pool, are distributed to native stakers.
 
 * Rewards for Bitcoin stakers are further distributed based on the voting power
-  and commission rate of the finality provider the stake has been delegated to.
+  and commission rate of the Finality Provider the stake has been delegated to.
   The rewards are entered into a gauge, which stakers can query and withdraw
   from through a transaction submission.
 * Rewards are distributed when a block is finalized. The system processes


### PR DESCRIPTION
- Consistent Capitalization for "Finality Providers" "Vigilante Watcher" "Phase-1"
- Clarified use of "Babylon Genesis" when referring to the mainnet chain
- Corrected spelling of "minimum"