### PR TITLE
feat: Wire up ibc callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ check of rewards
 
 - [#402](https://github.com/babylonlabs-io/babylon/pull/402) **Babylon multi-staking support**.
 This PR contains a series of PRs on multi-staking support and BTC staking integration.
+- [#847](https://github.com/babylonlabs-io/babylon/pull/847) Add ibc callbacks to
+transfer stack
 
 ### Bug fixes
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -17,6 +17,32 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	appparams "github.com/babylonlabs-io/babylon/v2/app/params"
+	bbn "github.com/babylonlabs-io/babylon/v2/types"
+	owasm "github.com/babylonlabs-io/babylon/v2/wasmbinding"
+	btccheckpointkeeper "github.com/babylonlabs-io/babylon/v2/x/btccheckpoint/keeper"
+	btccheckpointtypes "github.com/babylonlabs-io/babylon/v2/x/btccheckpoint/types"
+	btclightclientkeeper "github.com/babylonlabs-io/babylon/v2/x/btclightclient/keeper"
+	btclightclienttypes "github.com/babylonlabs-io/babylon/v2/x/btclightclient/types"
+	btcstakingkeeper "github.com/babylonlabs-io/babylon/v2/x/btcstaking/keeper"
+	btcstakingtypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
+	bsckeeper "github.com/babylonlabs-io/babylon/v2/x/btcstkconsumer/keeper"
+	bsctypes "github.com/babylonlabs-io/babylon/v2/x/btcstkconsumer/types"
+	checkpointingkeeper "github.com/babylonlabs-io/babylon/v2/x/checkpointing/keeper"
+	checkpointingtypes "github.com/babylonlabs-io/babylon/v2/x/checkpointing/types"
+	epochingkeeper "github.com/babylonlabs-io/babylon/v2/x/epoching/keeper"
+	epochingtypes "github.com/babylonlabs-io/babylon/v2/x/epoching/types"
+	finalitykeeper "github.com/babylonlabs-io/babylon/v2/x/finality/keeper"
+	finalitytypes "github.com/babylonlabs-io/babylon/v2/x/finality/types"
+	incentivekeeper "github.com/babylonlabs-io/babylon/v2/x/incentive/keeper"
+	incentivetypes "github.com/babylonlabs-io/babylon/v2/x/incentive/types"
+	mintkeeper "github.com/babylonlabs-io/babylon/v2/x/mint/keeper"
+	minttypes "github.com/babylonlabs-io/babylon/v2/x/mint/types"
+	monitorkeeper "github.com/babylonlabs-io/babylon/v2/x/monitor/keeper"
+	monitortypes "github.com/babylonlabs-io/babylon/v2/x/monitor/types"
+	"github.com/babylonlabs-io/babylon/v2/x/zoneconcierge"
+	zckeeper "github.com/babylonlabs-io/babylon/v2/x/zoneconcierge/keeper"
+	zctypes "github.com/babylonlabs-io/babylon/v2/x/zoneconcierge/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -44,6 +70,7 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	ibccallbacks "github.com/cosmos/ibc-go/modules/apps/callbacks"
 	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
 	ibcwasmkeeper "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/keeper"
@@ -658,17 +685,31 @@ func (ak *AppKeepers) InitKeepers(
 	ak.GovKeeper.SetLegacyRouter(govRouter)
 
 	// Create all supported IBC routes
+	var wasmStack porttypes.IBCModule
+	wasmStackIBCHandler := wasm.NewIBCHandler(ak.WasmKeeper, ak.IBCKeeper.ChannelKeeper, ak.IBCFeeKeeper)
+	wasmStack = ibcfee.NewIBCMiddleware(wasmStackIBCHandler, ak.IBCFeeKeeper)
+
+	// Create Transfer Stack
+	// SendPacket, since it is originating from the application to core IBC:
+	// transferKeeper.SendPacket -> callbacks.Sen§dPacket -> feeKeeper.SendPacket -> channel.SendPacket
+
+	// RecvPacket, message that originates from core IBC and goes down to app, the flow is the other way
+	// channel.RecvPacket -> callbacks.OnRecvPacket -> fee.OnRecvPacket -> transfer.OnRecvPacket
+
+	// transfer stack contains (from top to bottom):
+	// - IBC Callbacks Middleware
+	// - IBC Fee Middleware
+	// - Transfer
 	var transferStack porttypes.IBCModule
 	transferStack = transfer.NewIBCModule(ak.TransferKeeper)
 	transferStack = ibcfee.NewIBCMiddleware(transferStack, ak.IBCFeeKeeper)
+	transferStack = ibccallbacks.NewIBCMiddleware(transferStack, ak.IBCFeeKeeper, wasmStackIBCHandler,
+		appparams.MaxIBCCallbackGas)
+	ak.TransferKeeper.WithICS4Wrapper(transferStack.(porttypes.ICS4Wrapper))
 
 	var zoneConciergeStack porttypes.IBCModule
 	zoneConciergeStack = zoneconcierge.NewIBCModule(ak.ZoneConciergeKeeper)
 	zoneConciergeStack = ibcfee.NewIBCMiddleware(zoneConciergeStack, ak.IBCFeeKeeper)
-
-	var wasmStack porttypes.IBCModule
-	wasmStack = wasm.NewIBCHandler(ak.WasmKeeper, ak.IBCKeeper.ChannelKeeper, ak.IBCFeeKeeper)
-	wasmStack = ibcfee.NewIBCMiddleware(wasmStack, ak.IBCFeeKeeper)
 
 	// Create static IBC router, add ibc-transfer module route, then set and seal it
 	ibcRouter := porttypes.NewRouter().

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -30,6 +30,9 @@ const (
 	// GlobalMinGasPrice is used in the AnteHandler to ensure
 	// that all transactions have a gas price greater than or equal to this value.
 	GlobalMinGasPrice = DefaultMinGasPrice
+
+	// MaxIBCCallbackGas should roughly be a couple orders of magnitude larger than needed.
+	MaxIBCCallbackGas = uint64(10_000_000)
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,8 @@ require (
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.1 // indirect
 	github.com/gogo/status v1.1.0 // indirect
+	// https://github.com/cosmos/ibc-go/releases/tag/modules%2Fapps%2Fcallbacks%2Fv0.2.0%2Bibc-go-v8.0
+	github.com/cosmos/ibc-go/modules/apps/callbacks v0.2.1-0.20231113120333-342c00b0f8bd
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
@@ -175,7 +177,6 @@ require (
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
-	github.com/cosmos/ibc-go/modules/apps/callbacks v0.2.1-0.20231113120333-342c00b0f8bd // indirect
 	github.com/cosmos/ics23/go v0.11.0 // indirect
 	github.com/creachadair/atomicfile v0.3.1 // indirect
 	github.com/creachadair/tomledit v0.0.24 // indirect

--- a/go.mod
+++ b/go.mod
@@ -75,9 +75,9 @@ require (
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.1 // indirect
-	github.com/gogo/status v1.1.0 // indirect
 	// https://github.com/cosmos/ibc-go/releases/tag/modules%2Fapps%2Fcallbacks%2Fv0.2.0%2Bibc-go-v8.0
 	github.com/cosmos/ibc-go/modules/apps/callbacks v0.2.1-0.20231113120333-342c00b0f8bd
+	github.com/gogo/status v1.1.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
@@ -273,7 +273,6 @@ require (
 // Long lived replaces of Cosmos SDK
 // see: https://github.com/cosmos/cosmos-sdk/blob/v0.50.3/go.mod
 replace (
-
 	// core v0.12 was tagged wrong
 	cosmossdk.io/core => cosmossdk.io/core v0.11.0
 	// use cosmos fork of keyring


### PR DESCRIPTION
Wiring based on : https://github.com/cosmos/ibc-go/blob/modules/apps/callbacks/v0.2.0%2Bibc-go-v8.0/modules/apps/callbacks/testing/simapp/app.go#L511

As IBC-callbacks are stateless, no upgrade is needed