### PR TITLE
fix: goreleaser for mainnet

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,13 +33,14 @@ builds:
       - -X github.com/cosmos/cosmos-sdk/version.AppName=babylond
       - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
       - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
-      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=ledger,muslc
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=ledger,muslc,mainnet
       - -linkmode=external
       - -w -s
       - -extldflags "-Wl,-z,muldefs -static -z noexecstack"
     tags:
       - ledger
       - muslc
+      - mainnet
 
   - id: babylond-testnet-linux-amd64
     main: ./cmd/babylond/main.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This PR contains a series of PRs on multi-staking support and BTC staking integr
 
 ### Bug fixes
 
+- [#796](https://github.com/babylonlabs-io/babylon/pull/796) fix: goreleaser add `mainnet` build flag to generated binary
 - [#741](https://github.com/babylonlabs-io/babylon/pull/741) chore: fix register consumer CLI
 - [#731](https://github.com/babylonlabs-io/babylon/pull/731) chore: fix block timeout in Babylon client
 - [#525](https://github.com/babylonlabs-io/babylon/pull/525) fix: add back `NewIBCHeaderDecorator` post handler


### PR DESCRIPTION
- Add `mainnet` build tag, since goreleaser is not using make to build, it needs to add mainnet manually