### PR TITLE
fix: update tokenfactory params to use `ubbn` as fee denom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
-- [#884](https://github.com/babylonlabs-io/babylon/pull/884) Bump tokenfactory version to v0.50.6
+- [#909](https://github.com/babylonlabs-io/babylon/pull/909) Update tokenfactory upgrade fee params to `ubbn` .
+- [#884](https://github.com/babylonlabs-io/babylon/pull/884) Bump tokenfactory version to v0.50.6.
 - [#879](https://github.com/babylonlabs-io/babylon/pull/879) Add v2 e2e upgrade test.
 - [#869](https://github.com/babylonlabs-io/babylon/pull/869) Rename CZ to Consumer in btcstkconsumer and zoneconcierge.
 - [#846](https://github.com/babylonlabs-io/babylon/pull/846) Add tokenfactory module.

--- a/app/upgrades/v2/upgrades.go
+++ b/app/upgrades/v2/upgrades.go
@@ -37,6 +37,11 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, 
 		// Set the denom creation fee to ubbn
 		params := tokenfactorytypes.DefaultParams()
 		params.DenomCreationFee = sdk.NewCoins(sdk.NewInt64Coin(types.DefaultBondDenom, 10_000_000))
+
+		if err := params.Validate(); err != nil {
+			return nil, err
+		}
+
 		if err := keepers.TokenFactoryKeeper.SetParams(ctx, params); err != nil {
 			return nil, err
 		}

--- a/app/upgrades/v2/upgrades.go
+++ b/app/upgrades/v2/upgrades.go
@@ -2,11 +2,10 @@ package v2
 
 import (
 	"context"
-	"cosmossdk.io/math"
 	store "cosmossdk.io/store/types"
 	"github.com/babylonlabs-io/babylon/v2/app/keepers"
 	"github.com/babylonlabs-io/babylon/v2/app/upgrades"
-	minttypes "github.com/babylonlabs-io/babylon/v2/x/mint/types"
+	"github.com/babylonlabs-io/babylon/v2/x/mint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	pfmroutertypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8/packetforward/types"
 	tokenfactorytypes "github.com/strangelove-ventures/tokenfactory/x/tokenfactory/types"
@@ -36,8 +35,8 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, 
 		}
 
 		// Set the denom creation fee to ubbn
-		params := keepers.TokenFactoryKeeper.GetParams(ctx)
-		params.DenomCreationFee = sdk.NewCoins(sdk.NewCoin(minttypes.DefaultBondDenom, math.NewInt(10000000)))
+		params := tokenfactorytypes.DefaultParams()
+		params.DenomCreationFee = sdk.NewCoins(sdk.NewInt64Coin(types.DefaultBondDenom, 10_000_000))
 		if err := keepers.TokenFactoryKeeper.SetParams(ctx, params); err != nil {
 			return nil, err
 		}

--- a/app/upgrades/v2/upgrades.go
+++ b/app/upgrades/v2/upgrades.go
@@ -2,10 +2,12 @@ package v2
 
 import (
 	"context"
-
+	"cosmossdk.io/math"
 	store "cosmossdk.io/store/types"
 	"github.com/babylonlabs-io/babylon/v2/app/keepers"
 	"github.com/babylonlabs-io/babylon/v2/app/upgrades"
+	minttypes "github.com/babylonlabs-io/babylon/v2/x/mint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	pfmroutertypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8/packetforward/types"
 	tokenfactorytypes "github.com/strangelove-ventures/tokenfactory/x/tokenfactory/types"
 
@@ -30,6 +32,13 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, 
 		// Run migrations before applying any other state changes.
 		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
 		if err != nil {
+			return nil, err
+		}
+
+		// Set the denom creation fee to ubbn
+		params := keepers.TokenFactoryKeeper.GetParams(ctx)
+		params.DenomCreationFee = sdk.NewCoins(sdk.NewCoin(minttypes.DefaultBondDenom, math.NewInt(10000000)))
+		if err := keepers.TokenFactoryKeeper.SetParams(ctx, params); err != nil {
 			return nil, err
 		}
 

--- a/test/e2e/software_upgrade_e2e_v2_test.go
+++ b/test/e2e/software_upgrade_e2e_v2_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"github.com/babylonlabs-io/babylon/v2/x/mint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 
@@ -102,7 +103,7 @@ func (s *SoftwareUpgradeV2TestSuite) TestUpgradeV2() {
 
 	feeEntry, ok := denomCreationFee[0].(map[string]interface{})
 	s.Require().True(ok, "fee entry should be a map")
-	s.Equal("stake", feeEntry["denom"])
+	s.Equal(types.DefaultBondDenom, feeEntry["denom"])
 	s.Equal("10000000", feeEntry["amount"])
 
 	s.Equal("2000000", params["denom_creation_gas_consume"])


### PR DESCRIPTION
Updates params in upgrade to use `ubbn` as fee denom and default amounts