### PR TITLE
[backport] feat: create update-bls-password cmd (#871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [#847](https://github.com/babylonlabs-io/babylon/pull/847) Add ibc callbacks to
 transfer stack
 - [#859](https://github.com/babylonlabs-io/babylon/pull/859) Update init/export genesis logic in `x/finality` module
+- [#871](https://github.com/babylonlabs-io/babylon/pull/871) create `update-bls-password` cmd
 - [#876](https://github.com/babylonlabs-io/babylon/pull/876) Add Packet Forwarding Middleware (PFM) module.
 - [#881](https://github.com/babylonlabs-io/babylon/pull/881) Update init/export genesis logic in `x/mint` module
 - [#883](https://github.com/babylonlabs-io/babylon/pull/883) Update init/export genesis logic in `x/monitor` module

--- a/app/signer/bls.go
+++ b/app/signer/bls.go
@@ -87,30 +87,40 @@ func GenBls(keyFilePath, passwordFilePath, password string) *Bls {
 	return pv
 }
 
+// loadBlsPrivKeyFromFile loads a BLS private key from a file.
+// Password should be determined before calling this function.
+func loadBlsPrivKeyFromFile(keyFilePath, password string) (bls12381.PrivateKey, error) {
+	keystore, err := erc2335.LoadKeyStore(keyFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load BLS key file: %w", err)
+	}
+
+	privKey, err := erc2335.Decrypt(keystore, password)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt BLS key: %w", err)
+	}
+
+	blsPrivKey := bls12381.PrivateKey(privKey)
+	if err := blsPrivKey.ValidateBasic(); err != nil {
+		return nil, fmt.Errorf("invalid BLS private key: %w", err)
+	}
+
+	return blsPrivKey, nil
+}
+
 // TryLoadBlsFromFile attempts to load a BLS key from the given file paths.
 // It tries to use environment variable for password first, then falls back to file-based password.
 // Returns error if the key file exists, but cannot get password or the key cannot
 // be decrypted
 func TryLoadBlsFromFile(keyFilePath, passwordFilePath string) (*Bls, bool, error) {
-	keystore, err := erc2335.LoadKeyStore(keyFilePath)
-	if err != nil {
-		//nolint:nilerr
-		return nil, false, nil
-	}
-
 	password, err := GetBlsPassword(passwordFilePath)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get password: %w", err)
 	}
 
-	privKey, err := erc2335.Decrypt(keystore, password)
+	blsPrivKey, err := loadBlsPrivKeyFromFile(keyFilePath, password)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to decrypt BLS key: %w", err)
-	}
-
-	blsPrivKey := bls12381.PrivateKey(privKey)
-	if err := blsPrivKey.ValidateBasic(); err != nil {
-		return nil, false, fmt.Errorf("invalid BLS private key: %w", err)
+		return nil, false, fmt.Errorf("failed to load BLS key: %w", err)
 	}
 
 	return &Bls{
@@ -177,24 +187,14 @@ func (k *BlsKey) Save(password string) {
 	}
 
 	// write generated erc2335 keystore to file
-	if err := tempfile.WriteFileAtomic(k.filePath, jsonBytes, 0600); err != nil {
+	if err := tempfile.WriteFileAtomic(k.filePath, jsonBytes, 0400); err != nil {
 		panic(fmt.Errorf("failed to write BLS key: %w", err))
-	}
-
-	// set bls_key.json to read only
-	if err := os.Chmod(k.filePath, 0400); err != nil {
-		panic(fmt.Errorf("failed to set read-only permission for BLS key file: %w", err))
 	}
 
 	// write password to file
 	if k.passwordPath != "" {
-		if err := tempfile.WriteFileAtomic(k.passwordPath, []byte(password), 0600); err != nil {
+		if err := tempfile.WriteFileAtomic(k.passwordPath, []byte(password), 0400); err != nil {
 			panic(fmt.Errorf("failed to write BLS password: %w", err))
-		}
-
-		// set bls_password.txt to read only
-		if err := os.Chmod(k.passwordPath, 0400); err != nil {
-			panic(fmt.Errorf("failed to set read-only permission for BLS password file: %w", err))
 		}
 	}
 }
@@ -329,26 +329,15 @@ func LoadBlsSignerIfExists(homeDir string, noPassword bool, customPasswordPath, 
 		return nil, nil
 	}
 
-	// Try to load keystore first
-	keystore, err := erc2335.LoadKeyStore(blsKeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load BLS key file: %w", err)
-	}
-
 	// Try to get password from all sources
 	password, err := GetBlsKeyPassword(noPassword, customPasswordPath, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get password: %w", err)
 	}
 
-	privKey, err := erc2335.Decrypt(keystore, password)
+	blsPrivKey, err := loadBlsPrivKeyFromFile(blsKeyFile, password)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt BLS key: %w", err)
-	}
-
-	blsPrivKey := bls12381.PrivateKey(privKey)
-	if err := blsPrivKey.ValidateBasic(); err != nil {
-		return nil, fmt.Errorf("invalid BLS private key: %w", err)
+		return nil, fmt.Errorf("failed to load BLS key: %w", err)
 	}
 
 	return &BlsKey{
@@ -439,21 +428,9 @@ func ShowBlsKey(homeDir string, password string) (map[string]interface{}, error)
 		return nil, fmt.Errorf("BLS key file does not exist at %s", blsKeyFile)
 	}
 
-	// Load keystore first to check if we can open the file
-	keystore, err := erc2335.LoadKeyStore(blsKeyFile)
+	blsPrivKey, err := loadBlsPrivKeyFromFile(blsKeyFile, password)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load BLS key file: %w", err)
-	}
-
-	// Try to decrypt the key with the provided password
-	privKey, err := erc2335.Decrypt(keystore, password)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt BLS key (incorrect password): %w", err)
-	}
-
-	blsPrivKey := bls12381.PrivateKey(privKey)
-	if err := blsPrivKey.ValidateBasic(); err != nil {
-		return nil, fmt.Errorf("invalid BLS private key: %w", err)
+		return nil, fmt.Errorf("failed to load BLS key: %w", err)
 	}
 
 	blsPubKey := blsPrivKey.PubKey()
@@ -465,6 +442,17 @@ func ShowBlsKey(homeDir string, password string) (map[string]interface{}, error)
 	}
 
 	return result, nil
+}
+
+// LoadBlsPrivKey loads a BLS private key from a file.
+func LoadBlsPrivKey(homeDir, password string) (bls12381.PrivateKey, error) {
+	blsKeyFile := determineKeyFilePath(homeDir, "")
+
+	if !cmtos.FileExists(blsKeyFile) {
+		return nil, fmt.Errorf("BLS key file does not exist at %s", blsKeyFile)
+	}
+
+	return loadBlsPrivKeyFromFile(blsKeyFile, password)
 }
 
 // CreateBlsKey creates a new BLS key
@@ -500,7 +488,7 @@ func CreateBlsKey(homeDir string, password string, passwordFilePath string, cmd 
 			cmd.Printf("An empty password file has been created at for backward compatibility.\n")
 		}
 	} else {
-		cmd.Printf("\n ⚠️ IMPORTANT: Your BLS key has been created with password protection. ⚠️\n")
+		cmd.Printf("\n⚠️ IMPORTANT: Your BLS key has been created with password protection. ⚠️\n")
 		cmd.Printf("You can provide this password when starting the node using one of these methods:\n")
 		cmd.Printf("1. (Recommended) Set the %s environment variable: \nexport %s=<your_password>\n", BlsPasswordEnvVar, BlsPasswordEnvVar)
 
@@ -513,6 +501,68 @@ func CreateBlsKey(homeDir string, password string, passwordFilePath string, cmd 
 		}
 		cmd.Println("3. If you did not specify the password in one of the above methods interactive password prompt will be displayed.")
 		cmd.Printf("\nRemember to securely store your password. If you lose it, you won't be able to access your BLS key.\n")
+	}
+
+	return nil
+}
+
+// UpdateBlsPassword updates the password for a BLS key
+// Takes a password that was determined by the password determination logic.
+func UpdateBlsPassword(homeDir string, blsPrivKey bls12381.PrivateKey, password string, passwordFilePath string, cmd *cobra.Command) error {
+	blsKeyFile := determineKeyFilePath(homeDir, "")
+
+	// Check if BLS key already exists
+	if !cmtos.FileExists(blsKeyFile) {
+		return fmt.Errorf("BLS key does not exist at %s", blsKeyFile)
+	}
+
+	// Create backup of BLS key file before removing it
+	backupBlsKeyFile := blsKeyFile + ".bk"
+	if err := cmtos.CopyFile(blsKeyFile, backupBlsKeyFile); err != nil {
+		return fmt.Errorf("failed to create backup of BLS key file: %w", err)
+	}
+
+	// Remove BLS key file
+	if err := os.Remove(blsKeyFile); err != nil {
+		return fmt.Errorf("failed to remove BLS key file: %w", err)
+	}
+
+	// If a password file is specified, ensure its directory exists too
+	if passwordFilePath != "" {
+		if err := EnsureDirs(passwordFilePath); err != nil {
+			return fmt.Errorf("failed to ensure password file directory exists: %w", err)
+		}
+	}
+
+	// Generate key with provided password
+	bls := NewBls(blsPrivKey, blsKeyFile, passwordFilePath)
+	bls.Key.Save(password)
+
+	// Remove backup of BLS key file
+	if err := os.Remove(backupBlsKeyFile); err != nil {
+		return fmt.Errorf("failed to remove backup of BLS key file: %w", err)
+	}
+
+	// Print appropriate message based on password source
+	if password == "" {
+		cmd.Printf("The password for BLS key updated successfully without password protection.\n")
+		if passwordFilePath != "" {
+			cmd.Printf("An empty password file has been created at for backward compatibility.\n")
+		}
+	} else {
+		cmd.Printf("\n⚠️ IMPORTANT: The password for BLS key has been updated with password protection. ⚠️\n")
+		cmd.Printf("You can provide this password when starting the node using one of these methods:\n")
+		cmd.Printf("1. (Recommended) Set the %s environment variable: \nexport %s=<new_password>\n", BlsPasswordEnvVar, BlsPasswordEnvVar)
+
+		if passwordFilePath != "" {
+			cmd.Printf("2. The new password has been stored in the specified password file. You can use it when starting the node by providing the path to the password file\n")
+			cmd.Printf("babylond start --bls-password-file=<path_to_password_file>\n")
+		} else {
+			cmd.Printf("2. (Not recommended) Create a new password file and provide its path when starting the node by specifying the path to the new password file.\n")
+			cmd.Printf("babylond start --bls-password-file=<path_to_file>\n")
+		}
+		cmd.Println("3. If you did not specify the new password in one of the above methods interactive password prompt will be displayed.")
+		cmd.Printf("\nRemember to securely store your new password. If you lose it, you won't be able to access your BLS key.\n")
 	}
 
 	return nil

--- a/app/signer/util.go
+++ b/app/signer/util.go
@@ -32,8 +32,6 @@ func EnsureDirs(paths ...string) error {
 func NewBlsPassword() string {
 	inBuf := bufio.NewReader(os.Stdin)
 
-	fmt.Println("Enter a secure password for your BLS key (input will be hidden)")
-
 	const maxAttempts = 3
 	var attempt int
 
@@ -42,12 +40,12 @@ func NewBlsPassword() string {
 			fmt.Printf("\nPasswords didn't match. Attempt %d of %d\n", attempt+1, maxAttempts)
 		}
 
-		password, err := GetBlsPasswordInput("Enter your BLS password: ", inBuf)
+		password, err := GetBlsPasswordInput("Enter your BLS password (input will be hidden): ", inBuf)
 		if err != nil {
 			cmtos.Exit(fmt.Sprintf("failed to get BLS password: %v", err.Error()))
 		}
 
-		confirmPassword, err := GetBlsPasswordInput("Confirm your BLS password: ", inBuf)
+		confirmPassword, err := GetBlsPasswordInput("Confirm your BLS password (input will be hidden): ", inBuf)
 		if err != nil {
 			cmtos.Exit(fmt.Sprintf("failed to get BLS password confirmation: %v", err.Error()))
 		}
@@ -104,9 +102,7 @@ func readLineFromBuf(buf *bufio.Reader) (string, error) {
 func GetBlsUnlockPasswordFromPrompt() string {
 	inBuf := bufio.NewReader(os.Stdin)
 
-	fmt.Println("Enter your BLS key password (input will be hidden):")
-
-	password, err := GetBlsPasswordInput("Enter password: ", inBuf)
+	password, err := GetBlsPasswordInput("Enter your BLS key password (input will be hidden): ", inBuf)
 	if err != nil {
 		cmtos.Exit(fmt.Sprintf("failed to get BLS password: %v", err.Error()))
 	}

--- a/cmd/babylond/cmd/root.go
+++ b/cmd/babylond/cmd/root.go
@@ -213,6 +213,7 @@ func initRootCmd(rootCmd *cobra.Command, txConfig client.TxEncodingConfig, basic
 		genhelpers.CmdGenHelpers(gentxModule.GenTxValidator),
 		MigrateBlsKeyCmd(),
 		CreateBlsKeyCmd(),
+		UpdateBlsPasswordCmd(),
 		ShowBlsKeyCmd(),
 		VerifyValidatorBlsKey(),
 		GenerateBlsPopCmd(),

--- a/cmd/babylond/cmd/update_bls_password.go
+++ b/cmd/babylond/cmd/update_bls_password.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+
+	"github.com/babylonlabs-io/babylon/v2/app"
+	appsigner "github.com/babylonlabs-io/babylon/v2/app/signer"
+)
+
+func UpdateBlsPasswordCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-bls-password",
+		Short: "Update the password of BLS key",
+		Long: strings.TrimSpace(`update-bls-password will update the password of BLS key.
+
+Password precedence:
+1. Environment variable BABYLON_BLS_PASSWORD
+2. Password file specified with --bls-password-file flag
+3. Interactive prompt
+
+Example:
+$ babylond update-bls-password
+$ babylond update-bls-password --bls-password-file=/path/to/password.txt
+$ babylond update-bls-password --no-bls-password
+`,
+		),
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			homeDir, err := cmd.Flags().GetString(flags.FlagHome)
+			if err != nil {
+				return fmt.Errorf("failed to get home directory: %w", err)
+			}
+
+			cmd.Println("\n⚠️ IMPORTANT: Your BLS key file will be overwritten! ⚠️")
+			cmd.Println("1. (Recommended) Please make a backup of your BLS key before proceeding.")
+			cmd.Println("2. To update the password of BLS key, you need to provide the old password.")
+			cmd.Println("3. Due to security issues, older versions only accept passwords via environment variables or prompts.")
+			cmd.Println("4. If the previous BLS key has no password, enter a blank string value at the prompt.")
+			cmd.Println("5. If BLS password is used from environment variable, you should reset environment variable to the new password after updating.")
+
+			// Ask for confirmation before proceeding
+			fmt.Print("\nDo you want to continue with updating the BLS password? [y/n]: ")
+			var response string
+			_, err = fmt.Scanln(&response)
+			if err != nil {
+				// If there's an error reading input, default to 'n' for safety
+				return fmt.Errorf("failed to read user input: %w", err)
+			}
+			response = strings.ToLower(strings.TrimSpace(response))
+			if response != "y" && response != "yes" {
+				return fmt.Errorf("BLS password update cancelled by user")
+			}
+
+			// Get old password from either environment variable or prompt
+			oldPassword, err := appsigner.GetBlsKeyPassword(false, "", false)
+			if err != nil {
+				return fmt.Errorf("failed to get old BLS password: %w", err)
+			}
+
+			// Unset environment variable for old version of password
+			// to prevent it from being used in the next step
+			// User should reset environment variable to the new password after updating
+			if err := os.Unsetenv(appsigner.BlsPasswordEnvVar); err != nil {
+				return fmt.Errorf("failed to unset BLS password environment variable: %w", err)
+			}
+
+			blsPrivKey, err := appsigner.LoadBlsPrivKey(homeDir, oldPassword)
+			if err != nil {
+				return fmt.Errorf("failed to load BLS key: %w", err)
+			}
+
+			cmd.Println("\nUpdate the existing bls key with a new password.")
+
+			noBlsPassword, err := cmd.Flags().GetBool(flagNoBlsPassword)
+			if err != nil {
+				return fmt.Errorf("failed to get noBlsPassword flag: %w", err)
+			}
+			passwordFile, err := cmd.Flags().GetString(flagBlsPasswordFile)
+			if err != nil {
+				return fmt.Errorf("failed to get passwordFile flag: %w", err)
+			}
+
+			// Determine password at the system boundary
+			newPassword, err := appsigner.GetBlsKeyPassword(noBlsPassword, passwordFile, true)
+			if err != nil {
+				return fmt.Errorf("failed to determine new BLS password: %w", err)
+			}
+
+			// Generate BLS key using the refactored function with explicit password
+			return appsigner.UpdateBlsPassword(homeDir, blsPrivKey, newPassword, passwordFile, cmd)
+		},
+	}
+
+	cmd.Flags().String(flags.FlagHome, app.DefaultNodeHome, "The node home directory")
+	cmd.Flags().Bool(flagNoBlsPassword, false, "Generate BLS key without password protection")
+	cmd.Flags().String(flagBlsPasswordFile, "", "Custom file path to store the BLS password")
+	return cmd
+}


### PR DESCRIPTION
This PR includes the following changes:

## Update the password encryption of the BLS key

- The existing password must be provided either via an interactive prompt or through the environment variable. For the security issue, existing password cannot be obtained by file.
- If previous version of BLS key does not have a password, enter empty value into prompt.
- The new password is managed using the same set of flags that are used when initially generating a BLS key.
- Users are asked to process updating password of BLS since `bls_key.json` is overwritten with new password.
- The `BABYLON_BLS_PASSWORD` environment variable is used to load the existing password. After running `update-bls-password`, users should update this variable to reflect the new password.
- Since both `bls_key.json` and its associated password file are set to read-only in [#850](https://github.com/babylonlabs-io/babylon/pull/850), they are first removed and then recreated during the update process.
- A backup of `bls_key.json` is made during update-bls-password to protect against potential errors. After `update-bls-password` completes successfully, the backup of `bls_key.json` is removed.

```
$ babylond update-bls-password [flags]
```

Flags:
- `--no-bls-password`: Set the new password to an empty value (remove the password).
- `--bls-password-file`: Path to the file where the new password will be stored.