### PR TITLE
fix: downgrade proto to 0.14

### DIFF
--- a/proto/buf.gen.swagger.yaml
+++ b/proto/buf.gen.swagger.yaml
@@ -1,5 +1,5 @@
 version: v1
 plugins:
-  - name: openapiv2
+  - name: swagger
     out: ../tmp-swagger-gen
-    opt: logtostderr=true,simple_operation_ids=true,openapi_naming_strategy=fqn
+    opt: logtostderr=true,fqn_for_swagger_name=true,simple_operation_ids=true

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -11,7 +11,7 @@ breaking:
     - FILE
 lint:
   use:
-    - STANDARD
+    - DEFAULT
     - COMMENTS
     - FILE_LOWER_SNAKE_CASE
     - COMMENT_MESSAGE

--- a/proto/scripts/protocgen.sh
+++ b/proto/scripts/protocgen.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 cd proto
 proto_dirs=$(find ./babylon -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 
-buf dep update
+buf mod update
 for dir in $proto_dirs; do
   for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
     if grep go_package $file &>/dev/null; then

--- a/scripts/makefile/protobuf.mk
+++ b/scripts/makefile/protobuf.mk
@@ -3,7 +3,7 @@
 ###                                Protobuf                                 ###
 ###############################################################################
 
-protoVer=0.16.0
+protoVer=0.14.0
 protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
 protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(protoImageName)
 


### PR DESCRIPTION
Downgrade to `0.14` as there needs to be some investigation against why we should upgrade to `0.16`