### PR TITLE
chore: move goreleaser job to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,18 @@ jobs:
         | babylonlabs/babylond:${{ inputs.tag }} | Mainnet image |
         | babylonlabs/babylond:${{ inputs.tag }}-testnet | Testnet image |
     secrets: inherit
+
+  goreleaser:
+    name: Create release
+    needs: call-reusable-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Make release
+        run: |
+          make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When a release is created using the [release workflow](https://github.com/babylonlabs-io/babylon/blob/main/.github/workflows/release.yml), it doesn't trigger the gorelease workflow due to the limitation with `github.token` ([ref](https://github.com/actions/create-release/issues/71)).
This PR moves the goreleaser job into the release workflow, allowing it to be executed once the release is created
