### PR TITLE
backport(bugfix): add checks for slashed fp in gov resume finality (#829) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - [#845](https://github.com/babylonlabs-io/babylon/pull/845) fix: Properly wire `btclightclient` hook for
 `btcstaking` to panic in case of a BTC reorg larger than `BtcConfirmationDepth`.
+- [#829](https://github.com/babylonlabs-io/babylon/pull/829) fix: add checks for slashed fp in gov resume finality.
 
 ## v1.0.2
 

--- a/cmd/babylond/cmd/cmd_test.go
+++ b/cmd/babylond/cmd/cmd_test.go
@@ -14,12 +14,13 @@ import (
 )
 
 func TestInitCmd(t *testing.T) {
+	tmpDir := t.TempDir()
 	rootCmd := cmd.NewRootCmd()
 	rootCmd.SetArgs([]string{
 		"init",     // Test the init cmd
 		"app-test", // Moniker
 		fmt.Sprintf("--%s=%s", cli.FlagOverwrite, "true"), // Overwrite genesis.json, in case it already exists
-		fmt.Sprintf("--%s=%s", flags.FlagHome, t.TempDir()),
+		fmt.Sprintf("--%s=%s", flags.FlagHome, tmpDir),
 		"--no-bls-password",
 	})
 

--- a/test/e2e/initialization/config.go
+++ b/test/e2e/initialization/config.go
@@ -296,6 +296,7 @@ func updateBankGenesis(bankGenState *banktypes.GenesisState) {
 func updateGovGenesis(votingPeriod, expeditedVotingPeriod time.Duration) func(govGenState *govv1.GenesisState) {
 	return func(govGenState *govv1.GenesisState) {
 		govGenState.Params.MinDeposit = sdk.NewCoins(sdk.NewCoin(BabylonDenom, sdkmath.NewInt(100)))
+		govGenState.Params.ExpeditedMinDeposit = sdk.NewCoins(sdk.NewCoin(BabylonDenom, sdkmath.NewInt(1000)))
 		govGenState.Params.VotingPeriod = &votingPeriod
 		govGenState.Params.ExpeditedVotingPeriod = &expeditedVotingPeriod
 	}

--- a/test/replay/app_replay_e2e_test.go
+++ b/test/replay/app_replay_e2e_test.go
@@ -1,7 +1,9 @@
 package replay
 
 import (
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -10,30 +12,34 @@ import (
 )
 
 func TestReplayBlocks(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	driverTempDir := t.TempDir()
 	replayerTempDir := t.TempDir()
-	driver := NewBabylonAppDriver(t, driverTempDir, replayerTempDir)
+	driver := NewBabylonAppDriver(r, t, driverTempDir, replayerTempDir)
 
 	for i := 0; i < 100; i++ {
-		driver.GenerateNewBlock(t)
+		driver.GenerateNewBlock()
 	}
 
 	replayer := NewBlockReplayer(t, replayerTempDir)
-	replayer.ReplayBlocks(t, driver.FinalizedBlocks)
+	replayer.ReplayBlocks(t, driver.GetFinalizedBlocks())
 
 	// after replay we should have the same apphash
-	require.Equal(t, driver.LastState.LastBlockHeight, replayer.LastState.LastBlockHeight)
-	require.Equal(t, driver.LastState.AppHash, replayer.LastState.AppHash)
+	require.Equal(t, driver.GetLastState().LastBlockHeight, replayer.LastState.LastBlockHeight)
+	require.Equal(t, driver.GetLastState().AppHash, replayer.LastState.AppHash)
 }
 
 func TestSendingTxFromDriverAccount(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	driverTempDir := t.TempDir()
 	replayerTempDir := t.TempDir()
-	driver := NewBabylonAppDriver(t, driverTempDir, replayerTempDir)
+	driver := NewBabylonAppDriver(r, t, driverTempDir, replayerTempDir)
 
 	// go over epoch boundary
 	for i := 0; i < 1+epochLength; i++ {
-		driver.GenerateNewBlock(t)
+		driver.GenerateNewBlock()
 	}
 
 	_, _, addr1 := testdata.KeyTestPubAddr()
@@ -52,9 +58,9 @@ func TestSendingTxFromDriverAccount(t *testing.T) {
 
 	// check that replayer has the same state as driver, as we replayed all blocks
 	replayer := NewBlockReplayer(t, replayerTempDir)
-	replayer.ReplayBlocks(t, driver.FinalizedBlocks)
+	replayer.ReplayBlocks(t, driver.GetFinalizedBlocks())
 
 	// after replay we should have the same apphash
-	require.Equal(t, driver.LastState.LastBlockHeight, replayer.LastState.LastBlockHeight)
-	require.Equal(t, driver.LastState.AppHash, replayer.LastState.AppHash)
+	require.Equal(t, driver.GetLastState().LastBlockHeight, replayer.LastState.LastBlockHeight)
+	require.Equal(t, driver.GetLastState().AppHash, replayer.LastState.AppHash)
 }

--- a/test/replay/covenant_sender.go
+++ b/test/replay/covenant_sender.go
@@ -1,0 +1,155 @@
+package replay
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/babylonlabs-io/babylon/v2/btcstaking"
+	"github.com/babylonlabs-io/babylon/v2/types"
+	bstypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+
+	babylonApp "github.com/babylonlabs-io/babylon/v2/app"
+	"github.com/babylonlabs-io/babylon/v2/testutil/datagen"
+	"github.com/stretchr/testify/require"
+)
+
+type CovenantSender struct {
+	*SenderInfo
+	r   *rand.Rand
+	t   *testing.T
+	d   *BabylonAppDriver
+	app *babylonApp.BabylonApp
+}
+
+type StakingInfos struct {
+	FpPKs                 []*btcec.PublicKey
+	CovenantPks           []*btcec.PublicKey
+	StakerAddr            string
+	StakingTxHash         string
+	StakingSlashingInfo   *datagen.TestStakingSlashingInfo
+	UnbondingSlashingInfo *datagen.TestUnbondingSlashingInfo
+}
+
+func parseInfos(
+	t *testing.T,
+	resp *bstypes.BTCDelegationResponse,
+	params *bstypes.Params,
+) *StakingInfos {
+	stakingTx, _, err := types.NewBTCTxFromHex(resp.StakingTxHex)
+	require.NoError(t, err)
+	unbondingTx, _, err := types.NewBTCTxFromHex(resp.UndelegationResponse.UnbondingTxHex)
+	require.NoError(t, err)
+	slashingTx, err := bstypes.NewBTCSlashingTxFromHex(resp.SlashingTxHex)
+	require.NoError(t, err)
+	unbondingSlashingTx, err := bstypes.NewBTCSlashingTxFromHex(resp.UndelegationResponse.SlashingTxHex)
+	require.NoError(t, err)
+
+	fpPKs := make([]*btcec.PublicKey, len(resp.FpBtcPkList))
+	for i, pk := range resp.FpBtcPkList {
+		fpPKs[i] = pk.MustToBTCPK()
+	}
+
+	covenantPks := make([]*btcec.PublicKey, len(params.CovenantPks))
+
+	for i, pk := range params.CovenantPks {
+		covenantPks[i] = pk.MustToBTCPK()
+	}
+
+	stakingInfo, err := btcstaking.BuildStakingInfo(
+		resp.BtcPk.MustToBTCPK(),
+		fpPKs,
+		covenantPks,
+		params.CovenantQuorum,
+		uint16(resp.StakingTime),
+		btcutil.Amount(resp.TotalSat),
+		BtcParams,
+	)
+	require.NoError(t, err)
+
+	unbondingInfo, err := btcstaking.BuildUnbondingInfo(
+		resp.BtcPk.MustToBTCPK(),
+		fpPKs,
+		covenantPks,
+		params.CovenantQuorum,
+		uint16(resp.UnbondingTime),
+		btcutil.Amount(resp.TotalSat-uint64(params.UnbondingFeeSat)),
+		BtcParams,
+	)
+	require.NoError(t, err)
+
+	testStakingInfo := datagen.TestStakingSlashingInfo{
+		StakingTx:   stakingTx,
+		SlashingTx:  slashingTx,
+		StakingInfo: stakingInfo,
+	}
+
+	testUnbondingInfo := datagen.TestUnbondingSlashingInfo{
+		UnbondingTx:   unbondingTx,
+		SlashingTx:    unbondingSlashingTx,
+		UnbondingInfo: unbondingInfo,
+	}
+
+	stkTxHash := stakingTx.TxHash().String()
+
+	return &StakingInfos{
+		FpPKs:                 fpPKs,
+		CovenantPks:           covenantPks,
+		StakerAddr:            resp.StakerAddr,
+		StakingTxHash:         stkTxHash,
+		StakingSlashingInfo:   &testStakingInfo,
+		UnbondingSlashingInfo: &testUnbondingInfo,
+	}
+}
+
+func (c *CovenantSender) SendCovenantSignatures() {
+	pendingDels := c.d.GetPendingBTCDelegations(c.t)
+	params := c.d.GetBTCStakingParams(c.t)
+
+	for _, del := range pendingDels {
+		infos := parseInfos(c.t, del, params)
+
+		slashingPkScriptPath, err := infos.StakingSlashingInfo.StakingInfo.SlashingPathSpendInfo()
+		require.NoError(c.t, err)
+		unbondingPkScriptPath, err := infos.StakingSlashingInfo.StakingInfo.UnbondingPathSpendInfo()
+		require.NoError(c.t, err)
+
+		covenantSigs, err := datagen.GenCovenantAdaptorSigs(
+			covenantSKs,
+			infos.FpPKs,
+			infos.StakingSlashingInfo.StakingTx,
+			slashingPkScriptPath.GetPkScriptPath(),
+			infos.StakingSlashingInfo.SlashingTx,
+		)
+		require.NoError(c.t, err)
+
+		covUnbondingSlashingSigs, covUnbondingSigs, err := infos.UnbondingSlashingInfo.GenCovenantSigs(
+			covenantSKs,
+			infos.FpPKs,
+			infos.StakingSlashingInfo.StakingTx,
+			unbondingPkScriptPath.GetPkScriptPath(),
+		)
+		require.NoError(c.t, err)
+
+		for i := 0; i < len(infos.CovenantPks); i++ {
+			msgAddCovenantSig := &bstypes.MsgAddCovenantSigs{
+				Signer:                  c.AddressString(),
+				Pk:                      covenantSigs[i].CovPk,
+				StakingTxHash:           infos.StakingTxHash,
+				SlashingTxSigs:          covenantSigs[i].AdaptorSigs,
+				UnbondingTxSig:          covUnbondingSigs[i].Sig,
+				SlashingUnbondingTxSigs: covUnbondingSlashingSigs[i].AdaptorSigs,
+			}
+			// send each message with different transactions
+			DefaultSendTxWithMessagesSuccess(
+				c.t,
+				c.app,
+				c.SenderInfo,
+				msgAddCovenantSig,
+			)
+
+			c.IncSeq()
+		}
+	}
+}

--- a/test/replay/driver.go
+++ b/test/replay/driver.go
@@ -6,18 +6,17 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	goMath "math"
+
 	"math/rand"
 	"path/filepath"
 	"testing"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/babylonlabs-io/babylon/v2/btctxformatter"
 	bbn "github.com/babylonlabs-io/babylon/v2/types"
 	btckckpttypes "github.com/babylonlabs-io/babylon/v2/x/btccheckpoint/types"
 	ckpttypes "github.com/babylonlabs-io/babylon/v2/x/checkpointing/types"
-	et "github.com/babylonlabs-io/babylon/v2/x/epoching/types"
-	ftypes "github.com/babylonlabs-io/babylon/v2/x/finality/types"
 
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
@@ -45,10 +44,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	gogoprotoio "github.com/cosmos/gogoproto/io"
 	"github.com/otiai10/copy"
 	"github.com/stretchr/testify/require"
@@ -74,12 +74,12 @@ var validatorConfig = &initialization.NodeConfig{
 }
 
 const (
-	chainID      = initialization.ChainAID
-	testPartSize = 65536
-
-	defaultGasLimit = 5000000
+	chainID         = initialization.ChainAID
+	testPartSize    = 65536
+	defaultGasLimit = 750000
 	defaultFee      = 500000
 	epochLength     = 10
+	blkTime         = time.Second * 5
 )
 
 var (
@@ -91,19 +91,9 @@ var (
 func getGenDoc(
 	t *testing.T, nodeDir string) (map[string]json.RawMessage, *genutiltypes.AppGenesis) {
 	path := filepath.Join(nodeDir, "config", "genesis.json")
-	fmt.Printf("path to gendoc: %s\n", path)
-
 	genState, appGenesis, err := genutiltypes.GenesisStateFromGenFile(path)
 	require.NoError(t, err)
 	return genState, appGenesis
-}
-
-func MsgsToSdkMsg[M sdk.Msg](msgs []M) []sdk.Msg {
-	sdkMsgs := make([]sdk.Msg, len(msgs))
-	for i, msg := range msgs {
-		sdkMsgs[i] = msg
-	}
-	return sdkMsgs
 }
 
 type AppOptionsMap map[string]interface{}
@@ -127,10 +117,10 @@ func NewAppOptionsWithFlagHome(homePath string) servertypes.AppOptions {
 	}
 }
 
-func getBlockId(t *testing.T, block *cmttypes.Block) cmttypes.BlockID {
+func getBlockId(t *testing.T, block *cmttypes.Block) (cmttypes.BlockID, *cmttypes.PartSet) {
 	bps, err := block.MakePartSet(testPartSize)
 	require.NoError(t, err)
-	return cmttypes.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
+	return cmttypes.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}, bps
 }
 
 type FinalizedBlock struct {
@@ -140,34 +130,44 @@ type FinalizedBlock struct {
 }
 
 type BabylonAppDriver struct {
-	App                  *app.BabylonApp
-	BlsSigner            checkpointingtypes.BlsSigner
-	DriverAccountPrivKey cryptotypes.PrivKey
-	DriverAccountSeqNr   uint64
-	DriverAccountAccNr   uint64
-	BlockExec            *sm.BlockExecutor
-	BlockStore           *store.BlockStore
-	StateStore           sm.Store
-	NodeDir              string
-	ValidatorAddress     []byte
-	FinalizedBlocks      []FinalizedBlock
-	LastState            sm.State
-	DelegatorAddress     sdk.ValAddress
-	CometPrivKey         cmtcrypto.PrivKey
+	*SenderInfo
+	r                *rand.Rand
+	t                *testing.T
+	App              *app.BabylonApp
+	BlsSigner        checkpointingtypes.BlsSigner
+	BlockExec        *sm.BlockExecutor
+	BlockStore       *store.BlockStore
+	StateStore       sm.Store
+	NodeDir          string
+	ValidatorAddress []byte
+	DelegatorAddress sdk.ValAddress
+	CometPrivKey     cmtcrypto.PrivKey
+	CurrentTime      time.Time
+}
+
+// NewBabylonAppDriverTmpDir initializes Babylon driver for block creation with
+// temporary directories
+func NewBabylonAppDriverTmpDir(r *rand.Rand, t *testing.T) *BabylonAppDriver {
+	driverTempDir := t.TempDir()
+	replayerTempDir := t.TempDir()
+	return NewBabylonAppDriver(r, t, driverTempDir, replayerTempDir)
 }
 
 // Inititializes Babylon driver for block creation
 func NewBabylonAppDriver(
+	r *rand.Rand,
 	t *testing.T,
 	dir string,
 	copyDir string,
 ) *BabylonAppDriver {
+	expeditedVotingPeriod := blkTime + time.Second
+
 	chain, err := initialization.InitChain(
 		chainID,
 		dir,
 		[]*initialization.NodeConfig{validatorConfig},
-		3*time.Minute,
-		1*time.Minute,
+		expeditedVotingPeriod*2, // voting period
+		expeditedVotingPeriod,   // expedited
 		1,
 		[]*btclighttypes.BTCHeaderInfo{},
 	)
@@ -204,7 +204,6 @@ func NewBabylonAppDriver(
 	require.NotNil(t, blsSigner)
 	signerValAddress := sdk.ValAddress(chain.Nodes[0].PublicAddress)
 	require.NoError(t, err)
-	fmt.Printf("signer val address: %s\n", signerValAddress.String())
 
 	appOptions := NewAppOptionsWithFlagHome(chain.Nodes[0].ConfigDir)
 	baseAppOptions := server.DefaultBaseappOptions(appOptions)
@@ -264,31 +263,39 @@ func NewBabylonAppDriver(
 	}
 
 	return &BabylonAppDriver{
-		App:                  tmpApp,
-		BlsSigner:            *blsSigner,
-		DriverAccountPrivKey: &validatorPrivKey,
-		// Driver account always start from 1, as we executed tx for creating validator
-		// in genesis block
-		DriverAccountSeqNr: 1,
-		DriverAccountAccNr: 0,
-		BlockExec:          blockExec,
-		BlockStore:         blockStore,
-		StateStore:         stateStore,
-		NodeDir:            chain.Nodes[0].ConfigDir,
-		ValidatorAddress:   validatorAddress,
-		FinalizedBlocks:    []FinalizedBlock{},
-		LastState:          state.Copy(),
-		DelegatorAddress:   signerValAddress,
-		CometPrivKey:       ed25519.PrivKey(chain.Nodes[0].CometPrivKey),
+		r:         r,
+		t:         t,
+		App:       tmpApp,
+		BlsSigner: *blsSigner,
+		SenderInfo: &SenderInfo{
+			privKey:        &validatorPrivKey,
+			sequenceNumber: 1,
+			accountNumber:  0,
+		},
+		BlockExec:        blockExec,
+		BlockStore:       blockStore,
+		StateStore:       stateStore,
+		NodeDir:          chain.Nodes[0].ConfigDir,
+		ValidatorAddress: validatorAddress,
+		DelegatorAddress: signerValAddress,
+		CometPrivKey:     ed25519.PrivKey(chain.Nodes[0].CometPrivKey),
+		// initiate time to current time
+		CurrentTime: time.Now(),
 	}
 }
 
+func (d *BabylonAppDriver) Ctx() sdk.Context {
+	return d.GetContextForLastFinalizedBlock()
+}
+
 func (d *BabylonAppDriver) GetLastFinalizedBlock() *FinalizedBlock {
-	if len(d.FinalizedBlocks) == 0 {
+	finalizedBlocks := d.GetFinalizedBlocks()
+
+	if len(finalizedBlocks) == 0 {
 		return nil
 	}
 
-	return &d.FinalizedBlocks[len(d.FinalizedBlocks)-1]
+	return &finalizedBlocks[len(finalizedBlocks)-1]
 }
 
 func (d *BabylonAppDriver) GetContextForLastFinalizedBlock() sdk.Context {
@@ -296,16 +303,28 @@ func (d *BabylonAppDriver) GetContextForLastFinalizedBlock() sdk.Context {
 	return d.App.NewUncachedContext(false, *lastFinalizedBlock.Block.Header.ToProto())
 }
 
-type senderInfo struct {
+type SenderInfo struct {
 	privKey        cryptotypes.PrivKey
 	sequenceNumber uint64
 	accountNumber  uint64
 }
 
+func (s *SenderInfo) IncSeq() {
+	s.sequenceNumber++
+}
+
+func (s *SenderInfo) Address() sdk.AccAddress {
+	return sdk.AccAddress(s.privKey.PubKey().Address())
+}
+
+func (s *SenderInfo) AddressString() string {
+	return s.Address().String()
+}
+
 func createTx(
 	t *testing.T,
 	txConfig client.TxConfig,
-	senderInfo *senderInfo,
+	senderInfo *SenderInfo,
 	gas uint64,
 	fee sdk.Coin,
 	msgs ...sdk.Msg,
@@ -356,7 +375,7 @@ func createTx(
 
 func (d *BabylonAppDriver) CreateTx(
 	t *testing.T,
-	senderInfo *senderInfo,
+	senderInfo *SenderInfo,
 	gas uint64,
 	fee sdk.Coin,
 	msgs ...sdk.Msg,
@@ -368,7 +387,7 @@ func (d *BabylonAppDriver) CreateTx(
 // execution was successful
 func (d *BabylonAppDriver) SendTxWithMessagesSuccess(
 	t *testing.T,
-	senderInfo *senderInfo,
+	senderInfo *SenderInfo,
 	gas uint64,
 	fee sdk.Coin,
 	msgs ...sdk.Msg,
@@ -381,6 +400,41 @@ func (d *BabylonAppDriver) SendTxWithMessagesSuccess(
 	})
 	require.NoError(t, err)
 	require.Equal(t, result.Code, uint32(0))
+}
+
+func SendTxWithMessagesSuccess(
+	t *testing.T,
+	app *babylonApp.BabylonApp,
+	senderInfo *SenderInfo,
+	gas uint64,
+	fee sdk.Coin,
+	msgs ...sdk.Msg,
+) {
+	txBytes := createTx(t, app.TxConfig(), senderInfo, gas, fee, msgs...)
+
+	result, err := app.CheckTx(&abci.RequestCheckTx{
+		Tx:   txBytes,
+		Type: abci.CheckTxType_New,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, result.Code, uint32(0))
+}
+
+func DefaultSendTxWithMessagesSuccess(
+	t *testing.T,
+	app *babylonApp.BabylonApp,
+	senderInfo *SenderInfo,
+	msgs ...sdk.Msg,
+) {
+	SendTxWithMessagesSuccess(
+		t,
+		app,
+		senderInfo,
+		defaultGasLimit,
+		defaultFeeCoin,
+		msgs...,
+	)
 }
 
 func signVoteExtension(
@@ -406,148 +460,140 @@ func signVoteExtension(
 	return extensionSig
 }
 
-func (d *BabylonAppDriver) GenerateNewBlock(t *testing.T) *abci.ResponseFinalizeBlock {
-	if len(d.FinalizedBlocks) == 0 {
-		extCommitFirsBlock := &cmttypes.ExtendedCommit{}
-		block1, err := d.BlockExec.CreateProposalBlock(
-			context.Background(),
-			1,
-			d.LastState,
-			extCommitFirsBlock,
-			d.ValidatorAddress,
-		)
-		require.NoError(t, err)
-		require.NotNil(t, block1)
+func (d *BabylonAppDriver) GenerateNewBlock() *abci.ResponseFinalizeBlock {
+	lastState, err := d.StateStore.Load()
+	require.NoError(d.t, err)
+	require.NotNil(d.t, lastState)
 
-		accepted, err := d.BlockExec.ProcessProposal(block1, d.LastState)
-		require.NoError(t, err)
-		require.True(t, accepted)
-
-		block1ID := getBlockId(t, block1)
-		state, err := d.BlockExec.ApplyVerifiedBlock(d.LastState, block1ID, block1)
-		require.NoError(t, err)
-		require.NotNil(t, state)
-
-		d.FinalizedBlocks = append(d.FinalizedBlocks, FinalizedBlock{
-			Height: 1,
-			ID:     block1ID,
-			Block:  block1,
-		})
-		d.LastState = state.Copy()
-
-		lastResponse, err := d.StateStore.LoadFinalizeBlockResponse(1)
-		require.NoError(t, err)
-		require.NotNil(t, lastResponse)
-		return lastResponse
+	var lastCommit *cmttypes.ExtendedCommit
+	if lastState.LastBlockHeight == 0 {
+		lastCommit = &cmttypes.ExtendedCommit{}
 	} else {
-		lastFinalizedBlock := d.GetLastFinalizedBlock()
-
-		var extension []byte
-
-		if lastFinalizedBlock.Height > 1 {
-			ext, err := d.BlockExec.ExtendVote(
-				context.Background(),
-				&cmttypes.Vote{
-					BlockID: lastFinalizedBlock.ID,
-					Height:  int64(lastFinalizedBlock.Height),
-				},
-				lastFinalizedBlock.Block,
-				d.LastState,
-			)
-			require.NoError(t, err)
-			extension = ext
-		} else {
-			extension = []byte{}
-		}
-
-		extensionSig := signVoteExtension(
-			t,
-			extension,
-			lastFinalizedBlock.Height,
-			d.CometPrivKey,
-		)
-
-		// We are adding invalid signatures here as we are not validating them in
-		// ApplyBlock
-		extCommitSig := cmttypes.ExtendedCommitSig{
-			CommitSig: cmttypes.CommitSig{
-				BlockIDFlag:      cmttypes.BlockIDFlagCommit,
-				ValidatorAddress: d.ValidatorAddress,
-				Timestamp:        time.Now().Add(1 * time.Second),
-				Signature:        []byte("test"),
-			},
-			Extension:          extension,
-			ExtensionSignature: extensionSig,
-		}
-
-		oneValExtendedCommit := &cmttypes.ExtendedCommit{
-			Height:  int64(lastFinalizedBlock.Height),
-			Round:   0,
-			BlockID: lastFinalizedBlock.ID,
-			ExtendedSignatures: []cmttypes.ExtendedCommitSig{
-				extCommitSig,
-			},
-		}
-
-		block1, err := d.BlockExec.CreateProposalBlock(
-			context.Background(),
-			int64(lastFinalizedBlock.Height)+1,
-			d.LastState,
-			oneValExtendedCommit,
-			d.ValidatorAddress,
-		)
-		require.NoError(t, err)
-		require.NotNil(t, block1)
-
-		// it is here as it is good sanity check for all babylon custom validations
-		accepted, err := d.BlockExec.ProcessProposal(block1, d.LastState)
-		require.NoError(t, err)
-		require.True(t, accepted)
-
-		block1ID := getBlockId(t, block1)
-		state, err := d.BlockExec.ApplyVerifiedBlock(d.LastState, block1ID, block1)
-		require.NoError(t, err)
-		require.NotNil(t, state)
-
-		d.FinalizedBlocks = append(d.FinalizedBlocks, FinalizedBlock{
-			Height: lastFinalizedBlock.Height + 1,
-			ID:     block1ID,
-			Block:  block1,
-		})
-		d.LastState = state.Copy()
-
-		lastResponse, err := d.StateStore.LoadFinalizeBlockResponse(state.LastBlockHeight)
-		require.NoError(t, err)
-		require.NotNil(t, lastResponse)
-		return lastResponse
+		lastCommit = d.BlockStore.LoadBlockExtendedCommit(lastState.LastBlockHeight)
+		require.NotNil(d.t, lastCommit)
 	}
+
+	block1, err := d.BlockExec.CreateProposalBlock(
+		context.Background(),
+		lastState.LastBlockHeight+1,
+		lastState,
+		lastCommit,
+		d.ValidatorAddress,
+	)
+	require.NoError(d.t, err)
+	require.NotNil(d.t, block1)
+
+	block1ID, partSet := getBlockId(d.t, block1)
+
+	extension, err := d.BlockExec.ExtendVote(
+		context.Background(),
+		&cmttypes.Vote{
+			BlockID: block1ID,
+			Height:  block1.Height,
+		},
+		block1,
+		lastState,
+	)
+	require.NoError(d.t, err)
+
+	extensionSig := signVoteExtension(
+		d.t,
+		extension,
+		uint64(block1.Height),
+		d.CometPrivKey,
+	)
+
+	// We are adding invalid signatures here as we are not validating them in
+	// ApplyBlock
+	// add slepp to avoid zero duration for minting
+	// Simulate 5s block time
+	newTime := d.CurrentTime.Add(blkTime)
+	extCommitSig := cmttypes.ExtendedCommitSig{
+		CommitSig: cmttypes.CommitSig{
+			BlockIDFlag:      cmttypes.BlockIDFlagCommit,
+			ValidatorAddress: d.ValidatorAddress,
+			Timestamp:        newTime,
+			Signature:        []byte("test"),
+		},
+		Extension:          extension,
+		ExtensionSignature: extensionSig,
+	}
+	d.CurrentTime = newTime
+
+	oneValExtendedCommit := &cmttypes.ExtendedCommit{
+		Height:  block1.Height,
+		Round:   0,
+		BlockID: block1ID,
+		ExtendedSignatures: []cmttypes.ExtendedCommitSig{
+			extCommitSig,
+		},
+	}
+
+	accepted, err := d.BlockExec.ProcessProposal(block1, lastState)
+	require.NoError(d.t, err)
+	require.True(d.t, accepted)
+
+	state, err := d.BlockExec.ApplyVerifiedBlock(lastState, block1ID, block1)
+	require.NoError(d.t, err)
+	require.NotNil(d.t, state)
+
+	d.BlockStore.SaveBlockWithExtendedCommit(
+		block1,
+		partSet,
+		oneValExtendedCommit,
+	)
+
+	lastResponse, err := d.StateStore.LoadFinalizeBlockResponse(block1.Height)
+	require.NoError(d.t, err)
+	require.NotNil(d.t, lastResponse)
+	return lastResponse
 }
 
-func (d *BabylonAppDriver) GenerateNewBlockAssertExecutionSuccess(
-	t *testing.T,
-) {
-	response := d.GenerateNewBlock(t)
+func (d *BabylonAppDriver) GetFinalizedBlocks() []FinalizedBlock {
+	lastState, err := d.StateStore.Load()
+	require.NoError(d.t, err)
+	require.NotNil(d.t, lastState)
+
+	blocks := []FinalizedBlock{}
+
+	for i := int64(1); i <= lastState.LastBlockHeight; i++ {
+		block := d.BlockStore.LoadBlock(i)
+		require.NotNil(d.t, block)
+
+		id, _ := getBlockId(d.t, block)
+
+		blocks = append(blocks, FinalizedBlock{
+			Height: uint64(block.Height),
+			ID:     id,
+			Block:  block,
+		})
+	}
+
+	return blocks
+}
+
+func (d *BabylonAppDriver) GetLastState() sm.State {
+	lastState, err := d.StateStore.Load()
+	require.NoError(d.t, err)
+	require.NotNil(d.t, lastState)
+	return lastState
+}
+
+func (d *BabylonAppDriver) GenerateNewBlockAssertExecutionSuccess() {
+	response := d.GenerateNewBlock()
 
 	for _, tx := range response.TxResults {
-		require.Equal(t, tx.Code, uint32(0))
+		// ignore checkpoint txs
+		if tx.GasWanted == 0 {
+			continue
+		}
+
+		require.Equal(d.t, tx.Code, uint32(0), tx.Log)
 	}
 }
 
 func (d *BabylonAppDriver) GetDriverAccountAddress() sdk.AccAddress {
-	return sdk.AccAddress(d.DriverAccountPrivKey.PubKey().Address())
-}
-
-func (d *BabylonAppDriver) GetDriverAccountSenderInfo() *senderInfo {
-	return &senderInfo{
-		privKey:        d.DriverAccountPrivKey,
-		sequenceNumber: d.DriverAccountSeqNr,
-		accountNumber:  d.DriverAccountAccNr,
-	}
-}
-
-func (d *BabylonAppDriver) GetBTCLCTip() (*wire.BlockHeader, uint32) {
-	tipInfo := d.App.BTCLightClientKeeper.GetTipInfo(d.GetContextForLastFinalizedBlock())
-	return tipInfo.Header.ToBlockHeader(), tipInfo.Height
+	return sdk.AccAddress(d.SenderInfo.privKey.PubKey().Address())
 }
 
 func BlocksWithProofsToHeaderBytes(blocks []*datagen.BlockWithProofs) []bbn.BTCHeaderBytes {
@@ -593,54 +639,67 @@ func (d *BabylonAppDriver) GenBlockWithTransactions(
 	return block
 }
 
-func (d *BabylonAppDriver) getDelegationWithStatus(t *testing.T, status bstypes.BTCDelegationStatus) []*bstypes.BTCDelegationResponse {
-	pagination := &query.PageRequest{}
-	pagination.Limit = goMath.MaxUint32
+func blockWithProofsToActivationMessages(
+	blockWithProofs *datagen.BlockWithProofs,
+	senderAddr sdk.AccAddress,
+) []sdk.Msg {
+	msgs := []sdk.Msg{}
 
-	delegations, err := d.App.BTCStakingKeeper.BTCDelegations(d.GetContextForLastFinalizedBlock(), &bstypes.QueryBTCDelegationsRequest{
-		Status:     status,
-		Pagination: pagination,
+	for i, tx := range blockWithProofs.Transactions {
+		// no coinbase tx
+		if i == 0 {
+			continue
+		}
+
+		msgs = append(msgs, &bstypes.MsgAddBTCDelegationInclusionProof{
+			Signer:                  senderAddr.String(),
+			StakingTxHash:           tx.TxHash().String(),
+			StakingTxInclusionProof: bstypes.NewInclusionProofFromSpvProof(blockWithProofs.Proofs[i]),
+		})
+	}
+	return msgs
+}
+
+// Activates all verified delegations in two blocks:
+// 1. First block extends light client so that all stakers are confirmed
+// 2. Second block activates all verified delegations
+func (d *BabylonAppDriver) ActivateVerifiedDelegations(expectedVerifiedDelegations int) {
+	verifiedDelegations := d.GetVerifiedBTCDelegations(d.t)
+	btcCheckpointParams := d.GetBTCCkptParams(d.t)
+
+	// Only verify number if requested
+	if expectedVerifiedDelegations != 0 {
+		require.Equal(d.t, len(verifiedDelegations), expectedVerifiedDelegations)
+	}
+
+	tip, _ := d.GetBTCLCTip()
+	var transactions []*wire.MsgTx
+	for _, del := range verifiedDelegations {
+		stakingTx, _, err := bbn.NewBTCTxFromHex(del.StakingTxHex)
+		require.NoError(d.t, err)
+		transactions = append(transactions, stakingTx)
+	}
+
+	block := datagen.GenRandomBtcdBlockWithTransactions(d.r, transactions, tip)
+	headers := BlocksWithProofsToHeaderBytes([]*datagen.BlockWithProofs{block})
+
+	confirmationBLocks := datagen.GenNEmptyBlocks(
+		d.r,
+		uint64(btcCheckpointParams.BtcConfirmationDepth),
+		&block.Block.Header,
+	)
+	confirmationHeaders := BlocksWithProofsToHeaderBytes(confirmationBLocks)
+
+	headers = append(headers, confirmationHeaders...)
+
+	// extend our light client so that all stakers are confirmed
+	d.SendTxWithMsgsFromDriverAccount(d.t, &btclighttypes.MsgInsertHeaders{
+		Signer:  d.GetDriverAccountAddress().String(),
+		Headers: headers,
 	})
-	require.NoError(t, err)
-	return delegations.BtcDelegations
-}
 
-func (d *BabylonAppDriver) GetAllBTCDelegations(t *testing.T) []*bstypes.BTCDelegationResponse {
-	return d.getDelegationWithStatus(t, bstypes.BTCDelegationStatus_ANY)
-}
-
-func (d *BabylonAppDriver) GetVerifiedBTCDelegations(t *testing.T) []*bstypes.BTCDelegationResponse {
-	return d.getDelegationWithStatus(t, bstypes.BTCDelegationStatus_VERIFIED)
-}
-
-func (d *BabylonAppDriver) GetActiveBTCDelegations(t *testing.T) []*bstypes.BTCDelegationResponse {
-	return d.getDelegationWithStatus(t, bstypes.BTCDelegationStatus_ACTIVE)
-}
-
-func (d *BabylonAppDriver) GetBTCStakingParams(t *testing.T) *bstypes.Params {
-	params := d.App.BTCStakingKeeper.GetParams(d.GetContextForLastFinalizedBlock())
-	return &params
-}
-
-func (d *BabylonAppDriver) GetEpochingParams() et.Params {
-	return d.App.EpochingKeeper.GetParams(d.GetContextForLastFinalizedBlock())
-}
-
-func (d *BabylonAppDriver) GetEpoch() *et.Epoch {
-	return d.App.EpochingKeeper.GetEpoch(d.GetContextForLastFinalizedBlock())
-}
-
-func (d *BabylonAppDriver) GetCheckpoint(
-	t *testing.T,
-	epochNumber uint64,
-) *ckpttypes.RawCheckpointWithMeta {
-	checkpoint, err := d.App.CheckpointingKeeper.GetRawCheckpoint(d.GetContextForLastFinalizedBlock(), epochNumber)
-	require.NoError(t, err)
-	return checkpoint
-}
-
-func (d *BabylonAppDriver) GetLastFinalizedEpoch() uint64 {
-	return d.App.CheckpointingKeeper.GetLastFinalizedEpoch(d.GetContextForLastFinalizedBlock())
+	acitvationMsgs := blockWithProofsToActivationMessages(block, d.GetDriverAccountAddress())
+	d.SendTxWithMsgsFromDriverAccount(d.t, acitvationMsgs...)
 }
 
 func (d *BabylonAppDriver) GenCkptForEpoch(r *rand.Rand, t *testing.T, epochNumber uint64) {
@@ -673,47 +732,27 @@ func (d *BabylonAppDriver) GenCkptForEpoch(r *rand.Rand, t *testing.T, epochNumb
 	d.SendTxWithMsgsFromDriverAccount(t, &msg)
 }
 
-func (d *BabylonAppDriver) FinializeCkptForEpoch(r *rand.Rand, t *testing.T, epochNumber uint64) {
+func (d *BabylonAppDriver) FinializeCkptForEpoch(epochNumber uint64) {
 	lastFinalizedEpoch := d.GetLastFinalizedEpoch()
-	require.Equal(t, lastFinalizedEpoch+1, epochNumber)
+	require.Equal(d.t, lastFinalizedEpoch+1, epochNumber)
 
-	btckptParams := d.GetBTCCkptParams(t)
-	d.GenCkptForEpoch(r, t, epochNumber)
+	btckptParams := d.GetBTCCkptParams(d.t)
+	d.GenCkptForEpoch(d.r, d.t, epochNumber)
 
-	_, _ = d.ExtendBTCLcWithNEmptyBlocks(r, t, btckptParams.CheckpointFinalizationTimeout)
+	_, _ = d.ExtendBTCLcWithNEmptyBlocks(d.r, d.t, btckptParams.CheckpointFinalizationTimeout)
 
 	lastFinalizedEpoch = d.GetLastFinalizedEpoch()
-	require.Equal(t, lastFinalizedEpoch, epochNumber)
+	require.Equal(d.t, lastFinalizedEpoch, epochNumber)
 }
 
-func (d *BabylonAppDriver) GetBTCCkptParams(t *testing.T) btckckpttypes.Params {
-	return d.App.BtcCheckpointKeeper.GetParams(d.GetContextForLastFinalizedBlock())
-}
-
-func (d *BabylonAppDriver) ProgressTillFirstBlockTheNextEpoch(t *testing.T) {
+func (d *BabylonAppDriver) ProgressTillFirstBlockTheNextEpoch() {
 	currnetEpochNunber := d.GetEpoch().EpochNumber
 	nextEpochNumber := currnetEpochNunber + 1
 
 	for currnetEpochNunber < nextEpochNumber {
-		d.GenerateNewBlock(t)
+		d.GenerateNewBlock()
 		currnetEpochNunber = d.GetEpoch().EpochNumber
 	}
-}
-
-func (d *BabylonAppDriver) GetActiveFpsAtHeight(t *testing.T, height uint64) []*ftypes.ActiveFinalityProvidersAtHeightResponse {
-	res, err := d.App.FinalityKeeper.ActiveFinalityProvidersAtHeight(
-		d.GetContextForLastFinalizedBlock(),
-		&ftypes.QueryActiveFinalityProvidersAtHeightRequest{
-			Height:     height,
-			Pagination: &query.PageRequest{},
-		},
-	)
-	require.NoError(t, err)
-	return res.FinalityProviders
-}
-
-func (d *BabylonAppDriver) GetActiveFpsAtCurrentHeight(t *testing.T) []*ftypes.ActiveFinalityProvidersAtHeightResponse {
-	return d.GetActiveFpsAtHeight(t, d.GetLastFinalizedBlock().Height)
 }
 
 func (d *BabylonAppDriver) WaitTillAllFpsJailed(t *testing.T) {
@@ -722,25 +761,25 @@ func (d *BabylonAppDriver) WaitTillAllFpsJailed(t *testing.T) {
 		if len(activeFps) == 0 {
 			break
 		}
-		d.GenerateNewBlock(t)
+		d.GenerateNewBlock()
 	}
 }
 
 // SendTxWithMsgsFromDriverAccount sends tx with msgs from driver account and asserts that
-// SendTxWithMsgsFromDriverAccount sends tx with msgs from driver account and asserts that
 // execution was successful. It assumes that there will only be one tx in the block.
 func (d *BabylonAppDriver) SendTxWithMsgsFromDriverAccount(
 	t *testing.T,
-	msgs ...sdk.Msg) {
+	msgs ...sdk.Msg,
+) {
 	d.SendTxWithMessagesSuccess(
 		t,
-		d.GetDriverAccountSenderInfo(),
+		d.SenderInfo,
 		defaultGasLimit,
 		defaultFeeCoin,
 		msgs...,
 	)
 
-	result := d.GenerateNewBlock(t)
+	result := d.GenerateNewBlock()
 
 	for _, rs := range result.TxResults {
 		// our checkpoint transactions have 0 gas wanted, skip them to avoid confusing the
@@ -750,202 +789,163 @@ func (d *BabylonAppDriver) SendTxWithMsgsFromDriverAccount(
 		}
 
 		// all executions should be successful
-		require.Equal(t, rs.Code, uint32(0))
+		require.Equal(t, rs.Code, uint32(0), rs.Log)
 	}
 
-	d.DriverAccountSeqNr++
+	d.IncSeq()
 }
 
-type BlockReplayer struct {
-	BlockExec *sm.BlockExecutor
-	LastState sm.State
+// Funciont to initate different type of senders
+
+type NewAccountInfo struct {
+	CreationMsg *banktypes.MsgSend
+	PrivKey     *secp256k1.PrivKey
 }
 
-func NewBlockReplayer(t *testing.T, nodeDir string) *BlockReplayer {
-	_, doc := getGenDoc(t, nodeDir)
+func accInfosToCreationMsgs(acInfos []*NewAccountInfo) []sdk.Msg {
+	msgs := []sdk.Msg{}
+	for _, acInfo := range acInfos {
+		msgs = append(msgs, acInfo.CreationMsg)
+	}
+	return msgs
+}
 
-	genDoc, err := doc.ToGenesisDoc()
-	require.NoError(t, err)
+func (d *BabylonAppDriver) CreateSendingAccountMessage() *NewAccountInfo {
+	accPrivKey := secp256k1.GenPrivKey()
+	accPubKey := accPrivKey.PubKey()
+	accAddress := sdk.AccAddress(accPubKey.Address())
 
-	state, err := sm.MakeGenesisState(genDoc)
-	require.NoError(t, err)
-
-	stateStore := sm.NewStore(dbmc.NewMemDB(), sm.StoreOptions{
-		DiscardABCIResponses: false,
-	})
-
-	if err := stateStore.Save(state); err != nil {
-		panic(err)
+	msgBankSend := banktypes.MsgSend{
+		FromAddress: d.GetDriverAccountAddress().String(),
+		ToAddress:   accAddress.String(),
+		// 100 BBN, should be enough for most tests
+		Amount: sdk.NewCoins(sdk.NewCoin("ubbn", sdkmath.NewInt(100000000))),
 	}
 
-	blsSigner, err := appsigner.InitBlsSigner(nodeDir)
-	require.NoError(t, err)
-	require.NotNil(t, blsSigner)
-
-	appOptions := NewAppOptionsWithFlagHome(nodeDir)
-	baseAppOptions := server.DefaultBaseappOptions(appOptions)
-	tmpApp := babylonApp.NewBabylonApp(
-		log.NewNopLogger(),
-		dbm.NewMemDB(),
-		nil,
-		true,
-		map[int64]bool{},
-		0,
-		blsSigner,
-		appOptions,
-		babylonApp.EmptyWasmOpts,
-		baseAppOptions...,
-	)
-
-	cmtApp := server.NewCometABCIWrapper(tmpApp)
-	procxyCons := proxy.NewMultiAppConn(
-		proxy.NewLocalClientCreator(cmtApp),
-		proxy.NopMetrics(),
-	)
-	err = procxyCons.Start()
-	require.NoError(t, err)
-
-	blockStore := store.NewBlockStore(dbmc.NewMemDB())
-
-	blockExec := sm.NewBlockExecutor(
-		stateStore,
-		cometlog.TestingLogger(),
-		procxyCons.Consensus(),
-		&mempool.NopMempool{},
-		sm.EmptyEvidencePool{},
-		blockStore,
-	)
-	require.NotNil(t, blockExec)
-
-	hs := cs.NewHandshaker(
-		stateStore,
-		state,
-		blockStore,
-		genDoc,
-	)
-
-	require.NotNil(t, hs)
-	hs.SetLogger(cometlog.TestingLogger())
-	err = hs.Handshake(procxyCons)
-	require.NoError(t, err)
-
-	state, err = stateStore.Load()
-	require.NoError(t, err)
-	require.NotNil(t, state)
-
-	return &BlockReplayer{
-		BlockExec: blockExec,
-		LastState: state,
+	return &NewAccountInfo{
+		CreationMsg: &msgBankSend,
+		PrivKey:     accPrivKey,
 	}
 }
 
-func (r *BlockReplayer) ReplayBlocks(t *testing.T, blocks []FinalizedBlock) {
-	for _, block := range blocks {
-		blockID := getBlockId(t, block.Block)
-		state, err := r.BlockExec.ApplyVerifiedBlock(r.LastState, blockID, block.Block)
-		require.NoError(t, err)
-		require.NotNil(t, state)
-		r.LastState = state.Copy()
+func (d *BabylonAppDriver) getAccountInfo(accAddress string) sdk.AccountI {
+	add, err := sdk.AccAddressFromBech32(accAddress)
+	require.NoError(d.t, err)
+	return d.App.AccountKeeper.GetAccount(d.GetContextForLastFinalizedBlock(), add)
+}
+
+func (d *BabylonAppDriver) CreateNStakerAccounts(n int) []*Staker {
+	// pre-condition
+	require.True(d.t, n > 0)
+
+	var bankMsgs []*NewAccountInfo
+	for i := 0; i < n; i++ {
+		bankMsgs = append(bankMsgs, d.CreateSendingAccountMessage())
 	}
-}
 
-type FinalityProviderInfo struct {
-	MsgCreateFinalityProvider *bstypes.MsgCreateFinalityProvider
-	BTCPrivateKey             *btcec.PrivateKey
-	BabylonAddress            sdk.AccAddress
-}
+	d.SendTxWithMsgsFromDriverAccount(d.t, accInfosToCreationMsgs(bankMsgs)...)
 
-func GenerateNFinalityProviders(
-	r *rand.Rand,
-	t *testing.T,
-	n uint32,
-	senderAddress sdk.AccAddress,
-) []*FinalityProviderInfo {
-	var infos []*FinalityProviderInfo
-	for i := uint32(0); i < n; i++ {
-		prv, _, err := datagen.GenRandomBTCKeyPair(r)
-		require.NoError(t, err)
-		msg, err := datagen.GenRandomCreateFinalityProviderMsgWithBTCBabylonSKs(
-			r,
-			prv,
-			senderAddress,
-		)
-		require.NoError(t, err)
-
-		infos = append(infos, &FinalityProviderInfo{
-			MsgCreateFinalityProvider: msg,
-			BTCPrivateKey:             prv,
-			BabylonAddress:            senderAddress,
+	stakers := []*Staker{}
+	for _, m := range bankMsgs {
+		acc := d.getAccountInfo(m.CreationMsg.ToAddress)
+		stakerPrivKey, err := btcec.NewPrivateKey()
+		require.NoError(d.t, err)
+		stakers = append(stakers, &Staker{
+			SenderInfo: &SenderInfo{
+				privKey:        m.PrivKey,
+				sequenceNumber: acc.GetSequence(),
+				accountNumber:  acc.GetAccountNumber(),
+			},
+			r:             d.r,
+			t:             d.t,
+			d:             d,
+			app:           d.App,
+			BTCPrivateKey: stakerPrivKey,
 		})
 	}
 
-	return infos
+	return stakers
 }
 
-func FpInfosToMsgs(fpInfos []*FinalityProviderInfo) []sdk.Msg {
-	msgs := []sdk.Msg{}
-	for _, fpInfo := range fpInfos {
-		msgs = append(msgs, fpInfo.MsgCreateFinalityProvider)
+func (d *BabylonAppDriver) CreateNFinalityProviderAccounts(n int) []*FinalityProvider {
+	var fpInfos []*NewAccountInfo
+	for i := 0; i < n; i++ {
+		fpInfos = append(fpInfos, d.CreateSendingAccountMessage())
 	}
-	return msgs
+
+	d.SendTxWithMsgsFromDriverAccount(d.t, accInfosToCreationMsgs(fpInfos)...)
+
+	fps := []*FinalityProvider{}
+	for _, accInf := range fpInfos {
+		acc := d.getAccountInfo(accInf.CreationMsg.ToAddress)
+
+		btvPrivKey, err := btcec.NewPrivateKey()
+		require.NoError(d.t, err)
+
+		fps = append(fps, &FinalityProvider{
+			SenderInfo: &SenderInfo{
+				privKey:        accInf.PrivKey,
+				sequenceNumber: acc.GetSequence(),
+				accountNumber:  acc.GetAccountNumber(),
+			},
+			r:             d.r,
+			t:             d.t,
+			d:             d,
+			app:           d.App,
+			BTCPrivateKey: btvPrivKey,
+			Description:   datagen.GenRandomDescription(d.r),
+		})
+	}
+
+	return fps
 }
 
-func GenerateNBTCDelegationsForFinalityProvider(
-	r *rand.Rand,
-	t *testing.T,
-	n uint32,
-	senderAddress sdk.AccAddress,
-	fpInfo *FinalityProviderInfo,
-	params *bstypes.Params,
-) []*datagen.CreateDelegationInfo {
-	var delInfos []*datagen.CreateDelegationInfo
+// One sender for all covenants to simplify the tests
+func (d *BabylonAppDriver) CreateCovenantSender() *CovenantSender {
+	accInfo := d.CreateSendingAccountMessage()
 
-	for i := uint32(0); i < n; i++ {
-		// TODO this slow due the key generation
-		stakerPrv, _, err := datagen.GenRandomBTCKeyPair(r)
-		require.NoError(t, err)
-		delInfo := datagen.GenRandomMsgCreateBtcDelegationAndMsgAddCovenantSignatures(
-			r,
-			t,
-			BtcParams,
-			senderAddress,
-			[]bbn.BIP340PubKey{*fpInfo.MsgCreateFinalityProvider.BtcPk},
-			stakerPrv,
-			covenantSKs,
-			params,
-		)
-		delInfos = append(delInfos, delInfo)
+	d.SendTxWithMsgsFromDriverAccount(d.t, accInfosToCreationMsgs([]*NewAccountInfo{accInfo})...)
+
+	acc := d.getAccountInfo(accInfo.CreationMsg.ToAddress)
+
+	return &CovenantSender{
+		SenderInfo: &SenderInfo{
+			privKey:        accInfo.PrivKey,
+			sequenceNumber: acc.GetSequence(),
+			accountNumber:  acc.GetAccountNumber(),
+		},
+		r:   d.r,
+		t:   d.t,
+		d:   d,
+		app: d.App,
 	}
-
-	return delInfos
 }
 
-func ToCreateBTCDelegationMsgs(
-	delInfos []*datagen.CreateDelegationInfo,
-) []sdk.Msg {
-	msgs := []sdk.Msg{}
-	for _, delInfo := range delInfos {
-		msgs = append(msgs, delInfo.MsgCreateBTCDelegation)
-	}
-	return msgs
+func (d *BabylonAppDriver) GovPropAndVote(msgInGovProp sdk.Msg) (lastPropId uint64) {
+	msgToSend := d.NewGovProp(msgInGovProp)
+	d.SendTxWithMsgsFromDriverAccount(d.t, msgToSend)
+
+	props := d.GovProposals()
+	lastPropId = props[len(props)-1].Id
+
+	d.GovVote(lastPropId)
+	return lastPropId
 }
 
-func ToCovenantSignaturesMsgs(
-	delInfos []*datagen.CreateDelegationInfo,
-) []sdk.Msg {
-	msgs := []sdk.Msg{}
-	for _, delInfo := range delInfos {
-		msgs = append(msgs, MsgsToSdkMsg(delInfo.MsgAddCovenantSigs)...)
-	}
-	return msgs
-}
+func (d *BabylonAppDriver) GovPropWaitPass(msgInGovProp sdk.Msg) {
+	propId := d.GovPropAndVote(msgInGovProp)
 
-func DelegationInfosToBTCTx(
-	delInfos []*datagen.CreateDelegationInfo,
-) []*wire.MsgTx {
-	txs := []*wire.MsgTx{}
-	for _, delInfo := range delInfos {
-		txs = append(txs, delInfo.StakingTx)
+	for {
+		prop := d.GovProposal(propId)
+
+		if prop.Status == v1.ProposalStatus_PROPOSAL_STATUS_FAILED {
+			d.t.Errorf("prop %d failed due to: %s", propId, prop.FailedReason)
+		}
+
+		if prop.Status == v1.ProposalStatus_PROPOSAL_STATUS_PASSED {
+			break
+		}
+
+		d.GenerateNewBlock()
 	}
-	return txs
 }

--- a/test/replay/driver_queries.go
+++ b/test/replay/driver_queries.go
@@ -1,0 +1,157 @@
+package replay
+
+import (
+	goMath "math"
+	"testing"
+
+	btckckpttypes "github.com/babylonlabs-io/babylon/v2/x/btccheckpoint/types"
+	"github.com/btcsuite/btcd/wire"
+	govk "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govv1types "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+
+	ftypes "github.com/babylonlabs-io/babylon/v2/x/finality/types"
+
+	bstypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
+	ckpttypes "github.com/babylonlabs-io/babylon/v2/x/checkpointing/types"
+	et "github.com/babylonlabs-io/babylon/v2/x/epoching/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/stretchr/testify/require"
+)
+
+func (d *BabylonAppDriver) getDelegationWithStatus(t *testing.T, status bstypes.BTCDelegationStatus) []*bstypes.BTCDelegationResponse {
+	pagination := &query.PageRequest{}
+	pagination.Limit = goMath.MaxUint32
+
+	ctx, err := d.App.CreateQueryContext(0, false)
+	require.NoError(t, err)
+	delegations, err := d.App.BTCStakingKeeper.BTCDelegations(ctx, &bstypes.QueryBTCDelegationsRequest{
+		Status:     status,
+		Pagination: pagination,
+	})
+	require.NoError(t, err)
+	return delegations.BtcDelegations
+}
+
+func (d *BabylonAppDriver) GetAllBTCDelegations(t *testing.T) []*bstypes.BTCDelegationResponse {
+	return d.getDelegationWithStatus(t, bstypes.BTCDelegationStatus_ANY)
+}
+
+func (d *BabylonAppDriver) GetVerifiedBTCDelegations(t *testing.T) []*bstypes.BTCDelegationResponse {
+	return d.getDelegationWithStatus(t, bstypes.BTCDelegationStatus_VERIFIED)
+}
+
+func (d *BabylonAppDriver) GetActiveBTCDelegations(t *testing.T) []*bstypes.BTCDelegationResponse {
+	return d.getDelegationWithStatus(t, bstypes.BTCDelegationStatus_ACTIVE)
+}
+
+func (d *BabylonAppDriver) GetPendingBTCDelegations(t *testing.T) []*bstypes.BTCDelegationResponse {
+	return d.getDelegationWithStatus(t, bstypes.BTCDelegationStatus_PENDING)
+}
+
+func (d *BabylonAppDriver) GetBTCStakingParams(t *testing.T) *bstypes.Params {
+	params := d.App.BTCStakingKeeper.GetParams(d.GetContextForLastFinalizedBlock())
+	return &params
+}
+
+func (d *BabylonAppDriver) GetEpochingParams() et.Params {
+	return d.App.EpochingKeeper.GetParams(d.GetContextForLastFinalizedBlock())
+}
+
+func (d *BabylonAppDriver) GetEpoch() *et.Epoch {
+	return d.App.EpochingKeeper.GetEpoch(d.GetContextForLastFinalizedBlock())
+}
+
+func (d *BabylonAppDriver) GetCheckpoint(
+	t *testing.T,
+	epochNumber uint64,
+) *ckpttypes.RawCheckpointWithMeta {
+	checkpoint, err := d.App.CheckpointingKeeper.GetRawCheckpoint(d.GetContextForLastFinalizedBlock(), epochNumber)
+	require.NoError(t, err)
+	return checkpoint
+}
+
+func (d *BabylonAppDriver) GetLastFinalizedEpoch() uint64 {
+	return d.App.CheckpointingKeeper.GetLastFinalizedEpoch(d.GetContextForLastFinalizedBlock())
+}
+
+func (d *BabylonAppDriver) GetActiveFpsAtHeight(t *testing.T, height uint64) []*ftypes.ActiveFinalityProvidersAtHeightResponse {
+	res, err := d.App.FinalityKeeper.ActiveFinalityProvidersAtHeight(
+		d.GetContextForLastFinalizedBlock(),
+		&ftypes.QueryActiveFinalityProvidersAtHeightRequest{
+			Height:     height,
+			Pagination: &query.PageRequest{},
+		},
+	)
+	require.NoError(t, err)
+	return res.FinalityProviders
+}
+
+func (d *BabylonAppDriver) GetVotingPowerDistCache(height uint64) *ftypes.VotingPowerDistCache {
+	return d.App.FinalityKeeper.GetVotingPowerDistCache(d.Ctx(), height)
+}
+
+func (d *BabylonAppDriver) GovProposals() []*govv1types.Proposal {
+	resp, err := d.GovQuerySvr().Proposals(d.Ctx(), &govv1types.QueryProposalsRequest{
+		ProposalStatus: govv1types.ProposalStatus_PROPOSAL_STATUS_VOTING_PERIOD,
+	})
+	require.NoError(d.t, err)
+	return resp.Proposals
+}
+
+func (d *BabylonAppDriver) GovProposal(propId uint64) *govv1types.Proposal {
+	resp, err := d.GovQuerySvr().Proposal(d.Ctx(), &govv1types.QueryProposalRequest{
+		ProposalId: propId,
+	})
+	require.NoError(d.t, err)
+	return resp.Proposal
+}
+
+func (d *BabylonAppDriver) GovQuerySvr() govv1types.QueryServer {
+	return govk.NewQueryServer(&d.App.GovKeeper)
+}
+
+func (d *BabylonAppDriver) GetAllFps(t *testing.T) []*bstypes.FinalityProviderResponse {
+	res, err := d.App.BTCStakingKeeper.FinalityProviders(
+		d.GetContextForLastFinalizedBlock(),
+		&bstypes.QueryFinalityProvidersRequest{},
+	)
+	require.NoError(t, err)
+	return res.FinalityProviders
+}
+
+func (d *BabylonAppDriver) GetActiveFpsAtCurrentHeight(t *testing.T) []*ftypes.ActiveFinalityProvidersAtHeightResponse {
+	return d.GetActiveFpsAtHeight(t, d.GetLastFinalizedBlock().Height)
+}
+
+func (d *BabylonAppDriver) GetFp(fpBTCPK []byte) *bstypes.FinalityProvider {
+	fp, err := d.App.BTCStakingKeeper.GetFinalityProvider(d.GetContextForLastFinalizedBlock(), fpBTCPK)
+	require.NoError(d.t, err)
+	return fp
+}
+
+func (d *BabylonAppDriver) GetActivationHeight(t *testing.T) uint64 {
+	res, err := d.App.FinalityKeeper.ActivatedHeight(
+		d.GetContextForLastFinalizedBlock(),
+		&ftypes.QueryActivatedHeightRequest{},
+	)
+	require.NoError(t, err)
+	return res.Height
+}
+
+func (d *BabylonAppDriver) GetIndexedBlock(height uint64) *ftypes.IndexedBlock {
+	res, err := d.App.FinalityKeeper.Block(
+		d.GetContextForLastFinalizedBlock(),
+		&ftypes.QueryBlockRequest{Height: height},
+	)
+	require.NoError(d.t, err)
+	return res.Block
+}
+
+func (d *BabylonAppDriver) GetBTCCkptParams(t *testing.T) btckckpttypes.Params {
+	return d.App.BtcCheckpointKeeper.GetParams(d.GetContextForLastFinalizedBlock())
+}
+
+func (d *BabylonAppDriver) GetBTCLCTip() (*wire.BlockHeader, uint32) {
+	tipInfo := d.App.BTCLightClientKeeper.GetTipInfo(d.GetContextForLastFinalizedBlock())
+	return tipInfo.Header.ToBlockHeader(), tipInfo.Height
+}

--- a/test/replay/finality_provider_sender.go
+++ b/test/replay/finality_provider_sender.go
@@ -1,0 +1,137 @@
+package replay
+
+import (
+	"math/rand"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	babylonApp "github.com/babylonlabs-io/babylon/v2/app"
+	"github.com/babylonlabs-io/babylon/v2/testutil/datagen"
+	bbn "github.com/babylonlabs-io/babylon/v2/types"
+	bstypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
+	"github.com/btcsuite/btcd/btcec/v2"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+)
+
+type FinalityProvider struct {
+	*SenderInfo
+	r             *rand.Rand
+	t             *testing.T
+	d             *BabylonAppDriver
+	app           *babylonApp.BabylonApp
+	BTCPrivateKey *btcec.PrivateKey
+	Description   *stakingtypes.Description
+	randListInfo  *datagen.RandListInfo
+}
+
+func (f *FinalityProvider) BTCPublicKey() *bbn.BIP340PubKey {
+	pk := bbn.NewBIP340PubKeyFromBTCPK(f.BTCPrivateKey.PubKey())
+	return pk
+}
+
+func (f *FinalityProvider) RegisterFinalityProvider() {
+	pop, err := datagen.NewPoPBTC(f.Address(), f.BTCPrivateKey)
+	require.NoError(f.t, err)
+
+	msg := &bstypes.MsgCreateFinalityProvider{
+		Addr:        f.AddressString(),
+		Description: f.Description,
+		// Default values
+		Commission: bstypes.CommissionRates{
+			Rate:          sdkmath.LegacyMustNewDecFromStr("0.05"),
+			MaxRate:       sdkmath.LegacyMustNewDecFromStr("0.1"),
+			MaxChangeRate: sdkmath.LegacyMustNewDecFromStr("0.05"),
+		},
+		BtcPk: f.BTCPublicKey(),
+		Pop:   pop,
+	}
+
+	DefaultSendTxWithMessagesSuccess(
+		f.t,
+		f.app,
+		f.SenderInfo,
+		msg,
+	)
+	// message accepted to the mempool increment sequence number
+	f.IncSeq()
+}
+
+func (f *FinalityProvider) CommitRandomness() {
+	randListInfo, msg, err := datagen.GenRandomMsgCommitPubRandList(
+		f.r,
+		f.BTCPrivateKey,
+		1,
+		10000,
+	)
+	require.NoError(f.t, err)
+
+	msg.Signer = f.AddressString()
+
+	DefaultSendTxWithMessagesSuccess(
+		f.t,
+		f.app,
+		f.SenderInfo,
+		msg,
+	)
+
+	// TODO: for now only one commmitment is supported
+	f.randListInfo = randListInfo
+
+	f.IncSeq()
+}
+
+func (f *FinalityProvider) CastVote(height uint64) {
+	indexedBlock := f.d.GetIndexedBlock(height)
+	f.CastVoteForHash(height, indexedBlock.AppHash)
+}
+
+// CastVoteForHash useful to cast bad vote
+func (f *FinalityProvider) CastVoteForHash(height uint64, blkAppHash []byte) {
+	msg, err := datagen.NewMsgAddFinalitySig(
+		f.AddressString(),
+		f.BTCPrivateKey,
+		1,
+		height,
+		f.randListInfo,
+		blkAppHash,
+	)
+	require.NoError(f.t, err)
+
+	DefaultSendTxWithMessagesSuccess(
+		f.t,
+		f.app,
+		f.SenderInfo,
+		msg,
+	)
+
+	f.IncSeq()
+}
+
+func (f *FinalityProvider) SendSelectiveSlashingEvidence() {
+	ctx := f.d.GetContextForLastFinalizedBlock()
+
+	resp, err := f.app.BTCStakingKeeper.FinalityProviderDelegations(ctx, &bstypes.QueryFinalityProviderDelegationsRequest{
+		FpBtcPkHex: f.BTCPublicKey().MarshalHex(),
+	})
+	require.NoError(f.t, err)
+
+	stkTxHex := resp.BtcDelegatorDelegations[0].Dels[0].StakingTxHex
+	tx, _, err := bbn.NewBTCTxFromHex(stkTxHex)
+	require.NoError(f.t, err)
+
+	msg := &bstypes.MsgSelectiveSlashingEvidence{
+		Signer:           f.AddressString(),
+		StakingTxHash:    tx.TxHash().String(),
+		RecoveredFpBtcSk: f.BTCPrivateKey.Serialize(),
+	}
+
+	DefaultSendTxWithMessagesSuccess(
+		f.t,
+		f.app,
+		f.SenderInfo,
+		msg,
+	)
+
+	f.IncSeq()
+}

--- a/test/replay/finality_test.go
+++ b/test/replay/finality_test.go
@@ -3,11 +3,11 @@ package replay
 import (
 	"math/rand"
 	"testing"
+	"time"
 
+	appparams "github.com/babylonlabs-io/babylon/v2/app/params"
 	"github.com/babylonlabs-io/babylon/v2/testutil/datagen"
-	bstypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
 	ftypes "github.com/babylonlabs-io/babylon/v2/x/finality/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,119 +17,195 @@ func FuzzJailing(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
 		t.Parallel()
 		r := rand.New(rand.NewSource(seed))
-		numFinalityProviders := uint32(datagen.RandomInRange(r, 5, 7))
-		numDelPerFp := uint32(2)
+		numFinalityProviders := datagen.RandomInRange(r, 2, 3)
+		numDelPerFp := 2
 		driverTempDir := t.TempDir()
 		replayerTempDir := t.TempDir()
-		driver := NewBabylonAppDriver(t, driverTempDir, replayerTempDir)
+		driver := NewBabylonAppDriver(r, t, driverTempDir, replayerTempDir)
+		driver.GenerateNewBlock()
 
-		driver.GenerateNewBlock(t)
-
-		stakingParams := driver.GetBTCStakingParams(t)
-
-		fpInfos := GenerateNFinalityProviders(
-			r,
-			t,
-			numFinalityProviders,
-			driver.GetDriverAccountAddress(),
-		)
-		registerMsgs := FpInfosToMsgs(fpInfos)
-		driver.SendTxWithMsgsFromDriverAccount(t, registerMsgs...)
-
-		var msgList []*ftypes.MsgCommitPubRandList
-		for _, fpInfo := range fpInfos {
-			_, msg, err := datagen.GenRandomMsgCommitPubRandList(r, fpInfo.BTCPrivateKey, 1, 1000)
-			require.NoError(t, err)
-			msg.Signer = driver.GetDriverAccountAddress().String()
-			msgList = append(msgList, msg)
-		}
-		// send all commit randomness messages in one block
-		driver.SendTxWithMsgsFromDriverAccount(t, MsgsToSdkMsg(msgList)...)
-		currnetEpochNunber := driver.GetEpoch().EpochNumber
-		driver.ProgressTillFirstBlockTheNextEpoch(t)
-
-		driver.FinializeCkptForEpoch(r, t, currnetEpochNunber)
-
-		// at this point randomness is finalized.
-		// - send delegations
-		// - send covenant signatures
-		// - send delegation inclusion proofs
-		var allDelegationInfos []*datagen.CreateDelegationInfo
-
-		for _, fpInfo := range fpInfos {
-			delInfos := GenerateNBTCDelegationsForFinalityProvider(
-				r,
-				t,
-				numDelPerFp,
-				driver.GetDriverAccountAddress(),
-				fpInfo,
-				stakingParams,
-			)
-			allDelegationInfos = append(allDelegationInfos, delInfos...)
-		}
-
-		createDelegationMsgs := ToCreateBTCDelegationMsgs(allDelegationInfos)
-		covenantSignaturesMsgs := ToCovenantSignaturesMsgs(allDelegationInfos)
-		driver.SendTxWithMsgsFromDriverAccount(t, createDelegationMsgs...)
-		driver.SendTxWithMsgsFromDriverAccount(t, covenantSignaturesMsgs...)
-
-		// all delegations are verified after activation finality provider should
-		// have voting power
-		stakingTransactions := DelegationInfosToBTCTx(allDelegationInfos)
-		blockWithProofs := driver.GenBlockWithTransactions(
-			r,
-			t,
-			stakingTransactions,
-		)
-		// make staking txs k-deep
-		driver.ExtendBTCLcWithNEmptyBlocks(r, t, 10)
-
-		activationMsgs := BlockWithProofsToActivationMessages(blockWithProofs, driver.GetDriverAccountAddress())
-
-		activeFps := driver.GetActiveFpsAtCurrentHeight(t)
-		require.Equal(t, 0, len(activeFps))
-
-		driver.SendTxWithMsgsFromDriverAccount(t, activationMsgs...)
-
-		// on the last block all power events were queued for execution
-		// after this block execution they should be processed and our fps should
-		// have voting power
-		driver.GenerateNewBlock(t)
-		activeFps = driver.GetActiveFpsAtCurrentHeight(t)
-		require.Equal(t, numFinalityProviders, uint32(len(activeFps)))
+		scenario := NewStandardScenario(driver)
+		scenario.InitScenario(numFinalityProviders, numDelPerFp)
 
 		// we do not have voting in this test, so wait until all fps are jailed
 		driver.WaitTillAllFpsJailed(t)
-		driver.GenerateNewBlock(t)
-		activeFps = driver.GetActiveFpsAtCurrentHeight(t)
+		driver.GenerateNewBlock()
+		activeFps := driver.GetActiveFpsAtCurrentHeight(t)
 		require.Equal(t, 0, len(activeFps))
 
 		// Replay all the blocks from driver and check appHash
 		replayer := NewBlockReplayer(t, replayerTempDir)
-		replayer.ReplayBlocks(t, driver.FinalizedBlocks)
+		replayer.ReplayBlocks(t, driver.GetFinalizedBlocks())
 		// after replay we should have the same apphash
-		require.Equal(t, driver.LastState.LastBlockHeight, replayer.LastState.LastBlockHeight)
-		require.Equal(t, driver.LastState.AppHash, replayer.LastState.AppHash)
+		require.Equal(t, driver.GetLastState().LastBlockHeight, replayer.LastState.LastBlockHeight)
+		require.Equal(t, driver.GetLastState().AppHash, replayer.LastState.AppHash)
 	})
 }
 
-func BlockWithProofsToActivationMessages(
-	blockWithProofs *datagen.BlockWithProofs,
-	senderAddr sdk.AccAddress,
-) []sdk.Msg {
-	msgs := []sdk.Msg{}
+func TestResumeFinalityOfSlashedFp(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	d := NewBabylonAppDriverTmpDir(r, t)
+	d.GenerateNewBlock()
 
-	for i, tx := range blockWithProofs.Transactions {
-		// no coinbase tx
-		if i == 0 {
+	scn := NewStandardScenario(d)
+	scn.InitScenario(2, 1) // 2 fps, 1 del each
+
+	numBlocksFinalized := uint64(2)
+	lastVotedBlkHeight := scn.FinalityFinalizeBlocks(scn.activationHeight, numBlocksFinalized)
+
+	// one fp continues to vote, but the one to be jailed one does not vote
+	indexSlashFp := 1
+	lastFinalizedBlkHeight := lastVotedBlkHeight
+
+	// vote only with one fp, to halt finality
+	for i := uint64(0); i < numBlocksFinalized; i++ {
+		lastVotedBlkHeight++
+		for _, fp := range scn.finalityProviders[:indexSlashFp] {
+			fp.CastVote(lastVotedBlkHeight)
+		}
+
+		d.GenerateNewBlock()
+
+		bl := d.GetIndexedBlock(lastVotedBlkHeight)
+		require.Equal(t, bl.Finalized, false)
+	}
+
+	// verifes that the fp is still not jailed or slashed
+	slashFp := scn.finalityProviders[indexSlashFp]
+	fp := d.GetFp(*slashFp.BTCPublicKey())
+	require.False(t, fp.Jailed)
+	require.False(t, fp.IsSlashed())
+
+	vp := d.App.FinalityKeeper.GetVotingPower(d.Ctx(), *slashFp.BTCPublicKey(), lastFinalizedBlkHeight)
+	require.NotZero(t, vp)
+
+	badBlock := d.GetIndexedBlock(lastVotedBlkHeight - 1)
+	goodBlock := d.GetIndexedBlock(lastVotedBlkHeight)
+	// fp slashed with bogus vote
+	slashFp.CastVoteForHash(lastVotedBlkHeight, badBlock.AppHash)
+	slashFp.CastVoteForHash(lastVotedBlkHeight, goodBlock.AppHash)
+
+	d.GenerateNewBlockAssertExecutionSuccess()
+
+	slashedFp := d.GetFp(*slashFp.BTCPublicKey())
+	require.False(t, slashedFp.Jailed)
+	require.True(t, slashedFp.IsSlashed())
+
+	// send gov proposal to resume finality
+	prop := ftypes.MsgResumeFinalityProposal{
+		Authority:     appparams.AccGov.String(),
+		FpPksHex:      []string{slashedFp.BtcPk.MarshalHex()},
+		HaltingHeight: uint32(lastFinalizedBlkHeight + 1), // fp voted in the last finalized
+	}
+	d.GovPropWaitPass(&prop)
+
+	d.GenerateNewBlock()
+	// check that the blocks got finalized
+	for blkHeight := lastFinalizedBlkHeight + 1; blkHeight <= lastVotedBlkHeight; blkHeight++ {
+		bl := d.GetIndexedBlock(blkHeight)
+		require.Equal(t, bl.Finalized, true)
+
+		vp := d.App.FinalityKeeper.GetVotingPower(d.Ctx(), *slashFp.BTCPublicKey(), blkHeight)
+		require.Zero(t, vp)
+	}
+
+	// the fp in the voting power distribution cache should still be marked as slashed
+	vpDstCache := d.GetVotingPowerDistCache(d.GetLastFinalizedBlock().Height)
+	for _, vpFp := range vpDstCache.FinalityProviders {
+		if vpFp.BtcPk.Equals(slashFp.BTCPublicKey()) {
+			require.True(d.t, vpFp.IsSlashed)
+			require.Zero(d.t, vpFp.TotalBondedSat)
 			continue
 		}
 
-		msgs = append(msgs, &bstypes.MsgAddBTCDelegationInclusionProof{
-			Signer:                  senderAddr.String(),
-			StakingTxHash:           tx.TxHash().String(),
-			StakingTxInclusionProof: bstypes.NewInclusionProofFromSpvProof(blockWithProofs.Proofs[i]),
-		})
+		require.False(d.t, vpFp.IsJailed)
+		require.False(d.t, vpFp.IsSlashed)
+		require.NotZero(d.t, vpFp.TotalBondedSat)
 	}
-	return msgs
+
+	// continue to be slashed status in btcstaking
+	slashedFp = d.GetFp(*slashFp.BTCPublicKey())
+	require.True(t, slashedFp.IsSlashed())
+}
+
+func TestResumeFinalityOfJailedSlashedFp(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	d := NewBabylonAppDriverTmpDir(r, t)
+	d.GenerateNewBlock()
+
+	scn := NewStandardScenario(d)
+	scn.InitScenario(2, 1) // 2 fps, 1 del each
+
+	// finalize first 2 blocks, where both vote
+	numBlocksFinalized := uint64(2)
+	lastVotedBlkHeight := scn.FinalityFinalizeBlocks(scn.activationHeight, numBlocksFinalized)
+
+	// one fp continues to vote, but the one to be jailed one does not vote
+	indexSlashFp := 1
+	jailedFp := scn.finalityProviders[indexSlashFp]
+	lastFinalizedBlkHeight := lastVotedBlkHeight
+
+	for {
+		lastVotedBlkHeight++
+		for _, fp := range scn.finalityProviders[:indexSlashFp] {
+			fp.CastVote(lastVotedBlkHeight)
+		}
+
+		d.GenerateNewBlock()
+
+		bl := d.GetIndexedBlock(lastVotedBlkHeight)
+		require.Equal(t, bl.Finalized, false)
+
+		fp := d.GetFp(*jailedFp.BTCPublicKey())
+		if fp.Jailed {
+			break
+		}
+	}
+
+	// fp is slashed, sending bogus vote is not enough since the fp
+	// is jailed, new votes are no accepted. It is needed to send a
+	// selective slash with one of the BTC delegations stk txs
+	jailedFp.SendSelectiveSlashingEvidence()
+	d.GenerateNewBlock()
+
+	slashedFp := d.GetFp(*jailedFp.BTCPublicKey())
+	require.True(t, slashedFp.IsSlashed())
+
+	// send gov proposal to resume finality
+	prop := ftypes.MsgResumeFinalityProposal{
+		Authority:     appparams.AccGov.String(),
+		FpPksHex:      []string{slashedFp.BtcPk.MarshalHex()},
+		HaltingHeight: uint32(lastFinalizedBlkHeight + 1), // fp voted in the last finalized
+	}
+	d.GovPropWaitPass(&prop)
+
+	d.GenerateNewBlock()
+	// check that the blocks got finalized
+	for blkHeight := lastFinalizedBlkHeight + 1; blkHeight <= lastVotedBlkHeight; blkHeight++ {
+		bl := d.GetIndexedBlock(blkHeight)
+		require.Equal(t, bl.Finalized, true)
+
+		vp := d.App.FinalityKeeper.GetVotingPower(d.Ctx(), *jailedFp.BTCPublicKey(), blkHeight)
+		require.Zero(t, vp)
+	}
+
+	// the fp in the voting power distribution cache should still be marked as slashed
+	vpDstCache := d.GetVotingPowerDistCache(d.GetLastFinalizedBlock().Height)
+	for _, vpFp := range vpDstCache.FinalityProviders {
+		if vpFp.BtcPk.Equals(jailedFp.BTCPublicKey()) {
+			require.True(d.t, vpFp.IsSlashed)
+			require.Zero(d.t, vpFp.TotalBondedSat)
+			continue
+		}
+
+		require.False(d.t, vpFp.IsJailed)
+		require.False(d.t, vpFp.IsSlashed)
+		require.NotZero(d.t, vpFp.TotalBondedSat)
+	}
+
+	// continue to be slashed status in btcstaking
+	slashedFp = d.GetFp(*jailedFp.BTCPublicKey())
+	require.True(t, slashedFp.IsSlashed())
 }

--- a/test/replay/gov.go
+++ b/test/replay/gov.go
@@ -1,0 +1,38 @@
+package replay
+
+import (
+	"github.com/babylonlabs-io/babylon/v2/testutil/datagen"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govv1types "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func (d *BabylonAppDriver) NewGovProp(msgs ...sdk.Msg) sdk.Msg {
+	p := d.GovParams()
+
+	msg, err := govv1types.NewMsgSubmitProposal(
+		msgs,
+		sdk.NewCoins(p.ExpeditedMinDeposit...),
+		d.AddressString(),
+		"",
+		datagen.GenRandomHexStr(d.r, 100),
+		datagen.GenRandomHexStr(d.r, 1000),
+		true,
+	)
+	require.NoError(d.t, err)
+
+	return msg
+}
+
+func (d *BabylonAppDriver) GovVote(propId uint64) {
+	msg := govv1types.NewMsgVote(d.Address(), propId, govv1types.OptionYes, "")
+
+	d.SendTxWithMsgsFromDriverAccount(d.t, msg)
+}
+
+func (d *BabylonAppDriver) GovParams() govv1types.Params {
+	p, err := d.GovQuerySvr().Params(d.Ctx(), &govv1types.QueryParamsRequest{})
+	require.NoError(d.t, err)
+
+	return *p.Params
+}

--- a/test/replay/replayer.go
+++ b/test/replay/replayer.go
@@ -1,0 +1,112 @@
+package replay
+
+import (
+	"testing"
+
+	"cosmossdk.io/log"
+	babylonApp "github.com/babylonlabs-io/babylon/v2/app"
+	appsigner "github.com/babylonlabs-io/babylon/v2/app/signer"
+	dbmc "github.com/cometbft/cometbft-db"
+	cs "github.com/cometbft/cometbft/consensus"
+	cometlog "github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/mempool"
+	"github.com/cometbft/cometbft/proxy"
+	sm "github.com/cometbft/cometbft/state"
+	"github.com/cometbft/cometbft/store"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/stretchr/testify/require"
+)
+
+type BlockReplayer struct {
+	BlockExec *sm.BlockExecutor
+	LastState sm.State
+}
+
+func NewBlockReplayer(t *testing.T, nodeDir string) *BlockReplayer {
+	_, doc := getGenDoc(t, nodeDir)
+
+	genDoc, err := doc.ToGenesisDoc()
+	require.NoError(t, err)
+
+	state, err := sm.MakeGenesisState(genDoc)
+	require.NoError(t, err)
+
+	stateStore := sm.NewStore(dbmc.NewMemDB(), sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+
+	if err := stateStore.Save(state); err != nil {
+		panic(err)
+	}
+
+	blsSigner, err := appsigner.InitBlsSigner(nodeDir)
+	require.NoError(t, err)
+	require.NotNil(t, blsSigner)
+
+	appOptions := NewAppOptionsWithFlagHome(nodeDir)
+	baseAppOptions := server.DefaultBaseappOptions(appOptions)
+	tmpApp := babylonApp.NewBabylonApp(
+		log.NewNopLogger(),
+		dbm.NewMemDB(),
+		nil,
+		true,
+		map[int64]bool{},
+		0,
+		blsSigner,
+		appOptions,
+		babylonApp.EmptyWasmOpts,
+		baseAppOptions...,
+	)
+
+	cmtApp := server.NewCometABCIWrapper(tmpApp)
+	procxyCons := proxy.NewMultiAppConn(
+		proxy.NewLocalClientCreator(cmtApp),
+		proxy.NopMetrics(),
+	)
+	err = procxyCons.Start()
+	require.NoError(t, err)
+
+	blockStore := store.NewBlockStore(dbmc.NewMemDB())
+
+	blockExec := sm.NewBlockExecutor(
+		stateStore,
+		cometlog.TestingLogger(),
+		procxyCons.Consensus(),
+		&mempool.NopMempool{},
+		sm.EmptyEvidencePool{},
+		blockStore,
+	)
+	require.NotNil(t, blockExec)
+
+	hs := cs.NewHandshaker(
+		stateStore,
+		state,
+		blockStore,
+		genDoc,
+	)
+
+	require.NotNil(t, hs)
+	hs.SetLogger(cometlog.TestingLogger())
+	err = hs.Handshake(procxyCons)
+	require.NoError(t, err)
+
+	state, err = stateStore.Load()
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	return &BlockReplayer{
+		BlockExec: blockExec,
+		LastState: state,
+	}
+}
+
+func (r *BlockReplayer) ReplayBlocks(t *testing.T, blocks []FinalizedBlock) {
+	for _, block := range blocks {
+		blockID, _ := getBlockId(t, block.Block)
+		state, err := r.BlockExec.ApplyVerifiedBlock(r.LastState, blockID, block.Block)
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		r.LastState = state.Copy()
+	}
+}

--- a/test/replay/scenario_builder.go
+++ b/test/replay/scenario_builder.go
@@ -1,0 +1,106 @@
+package replay
+
+import "github.com/stretchr/testify/require"
+
+type StandardScenario struct {
+	driver            *BabylonAppDriver
+	stakers           []*Staker
+	finalityProviders []*FinalityProvider
+	covenant          *CovenantSender
+	activationHeight  uint64
+}
+
+func NewStandardScenario(driver *BabylonAppDriver) *StandardScenario {
+	return &StandardScenario{
+		driver: driver,
+	}
+}
+
+// TODO: for now scenario works for small amount of fps and stakers, as with
+// larger amound we are hitting per block gas limit, which leads to account sequence
+// number errors. Improve this in the future.
+func (s *StandardScenario) InitScenario(
+	numFps int,
+	delegationsPerFp int,
+) {
+	covSender := s.driver.CreateCovenantSender()
+	fps := s.driver.CreateNFinalityProviderAccounts(numFps)
+	// each staker will delegate to same fp
+	stakers := s.driver.CreateNStakerAccounts(numFps)
+	s.driver.GenerateNewBlockAssertExecutionSuccess()
+
+	for _, fp := range fps {
+		fp.RegisterFinalityProvider()
+	}
+	// register all fps in one block
+	s.driver.GenerateNewBlockAssertExecutionSuccess()
+
+	for _, fp := range fps {
+		fp.CommitRandomness()
+	}
+
+	currnetEpochNunber := s.driver.GetEpoch().EpochNumber
+	s.driver.ProgressTillFirstBlockTheNextEpoch()
+	s.driver.FinializeCkptForEpoch(currnetEpochNunber)
+
+	// commit all fps in one block
+	s.driver.GenerateNewBlockAssertExecutionSuccess()
+
+	for i, fp := range fps {
+		for j := 0; j < delegationsPerFp; j++ {
+			stakers[i].CreatePreApprovalDelegation(
+				fp.BTCPublicKey(),
+				// default values for now
+				1000,
+				100000000,
+			)
+		}
+	}
+
+	s.driver.GenerateNewBlockAssertExecutionSuccess()
+	pendingDelegations := s.driver.GetPendingBTCDelegations(s.driver.t)
+	require.Equal(s.driver.t, len(pendingDelegations), numFps*delegationsPerFp)
+
+	covSender.SendCovenantSignatures()
+	s.driver.GenerateNewBlockAssertExecutionSuccess()
+
+	verifiedDelegations := s.driver.GetVerifiedBTCDelegations(s.driver.t)
+	require.Equal(s.driver.t, len(verifiedDelegations), numFps*delegationsPerFp)
+
+	s.driver.ActivateVerifiedDelegations(numFps * delegationsPerFp)
+	s.driver.GenerateNewBlockAssertExecutionSuccess()
+
+	activationHeight := s.driver.GetActivationHeight(s.driver.t)
+	require.Greater(s.driver.t, activationHeight, uint64(0))
+
+	activeFps := s.driver.GetActiveFpsAtHeight(s.driver.t, activationHeight)
+	require.Equal(s.driver.t, len(activeFps), numFps)
+
+	s.covenant = covSender
+	s.stakers = stakers
+	s.finalityProviders = fps
+	s.activationHeight = activationHeight
+}
+
+func (s *StandardScenario) FinalityFinalizeBlocks(fromBlockToFinalize, numBlocksToFinalize uint64) uint64 {
+	d := s.driver
+	t := d.t
+
+	latestFinalizedBlockHeight := uint64(0)
+	for blkHeight := fromBlockToFinalize; blkHeight <= fromBlockToFinalize+numBlocksToFinalize; blkHeight++ {
+		bl := d.GetIndexedBlock(blkHeight)
+		require.Equal(t, bl.Finalized, false)
+
+		for _, fp := range s.finalityProviders {
+			fp.CastVote(blkHeight)
+		}
+
+		d.GenerateNewBlockAssertExecutionSuccess()
+
+		bl = d.GetIndexedBlock(blkHeight)
+		require.Equal(t, bl.Finalized, true)
+		latestFinalizedBlockHeight = blkHeight
+	}
+
+	return latestFinalizedBlockHeight
+}

--- a/test/replay/staker_sender.go
+++ b/test/replay/staker_sender.go
@@ -1,0 +1,135 @@
+package replay
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/babylonlabs-io/babylon/v2/testutil/datagen"
+	"github.com/babylonlabs-io/babylon/v2/types"
+	bbn "github.com/babylonlabs-io/babylon/v2/types"
+	bstypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
+	"github.com/stretchr/testify/require"
+
+	babylonApp "github.com/babylonlabs-io/babylon/v2/app"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+)
+
+type Staker struct {
+	*SenderInfo
+	r             *rand.Rand
+	t             *testing.T
+	d             *BabylonAppDriver
+	app           *babylonApp.BabylonApp
+	BTCPrivateKey *btcec.PrivateKey
+}
+
+func (s *Staker) BTCPublicKey() *bbn.BIP340PubKey {
+	pk := bbn.NewBIP340PubKeyFromBTCPK(s.BTCPrivateKey.PubKey())
+	return pk
+}
+
+func (s *Staker) CreatePreApprovalDelegation(
+	fpKey *bbn.BIP340PubKey,
+	stakingTime uint32,
+	totalSat int64,
+) *bstypes.MsgCreateBTCDelegation {
+	params := s.d.GetBTCStakingParams(s.t)
+
+	var covenantPks []*btcec.PublicKey
+	for _, pk := range params.CovenantPks {
+		covenantPks = append(covenantPks, pk.MustToBTCPK())
+	}
+
+	stakingSlashingInfo := datagen.GenBTCStakingSlashingInfo(
+		s.r,
+		s.t,
+		BtcParams,
+		s.BTCPrivateKey,
+		[]*btcec.PublicKey{fpKey.MustToBTCPK()},
+		covenantPks,
+		params.CovenantQuorum,
+		uint16(stakingTime),
+		totalSat,
+		params.SlashingPkScript,
+		params.SlashingRate,
+		uint16(params.UnbondingTimeBlocks),
+	)
+
+	slashingPathSpendInfo, err := stakingSlashingInfo.StakingInfo.SlashingPathSpendInfo()
+	require.NoError(s.t, err)
+
+	// delegator pre-signs slashing tx
+	delegatorSig, err := stakingSlashingInfo.SlashingTx.Sign(
+		stakingSlashingInfo.StakingTx,
+		datagen.StakingOutIdx,
+		slashingPathSpendInfo.GetPkScriptPath(),
+		s.BTCPrivateKey,
+	)
+	require.NoError(s.t, err)
+
+	serializedStakingTx, err := bbn.SerializeBTCTx(stakingSlashingInfo.StakingTx)
+	require.NoError(s.t, err)
+
+	stkTxHash := stakingSlashingInfo.StakingTx.TxHash()
+	unbondingValue := uint64(totalSat) - uint64(params.UnbondingFeeSat)
+
+	unbondingSlashingInfo := datagen.GenBTCUnbondingSlashingInfo(
+		s.r,
+		s.t,
+		BtcParams,
+		s.BTCPrivateKey,
+		[]*btcec.PublicKey{fpKey.MustToBTCPK()},
+		covenantPks,
+		params.CovenantQuorum,
+		wire.NewOutPoint(&stkTxHash, datagen.StakingOutIdx),
+		uint16(params.UnbondingTimeBlocks),
+		int64(unbondingValue),
+		params.SlashingPkScript,
+		params.SlashingRate,
+		uint16(params.UnbondingTimeBlocks),
+	)
+
+	unbondingTxBytes, err := bbn.SerializeBTCTx(unbondingSlashingInfo.UnbondingTx)
+	require.NoError(s.t, err)
+	delSlashingTxSig, err := unbondingSlashingInfo.GenDelSlashingTxSig(s.BTCPrivateKey)
+	require.NoError(s.t, err)
+
+	pop, err := datagen.NewPoPBTC(s.Address(), s.BTCPrivateKey)
+	require.NoError(s.t, err)
+
+	msg := &bstypes.MsgCreateBTCDelegation{
+		StakerAddr:   s.AddressString(),
+		Pop:          pop,
+		BtcPk:        s.BTCPublicKey(),
+		FpBtcPkList:  []bbn.BIP340PubKey{*fpKey},
+		StakingTime:  stakingTime,
+		StakingValue: totalSat,
+		StakingTx:    serializedStakingTx,
+		// We are using nil for so
+		StakingTxInclusionProof:       nil,
+		SlashingTx:                    stakingSlashingInfo.SlashingTx,
+		DelegatorSlashingSig:          delegatorSig,
+		UnbondingValue:                int64(unbondingValue),
+		UnbondingTime:                 params.UnbondingTimeBlocks,
+		UnbondingTx:                   unbondingTxBytes,
+		UnbondingSlashingTx:           unbondingSlashingInfo.SlashingTx,
+		DelegatorUnbondingSlashingSig: delSlashingTxSig,
+	}
+
+	DefaultSendTxWithMessagesSuccess(
+		s.t,
+		s.app,
+		s.SenderInfo,
+		msg,
+	)
+
+	s.IncSeq()
+	return msg
+}
+
+func StakingTransaction(t *testing.T, msg *bstypes.MsgCreateBTCDelegation) *wire.MsgTx {
+	stakingTx, err := types.NewBTCTxFromBytes(msg.StakingTx)
+	require.NoError(t, err)
+	return stakingTx
+}

--- a/testutil/datagen/btcstaking.go
+++ b/testutil/datagen/btcstaking.go
@@ -302,6 +302,16 @@ type CreateDelegationInfo struct {
 	UnbondingTx            *wire.MsgTx
 }
 
+func DelegationInfosToBTCTx(
+	delInfos []*CreateDelegationInfo,
+) []*wire.MsgTx {
+	txs := []*wire.MsgTx{}
+	for _, delInfo := range delInfos {
+		txs = append(txs, delInfo.StakingTx)
+	}
+	return txs
+}
+
 // GenRandomMsgCreateBtcDelegation generates a random MsgCreateBTCDelegation message
 // valid for the given parameters.
 func GenRandomMsgCreateBtcDelegationAndMsgAddCovenantSignatures(

--- a/x/finality/keeper/gov.go
+++ b/x/finality/keeper/gov.go
@@ -1,13 +1,11 @@
 package keeper
 
 import (
-	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	bbntypes "github.com/babylonlabs-io/babylon/v2/types"
-	bstypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
 )
 
 // HandleResumeFinalityProposal handles the resume finality proposal in the following steps:
@@ -41,28 +39,56 @@ func (k Keeper) HandleResumeFinalityProposal(ctx sdk.Context, fpPksHex []string,
 			return fmt.Errorf("the finality provider %s has voted for height %d", fpPkHex, haltingHeight)
 		}
 
+		fpBtcPk := fpPk.MustMarshal()
+		fp, err := k.BTCStakingKeeper.GetFinalityProvider(ctx, fpBtcPk)
+		if err != nil {
+			return fmt.Errorf("failed to find the finality provider %s in btcstaking: %w", fpPkHex, err)
+		}
+
+		k.Logger(ctx).Debug(
+			"fp running proposal resume finality",
+			"jailed", fp.IsJailed(),
+			"slashed", fp.IsSlashed(),
+			"height", haltingHeight,
+			"public_key", fpPkHex,
+		)
+
+		// if the FP is already jailed or slashed, no need to try to set to jail
+		// or to update the signing info
+		if fp.IsSlashed() || fp.IsJailed() {
+			continue
+		}
+
+		k.Logger(ctx).Debug(
+			"fp will be jailed",
+			"height", haltingHeight,
+			"public_key", fpPkHex,
+		)
+
 		err = k.jailSluggishFinalityProvider(ctx, fpPk)
-		if err != nil && !errors.Is(err, bstypes.ErrFpAlreadyJailed) {
+		if err != nil {
 			return fmt.Errorf("failed to jail the finality provider %s: %w", fpPkHex, err)
 		}
 
 		// update signing info
-		signInfo, err := k.FinalityProviderSigningTracker.Get(ctx, fpPk.MustMarshal())
+		signInfo, err := k.FinalityProviderSigningTracker.Get(ctx, fpBtcPk)
 		if err != nil {
 			return fmt.Errorf("the signing info of finality provider %s is not created: %w", fpPkHex, err)
 		}
 		signInfo.JailedUntil = currentTime.Add(params.JailDuration)
 		signInfo.MissedBlocksCounter = 0
+
 		if err := k.DeleteMissedBlockBitmap(ctx, fpPk); err != nil {
 			return fmt.Errorf("failed to remove the missed block bit map for finality provider %s: %w", fpPkHex, err)
 		}
-		err = k.FinalityProviderSigningTracker.Set(ctx, fpPk.MustMarshal(), signInfo)
+
+		err = k.FinalityProviderSigningTracker.Set(ctx, fpBtcPk, signInfo)
 		if err != nil {
 			return fmt.Errorf("failed to set the signing info for finality provider %s: %w", fpPkHex, err)
 		}
 
 		k.Logger(ctx).Info(
-			"finality provider is jailed in the proposal",
+			"finality provider was jailed",
 			"height", haltingHeight,
 			"public_key", fpPkHex,
 		)
@@ -73,8 +99,14 @@ func (k Keeper) HandleResumeFinalityProposal(ctx sdk.Context, fpPksHex []string,
 		distCache := k.GetVotingPowerDistCache(ctx, h)
 		activeFps := distCache.GetActiveFinalityProviderSet()
 		for _, fpToJail := range fpPks {
-			if fp, exists := activeFps[fpToJail.MarshalHex()]; exists {
-				fp.IsJailed = true
+			fpDstInf, exists := activeFps[fpToJail.MarshalHex()]
+			if exists {
+				// if the fp was already slashed at that height, keep as it was
+				// and do not update to jailed.
+				if !fpDstInf.IsSlashed {
+					fpDstInf.IsJailed = true
+				}
+
 				k.SetVotingPower(ctx, fpToJail.MustMarshal(), h, 0)
 			}
 		}

--- a/x/finality/keeper/gov_test.go
+++ b/x/finality/keeper/gov_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/babylonlabs-io/babylon/v2/testutil/datagen"
 	keepertest "github.com/babylonlabs-io/babylon/v2/testutil/keeper"
 	bbntypes "github.com/babylonlabs-io/babylon/v2/types"
+	bstypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
 	"github.com/babylonlabs-io/babylon/v2/x/finality/keeper"
 	"github.com/babylonlabs-io/babylon/v2/x/finality/types"
 )
@@ -68,6 +69,9 @@ func TestHandleResumeFinalityProposal(t *testing.T) {
 
 	// create a resume finality proposal to jail the last fp
 	bsKeeper.EXPECT().JailFinalityProvider(ctx, gomock.Any()).Return(nil).AnyTimes()
+	bsKeeper.EXPECT().GetFinalityProvider(gomock.Any(), gomock.Any()).Return(&bstypes.FinalityProvider{
+		Jailed: false,
+	}, nil).AnyTimes()
 	err := fKeeper.HandleResumeFinalityProposal(ctx, publicKeysToHex(activeFpPks[1:]), uint32(haltingHeight))
 	require.NoError(t, err)
 
@@ -77,6 +81,133 @@ func TestHandleResumeFinalityProposal(t *testing.T) {
 		ib, err := fKeeper.GetBlock(ctx, i)
 		require.NoError(t, err)
 		require.True(t, ib.Finalized)
+	}
+}
+
+func TestHandleResumeFinalityProposalWithJailedAndSlashedFp(t *testing.T) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	bsKeeper := types.NewMockBTCStakingKeeper(ctrl)
+	iKeeper := types.NewMockIncentiveKeeper(ctrl)
+	// cKeeper := types.NewMockCheckpointingKeeper(ctrl)
+	fKeeper, ctx := keepertest.FinalityKeeper(t, bsKeeper, iKeeper, nil)
+
+	haltingHeight := uint64(100)
+	currentHeight := uint64(110)
+
+	// 4 FPs, after the missed blocks
+	// one will be slashed one jailed and two active
+	// each one with same VP, only one of the active is correctly voting
+	numFps := 4
+	activeFpPks := generateNFpPks(t, r, numFps)
+	setupActiveFps(t, activeFpPks, haltingHeight, fKeeper, ctx)
+	// set voting power table for each height, only the first fp votes
+	activeVotingFpPk, slashedFpPk, jailedFpPk, activeFpToBeJailed := activeFpPks[0], activeFpPks[1], activeFpPks[2], activeFpPks[3]
+	for h := haltingHeight; h <= currentHeight; h++ {
+		fKeeper.SetBlock(ctx, &types.IndexedBlock{
+			Height:    h,
+			AppHash:   datagen.GenRandomByteArray(r, 32),
+			Finalized: false,
+		})
+		dc := types.NewVotingPowerDistCache()
+		for i := 0; i < numFps; i++ {
+			fKeeper.SetVotingPower(ctx, activeFpPks[i].MustMarshal(), h, 1)
+			dc.AddFinalityProviderDistInfo(&types.FinalityProviderDistInfo{
+				BtcPk:          &activeFpPks[i],
+				TotalBondedSat: 1,
+				IsTimestamped:  true,
+			})
+		}
+		dc.ApplyActiveFinalityProviders(uint32(numFps))
+		votedSig, err := bbntypes.NewSchnorrEOTSSig(datagen.GenRandomByteArray(r, 32))
+		require.NoError(t, err)
+		fKeeper.SetSig(ctx, h, &activeVotingFpPk, votedSig)
+		fKeeper.SetVotingPowerDistCache(ctx, h, dc)
+	}
+
+	// tally blocks and none of them should be finalised
+	ctx = datagen.WithCtxHeight(ctx, currentHeight)
+	fKeeper.TallyBlocks(ctx, uint64(10000))
+	for i := haltingHeight; i < currentHeight; i++ {
+		ib, err := fKeeper.GetBlock(ctx, i)
+		require.NoError(t, err)
+		require.False(t, ib.Finalized)
+	}
+
+	slashedFp := &bstypes.FinalityProvider{
+		BtcPk:                &slashedFpPk,
+		Jailed:               false,
+		SlashedBabylonHeight: currentHeight,
+	}
+	bsKeeper.EXPECT().GetFinalityProvider(gomock.Any(), slashedFpPk.MustMarshal()).Return(slashedFp, nil).MaxTimes(1)
+
+	jailedFp := &bstypes.FinalityProvider{
+		BtcPk:  &slashedFpPk,
+		Jailed: true,
+	}
+	bsKeeper.EXPECT().GetFinalityProvider(gomock.Any(), jailedFpPk.MustMarshal()).Return(jailedFp, nil).MaxTimes(1)
+
+	activeNonVoting := &bstypes.FinalityProvider{
+		BtcPk:  &activeFpToBeJailed,
+		Jailed: false,
+	}
+	bsKeeper.EXPECT().GetFinalityProvider(gomock.Any(), activeFpToBeJailed.MustMarshal()).Return(activeNonVoting, nil).MaxTimes(1)
+
+	// create a resume finality proposal to jail the last fp only
+	// the already jailed and slashed fp should not be called
+	bsKeeper.EXPECT().JailFinalityProvider(ctx, activeFpToBeJailed.MustMarshal()).Return(nil).MaxTimes(1)
+	err := fKeeper.HandleResumeFinalityProposal(ctx, publicKeysToHex(activeFpPks[1:]), uint32(haltingHeight))
+	require.NoError(t, err)
+
+	fKeeper.TallyBlocks(ctx, types.MaxFinalizedRewardedBlocksPerEndBlock)
+
+	for i := haltingHeight; i <= currentHeight; i++ {
+		ib, err := fKeeper.GetBlock(ctx, i)
+		require.NoError(t, err)
+		require.True(t, ib.Finalized)
+	}
+
+	// check that the active non voting fp had the signing info updated
+	signingInfo, err := fKeeper.FinalityProviderSigningTracker.Get(ctx, activeFpToBeJailed)
+	require.NoError(t, err)
+	require.Zero(t, signingInfo.MissedBlocksCounter)
+
+	params := fKeeper.GetParams(ctx)
+	currentTime := ctx.HeaderInfo().Time
+	require.Equal(t, signingInfo.JailedUntil.String(), currentTime.Add(params.JailDuration).String())
+
+	// verifies the voting power distribution cache has set the FPs as jailed
+	// and the correct fps have zero voting power.
+	for h := haltingHeight; h <= currentHeight; h++ {
+		distCache := fKeeper.GetVotingPowerDistCache(ctx, h)
+
+		// checks the FPs have bonded sats, but zero voting power
+		for _, fpDstCache := range distCache.FinalityProviders {
+			vp := fKeeper.GetVotingPower(ctx, *fpDstCache.BtcPk, h)
+			require.Equal(t, fpDstCache.TotalBondedSat, uint64(1))
+
+			switch fpDstCache.BtcPk.MarshalHex() {
+			case activeVotingFpPk.MarshalHex():
+				require.Equal(t, vp, uint64(1))
+				require.False(t, fpDstCache.IsJailed)
+				require.False(t, fpDstCache.IsSlashed)
+			case slashedFpPk.MarshalHex():
+				require.Zero(t, vp)
+				// slashed could have been slashed for a few blocks before and
+				// it should keep as slashed, don't update to jailed
+				require.True(t, fpDstCache.IsSlashed || fpDstCache.IsJailed)
+			case jailedFpPk.MarshalHex():
+				require.Zero(t, vp)
+				require.True(t, fpDstCache.IsJailed)
+			case activeFpToBeJailed.MarshalHex():
+				require.Zero(t, vp)
+				require.True(t, fpDstCache.IsJailed)
+			default:
+				t.Error("unexpected fp")
+			}
+		}
 	}
 }
 

--- a/x/finality/keeper/power_dist_change_test.go
+++ b/x/finality/keeper/power_dist_change_test.go
@@ -1319,7 +1319,7 @@ func TestDoNotGenerateDuplicateEventsAfterHavingCovenantQuorum(t *testing.T) {
 }
 
 func AddBtcBlockWithDelegations(t *testing.T, r *rand.Rand, app *babylonApp.BabylonApp, ctx sdk.Context, delInfos ...*datagen.CreateDelegationInfo) (*datagen.BlockWithProofs, []*wire.MsgTx) {
-	stkTxs := replay.DelegationInfosToBTCTx(delInfos)
+	stkTxs := datagen.DelegationInfosToBTCTx(delInfos)
 	return AddBtcBlockWithTxs(t, r, app, ctx, stkTxs...), stkTxs
 }
 


### PR DESCRIPTION
Prior to this, any slashed FP at the latest height wouldn't be jailed and the proposal would fail
Add checks for FP slash and only set in vp distribution cache to jailed if it wasn't already slashed

Also had to update replay driver code to run tests

Backport: #829 