### PR TITLE
fix: btcstaking test fix

### DIFF
--- a/test/replay/btcstaking_test.go
+++ b/test/replay/btcstaking_test.go
@@ -362,7 +362,7 @@ func TestSlashingandFinalizingBlocks(t *testing.T) {
 	scenario.InitScenario(6, 1) // 6 finality providers
 
 	numBlocksInTest := uint64(10)
-	lastVotedBlkHeight := scenario.FinalityFinalizeBlocks(scenario.activationHeight, numBlocksInTest, nil)
+	lastVotedBlkHeight := scenario.FinalityFinalizeBlocks(scenario.activationHeight, numBlocksInTest, scenario.FpMapBtcPkHex())
 
 	indexSlashFp1 := 1
 	indexSlashFp2 := 2
@@ -430,7 +430,7 @@ func TestActivatingDelegationOnSlashedFp(t *testing.T) {
 	scenario.driver.GenerateNewBlockAssertExecutionSuccess()
 
 	numBlocksInTest := uint64(10)
-	lastVotedBlkHeight := scenario.FinalityFinalizeBlocks(scenario.activationHeight, numBlocksInTest, nil)
+	lastVotedBlkHeight := scenario.FinalityFinalizeBlocks(scenario.activationHeight, numBlocksInTest, scenario.FpMapBtcPkHex())
 
 	for i := uint64(0); i < numBlocksInTest; i++ {
 		lastVotedBlkHeight++
@@ -497,7 +497,7 @@ func TestJailingFinalityProvider(t *testing.T) {
 	scenario := NewStandardScenario(driver)
 	scenario.InitScenario(2, 1)
 
-	lastVotedBlkHeight := scenario.FinalityFinalizeBlocks(scenario.activationHeight, numBlocksFinalized, nil)
+	lastVotedBlkHeight := scenario.FinalityFinalizeBlocks(scenario.activationHeight, numBlocksFinalized, scenario.FpMapBtcPkHex())
 
 	fp := scenario.finalityProviders[0]
 


### PR DESCRIPTION
When merging the btcstaking test, there must have been a change to the test as it was being merged as it is now failing after merge although it wasnt before. Ive added nil to the test to handle this issue