### PR TITLE
chore: Refactor the staking script documentation

### DIFF
--- a/docs/staking-script.md
+++ b/docs/staking-script.md
@@ -258,7 +258,7 @@ The staking output can be spent through one of the following three script paths:
 
 > **⚡ Key Difference Between the Unbonding and Slashing Paths**
 > 
-> The main difference lies in the presence of `<FinalityProviderPk` in
+> The main difference lies in the presence of `<FinalityProviderPk>` in
 > the slashing path which has the following implications:
 > * For a staking request to become active, the BTC staker must include
 >   a valid (unsigned) unbonding transaction in the staking request.


### PR DESCRIPTION
Introduced the following changes

* Structure Updates
   * Numbered sections
   * Table of contents
   * Described the transactions associated with staking before the diagram and added separate sections explaining the different outputs.
* Modernized the narrative
* Removed details about the properties of the BTC staking protocol. This is a document providing a technical specification of the staking script.
* Added details on the limitations of certain values in the script and referenced the register bitcoin stake doc.
* Added details on the withdrawal transaction
