### PR TITLE
clean up resources from TmpAppOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ This PR contains a series of PRs on multi-staking support and BTC staking integr
 - [#731](https://github.com/babylonlabs-io/babylon/pull/731) chore: fix block timeout in Babylon client
 - [#525](https://github.com/babylonlabs-io/babylon/pull/525) fix: add back `NewIBCHeaderDecorator` post handler
 - [#793](https://github.com/babylonlabs-io/babylon/pull/793) fix: BLS key will be overwritten when the password is not retrieved
+- [#802](https://github.com/babylonlabs-io/babylon/pull/802) fix: clean up resources allocated by TmpAppOptions
 
 ## v1.0.0
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -24,13 +24,15 @@ func TestBabylonBlockedAddrs(t *testing.T) {
 	blsSigner := checkpointingtypes.BlsSigner(tbs)
 
 	logger := log.NewTestLogger(t)
+	appOpts, cleanup := TmpAppOptions()
+	defer cleanup()
 
 	app := NewBabylonAppWithCustomOptions(t, false, blsSigner, SetupOptions{
 		Logger:             logger,
 		DB:                 db,
 		InvCheckPeriod:     0,
 		SkipUpgradeHeights: map[int64]bool{},
-		AppOpts:            TmpAppOptions(),
+		AppOpts:            appOpts,
 	})
 
 	for acc := range BlockedAddresses() {
@@ -56,6 +58,9 @@ func TestBabylonBlockedAddrs(t *testing.T) {
 	require.NoError(t, err)
 
 	logger2 := log.NewTestLogger(t)
+
+	appOpts, cleanup = TmpAppOptions()
+	defer cleanup()
 	// Making a new app object with the db, so that initchain hasn't been called
 	app2 := NewBabylonApp(
 		logger2,
@@ -65,7 +70,7 @@ func TestBabylonBlockedAddrs(t *testing.T) {
 		map[int64]bool{},
 		0,
 		&blsSigner,
-		TmpAppOptions(),
+		appOpts,
 		EmptyWasmOpts,
 	)
 	_, err = app2.ExportAppStateAndValidators(false, []string{}, []string{})
@@ -85,13 +90,15 @@ func TestUpgradeStateOnGenesis(t *testing.T) {
 	blsSigner := checkpointingtypes.BlsSigner(tbs)
 
 	logger := log.NewTestLogger(t)
+	appOpts, cleanup := TmpAppOptions()
+	defer cleanup()
 
 	app := NewBabylonAppWithCustomOptions(t, false, blsSigner, SetupOptions{
 		Logger:             logger,
 		DB:                 db,
 		InvCheckPeriod:     0,
 		SkipUpgradeHeights: map[int64]bool{},
-		AppOpts:            TmpAppOptions(),
+		AppOpts:            appOpts,
 	})
 
 	// make sure the upgrade keeper has version map in state
@@ -109,13 +116,15 @@ func TestStakingRouterDisabled(t *testing.T) {
 	db := dbm.NewMemDB()
 	tbs, _ := testsigner.SetupTestBlsSigner()
 	logger := log.NewTestLogger(t)
+	appOpts, cleanup := TmpAppOptions()
+	defer cleanup()
 
 	app := NewBabylonAppWithCustomOptions(t, false, tbs, SetupOptions{
 		Logger:             logger,
 		DB:                 db,
 		InvCheckPeriod:     0,
 		SkipUpgradeHeights: map[int64]bool{},
-		AppOpts:            TmpAppOptions(),
+		AppOpts:            appOpts,
 	})
 
 	msgs := []sdk.Msg{

--- a/cmd/babylond/cmd/genhelpers/gentx_test.go
+++ b/cmd/babylond/cmd/genhelpers/gentx_test.go
@@ -42,12 +42,15 @@ func Test_CmdGenTx(t *testing.T) {
 
 	signer, err := signer.SetupTestBlsSigner()
 	require.NoError(t, err)
+	appOpts, cleanup := app.TmpAppOptions()
+	defer cleanup()
+
 	bbn := app.NewBabylonAppWithCustomOptions(t, false, signer, app.SetupOptions{
 		Logger:             logger,
 		DB:                 dbm.NewMemDB(),
 		InvCheckPeriod:     0,
 		SkipUpgradeHeights: map[int64]bool{},
-		AppOpts:            app.TmpAppOptions(),
+		AppOpts:            appOpts,
 	})
 
 	err = genutiltest.ExecInitCmd(bbn.BasicModuleManager, home, bbn.AppCodec())

--- a/cmd/babylond/cmd/testnet_test.go
+++ b/cmd/babylond/cmd/testnet_test.go
@@ -31,13 +31,15 @@ func Test_TestnetCmd(t *testing.T) {
 	tbs, err := signer.SetupTestBlsSigner()
 	require.NoError(t, err)
 	blsSigner := checkpointingtypes.BlsSigner(tbs)
+	appOpts, cleanup := app.TmpAppOptions()
+	defer cleanup()
 
 	bbn := app.NewBabylonAppWithCustomOptions(t, false, blsSigner, app.SetupOptions{
 		Logger:             logger,
 		DB:                 dbm.NewMemDB(),
 		InvCheckPeriod:     0,
 		SkipUpgradeHeights: map[int64]bool{},
-		AppOpts:            app.TmpAppOptions(),
+		AppOpts:            appOpts,
 	})
 	err = genutiltest.ExecInitCmd(bbn.BasicModuleManager, home, bbn.AppCodec())
 	require.NoError(t, err)

--- a/testutil/keeper/btclightclient.go
+++ b/testutil/keeper/btclightclient.go
@@ -57,8 +57,9 @@ func BTCLightClientKeeperWithCustomParams(
 
 	registry := codectypes.NewInterfaceRegistry()
 	cdc := codec.NewProtoCodec(registry)
-
-	testCfg := bbn.ParseBtcOptionsFromConfig(bapp.TmpAppOptions())
+	appOpts, cleanup := bapp.TmpAppOptions()
+	defer cleanup()
+	testCfg := bbn.ParseBtcOptionsFromConfig(appOpts)
 	stServ := runtime.NewKVStoreService(storeKey)
 	k := btclightclientk.NewKeeper(
 		cdc,


### PR DESCRIPTION
fixes: https://github.com/babylonlabs-io/babylon/issues/801
`TmpAppOptions` allocates external resources without giving the caller opportunity to clean them up. This pr changes that by also returning cleanup funciton for the caller to run when necessary.