### PR TITLE
fix: ensure active fps have signing info after proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ This PR contains a series of PRs on multi-staking support and BTC staking integr
 ### Bug fixes
 
 - [#829](https://github.com/babylonlabs-io/babylon/pull/829) fix: add checks for slashed fp in gov resume finality
+- [#860](https://github.com/babylonlabs-io/babylon/pull/860) fix: ensure active fps have signing info after finality resumption proposal
 - [#796](https://github.com/babylonlabs-io/babylon/pull/796) fix: goreleaser add `mainnet` build flag to generated binary
 - [#741](https://github.com/babylonlabs-io/babylon/pull/741) chore: fix register consumer CLI
 - [#731](https://github.com/babylonlabs-io/babylon/pull/731) chore: fix block timeout in Babylon client

--- a/client/query/client.go
+++ b/client/query/client.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/types/query"
 
-	"github.com/babylonlabs-io/babylon/v2/client/config"
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	"github.com/cosmos/cosmos-sdk/client"
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/babylonlabs-io/babylon/v2/client/config"
 )
 
 // QueryClient is a client that can only perform queries to a Babylon node

--- a/client/query/epoching.go
+++ b/client/query/epoching.go
@@ -3,9 +3,10 @@ package query
 import (
 	"context"
 
-	epochingtypes "github.com/babylonlabs-io/babylon/v2/x/epoching/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	sdkquerytypes "github.com/cosmos/cosmos-sdk/types/query"
+
+	epochingtypes "github.com/babylonlabs-io/babylon/v2/x/epoching/types"
 )
 
 // QueryEpoching queries the Epoching module of the Babylon node

--- a/test/replay/driver.go
+++ b/test/replay/driver.go
@@ -939,13 +939,13 @@ func (d *BabylonAppDriver) GovPropWaitPass(msgInGovProp sdk.Msg) {
 		prop := d.GovProposal(propId)
 
 		if prop.Status == v1.ProposalStatus_PROPOSAL_STATUS_FAILED {
-			d.t.Errorf("prop %d failed due to: %s", propId, prop.FailedReason)
+			d.t.Fatalf("prop %d failed due to: %s", propId, prop.FailedReason)
 		}
 
 		if prop.Status == v1.ProposalStatus_PROPOSAL_STATUS_PASSED {
 			break
 		}
 
-		d.GenerateNewBlock()
+		d.GenerateNewBlockAssertExecutionSuccess()
 	}
 }

--- a/x/finality/keeper/gov.go
+++ b/x/finality/keeper/gov.go
@@ -129,13 +129,13 @@ func (k Keeper) HandleResumeFinalityProposal(ctx sdk.Context, fpPksHex []string,
 	// it is possible that some inactive fps become active after the proposal
 	// therefore, we need to ensure every active finality provider has signing info
 	for pk, dc := range distCache.GetActiveFinalityProviderSet() {
-		signingInfo, err := k.FinalityProviderSigningTracker.Get(ctx, dc.BtcPk.MustMarshal())
+		_, err := k.FinalityProviderSigningTracker.Get(ctx, dc.BtcPk.MustMarshal())
 		if err == nil {
 			continue
 		}
 
 		if errors.Is(err, collections.ErrNotFound) {
-			signingInfo = ftypes.NewFinalityProviderSigningInfo(
+			signingInfo := ftypes.NewFinalityProviderSigningInfo(
 				dc.BtcPk,
 				currentHeight,
 				0,

--- a/x/finality/keeper/gov.go
+++ b/x/finality/keeper/gov.go
@@ -103,10 +103,9 @@ func (k Keeper) HandleResumeFinalityProposal(ctx sdk.Context, fpPksHex []string,
 	}
 
 	// set the all the given finality providers voting power to 0
-	var distCache *ftypes.VotingPowerDistCache
 	allActiveFps := make(map[string]*ftypes.FinalityProviderDistInfo)
 	for h := uint64(haltingHeight); h <= uint64(currentHeight); h++ {
-		distCache = k.GetVotingPowerDistCache(ctx, h)
+		distCache := k.GetVotingPowerDistCache(ctx, h)
 		activeFps := distCache.GetActiveFinalityProviderSet()
 		for _, fpToJail := range fpPks {
 			fpDstInf, exists := activeFps[fpToJail.MarshalHex()]

--- a/x/finality/keeper/gov_test.go
+++ b/x/finality/keeper/gov_test.go
@@ -374,7 +374,7 @@ func TestHandleResumeFinalityProposalMissingSigningInfo(t *testing.T) {
 
 	require.NotPanics(t, func() {
 		fKeeper.HandleLiveness(ctx, int64(nextHeight))
-	}, "Expected panic due to missing signing info for newly active FP")
+	}, "Unexpected panic due to missing signing info for newly active FP")
 }
 
 func generateNFpPks(t *testing.T, r *rand.Rand, n int) []bbntypes.BIP340PubKey {

--- a/x/finality/keeper/power_dist_change.go
+++ b/x/finality/keeper/power_dist_change.go
@@ -50,18 +50,18 @@ func (k Keeper) UpdatePowerDist(ctx context.Context) {
 	newDc := k.ProcessAllPowerDistUpdateEvents(ctx, dc, events)
 
 	// record voting power and cache for this height
-	k.recordVotingPowerAndCache(ctx, newDc)
+	k.RecordVotingPowerAndCache(ctx, newDc)
 	// emit events for finality providers with state updates
-	k.handleFPStateUpdates(ctx, dc, newDc)
+	k.HandleFPStateUpdates(ctx, dc, newDc)
 	// record metrics
 	k.recordMetrics(newDc)
 }
 
-// recordVotingPowerAndCache assigns voting power to each active finality provider
+// RecordVotingPowerAndCache assigns voting power to each active finality provider
 // with the following consideration:
 // 1. the fp must have timestamped pub rand
 // 2. the fp must in the top x ranked by the voting power (x is given by maxActiveFps)
-func (k Keeper) recordVotingPowerAndCache(ctx context.Context, newDc *ftypes.VotingPowerDistCache) {
+func (k Keeper) RecordVotingPowerAndCache(ctx context.Context, newDc *ftypes.VotingPowerDistCache) {
 	if newDc == nil {
 		panic("the voting power distribution cache cannot be nil")
 	}
@@ -93,8 +93,8 @@ func (k Keeper) recordVotingPowerAndCache(ctx context.Context, newDc *ftypes.Vot
 	k.SetVotingPowerDistCache(ctx, babylonTipHeight, newDc)
 }
 
-// handleFPStateUpdates emits events and triggers hooks for finality providers with state updates
-func (k Keeper) handleFPStateUpdates(ctx context.Context, prevDc, newDc *ftypes.VotingPowerDistCache) {
+// HandleFPStateUpdates emits events and triggers hooks for finality providers with state updates
+func (k Keeper) HandleFPStateUpdates(ctx context.Context, prevDc, newDc *ftypes.VotingPowerDistCache) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	newlyActiveFPs := newDc.FindNewActiveFinalityProviders(prevDc)


### PR DESCRIPTION
It is possible that some inactive fps become active after executing the finality resumption proposal. However, current implementation does not initiate signing info for those fps, which would cause panicking when handling liveness.

This PR fixed the issue by ensuring every active finality provider has signing info in the finality resumption proposal.