### PR TITLE
chore: update `fpdistributioninfo` validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ check of rewards
 - [#1040](https://github.com/babylonlabs-io/babylon/pull/1040) Rename ETH L2 to rollup
 - [#1061](https://github.com/babylonlabs-io/babylon/pull/1061) Add size and hex decode in
 `RefundableMsgHashes` validate genesis
+- [#1071](https://github.com/babylonlabs-io/babylon/pull/1071) Update `FinalityProviderDistInfo` validations
 
 ### State Machine Breaking
 

--- a/x/finality/types/genesis_test.go
+++ b/x/finality/types/genesis_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	time "time"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	"github.com/babylonlabs-io/babylon/v4/testutil/datagen"
@@ -15,6 +16,22 @@ func TestGenesisState_Validate(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	gs, err := datagen.GenRandomFinalityGenesisState(r)
 	require.NoError(t, err)
+	// Skip validation of voting power distribution cache for testing
+	gs.VpDstCache = nil
+
+	// Create a valid finality provider for testing
+	btcPk, err := datagen.GenRandomBIP340PubKey(r)
+	require.NoError(t, err)
+	addr := datagen.GenRandomSecp256k1Address().String()
+	validComm = sdkmath.LegacyMustNewDecFromStr("0.5")
+	fpDistInfo := &types.FinalityProviderDistInfo{
+		BtcPk:          btcPk,
+		Addr:           []byte(addr),
+		TotalBondedSat: 100,
+		IsTimestamped:  true,
+		Commission:     &validComm,
+	}
+
 	tests := []struct {
 		desc     string
 		genState *types.GenesisState
@@ -113,8 +130,25 @@ func TestGenesisState_Validate(t *testing.T) {
 		{
 			desc: "duplicate vp dist cache",
 			genState: &types.GenesisState{
-				Params:     gs.Params,
-				VpDstCache: append(gs.VpDstCache, gs.VpDstCache[0]),
+				Params: gs.Params,
+				VpDstCache: []*types.VotingPowerDistCacheBlkHeight{
+					{
+						BlockHeight: 1,
+						VpDistribution: &types.VotingPowerDistCache{
+							TotalVotingPower:  100,
+							NumActiveFps:      1,
+							FinalityProviders: []*types.FinalityProviderDistInfo{fpDistInfo},
+						},
+					},
+					{
+						BlockHeight: 1,
+						VpDistribution: &types.VotingPowerDistCache{
+							TotalVotingPower:  100,
+							NumActiveFps:      1,
+							FinalityProviders: []*types.FinalityProviderDistInfo{fpDistInfo},
+						},
+					},
+				},
 			},
 			valid:  false,
 			errMsg: "duplicate entry",

--- a/x/finality/types/genesis_test.go
+++ b/x/finality/types/genesis_test.go
@@ -22,11 +22,10 @@ func TestGenesisState_Validate(t *testing.T) {
 	// Create a valid finality provider for testing
 	btcPk, err := datagen.GenRandomBIP340PubKey(r)
 	require.NoError(t, err)
-	addr := datagen.GenRandomSecp256k1Address().String()
 	validComm = sdkmath.LegacyMustNewDecFromStr("0.5")
 	fpDistInfo := &types.FinalityProviderDistInfo{
 		BtcPk:          btcPk,
-		Addr:           []byte(addr),
+		Addr:           fpAddr1,
 		TotalBondedSat: 100,
 		IsTimestamped:  true,
 		Commission:     &validComm,

--- a/x/finality/types/power_table.go
+++ b/x/finality/types/power_table.go
@@ -209,6 +209,15 @@ func (fpdi FinalityProviderDistInfo) Validate() error {
 	if fpdi.BtcPk.Size() != bbn.BIP340PubKeyLen {
 		return fmt.Errorf("invalid fp dist info. finality provider BTC public key length: got %d, want %d", fpdi.BtcPk.Size(), bbn.BIP340PubKeyLen)
 	}
+
+	if fpdi.Addr == nil {
+		return fmt.Errorf("invalid fp dist info. empty finality provider address")
+	}
+
+	if _, err := sdk.AccAddressFromBech32(string(fpdi.Addr)); err != nil {
+		return fmt.Errorf("invalid bech32 address: %w", err)
+	}
+
 	return nil
 }
 

--- a/x/finality/types/power_table.go
+++ b/x/finality/types/power_table.go
@@ -228,7 +228,7 @@ func (fpdi FinalityProviderDistInfo) Validate() error {
 		return fmt.Errorf("invalid fp dist info. empty finality provider address")
 	}
 
-	if _, err := sdk.AccAddressFromBech32(string(fpdi.Addr)); err != nil {
+	if _, err := sdk.AccAddressFromBech32(sdk.AccAddress(fpdi.Addr).String()); err != nil {
 		return fmt.Errorf("invalid bech32 address: %w", err)
 	}
 

--- a/x/finality/types/power_table.go
+++ b/x/finality/types/power_table.go
@@ -218,6 +218,17 @@ func (fpdi FinalityProviderDistInfo) Validate() error {
 		return fmt.Errorf("invalid bech32 address: %w", err)
 	}
 
+	if fpdi.Commission == nil {
+		return fmt.Errorf("invalid fp dist info. commission is nil")
+	}
+
+	if fpdi.Commission.LT(sdkmath.LegacyZeroDec()) {
+		return fmt.Errorf("invalid fp dist info. commission is negative")
+	}
+
+	if fpdi.Commission.GT(sdkmath.LegacyOneDec()) {
+		return fmt.Errorf("invalid fp dist info. commission is greater than 1")
+	}
 	return nil
 }
 

--- a/x/finality/types/power_table_test.go
+++ b/x/finality/types/power_table_test.go
@@ -23,6 +23,7 @@ var (
 	fpPubKey3     = bbn.NewBIP340PubKeyFromBTCPK(fpPrivKey3.PubKey())
 	fpAddr1       = datagen.GenRandomSecp256k1Address().String()
 	fpAddr2       = datagen.GenRandomSecp256k1Address().String()
+	fpAddr3       = datagen.GenRandomSecp256k1Address().String()
 	negComm       = sdkmath.LegacyNewDec(-1)
 	highComm      = sdkmath.LegacyNewDec(2)
 	validComm     = sdkmath.LegacyMustNewDecFromStr("0.5")
@@ -486,17 +487,23 @@ func TestVotingPowerDistCache_Validate(t *testing.T) {
 						BtcPk:          fpPubKey1,
 						TotalBondedSat: 100,
 						IsTimestamped:  true,
+						Addr:           []byte(fpAddr1),
+						Commission:     &validComm,
 					},
 					{
 						BtcPk:          fpPubKey2,
 						TotalBondedSat: 200,
 						IsTimestamped:  true,
+						Addr:           []byte(fpAddr2),
+						Commission:     &validComm,
 					},
 					{
 						BtcPk:          fpPubKey3,
 						TotalBondedSat: 100,
 						IsTimestamped:  true,
 						IsJailed:       true,
+						Addr:           []byte(fpAddr3),
+						Commission:     &validComm,
 					},
 				},
 				NumActiveFps:     2,

--- a/x/finality/types/power_table_test.go
+++ b/x/finality/types/power_table_test.go
@@ -20,7 +20,7 @@ var (
 	fpPrivKey3, _ = btcec.NewPrivateKey()
 	fpPubKey1     = bbn.NewBIP340PubKeyFromBTCPK(fpPrivKey1.PubKey())
 	fpPubKey2     = bbn.NewBIP340PubKeyFromBTCPK(fpPrivKey2.PubKey())
-  fpPubKey3     = bbn.NewBIP340PubKeyFromBTCPK(fpPrivKey3.PubKey())
+	fpPubKey3     = bbn.NewBIP340PubKeyFromBTCPK(fpPrivKey3.PubKey())
 	fpAddr1       = datagen.GenRandomSecp256k1Address().String()
 	fpAddr2       = datagen.GenRandomSecp256k1Address().String()
 	negComm       = sdkmath.LegacyNewDec(-1)
@@ -477,6 +477,8 @@ func TestVotingPowerDistCache_Validate(t *testing.T) {
 				},
 			},
 			expErrMsg: "invalid fp dist info. commission is greater than 1",
+		},
+		{
 			name: "one inactive case",
 			vpdc: types.VotingPowerDistCache{
 				FinalityProviders: []*types.FinalityProviderDistInfo{
@@ -518,7 +520,6 @@ func TestVotingPowerDistCache_Validate(t *testing.T) {
 						Addr:           []byte(fpAddr2),
 						Commission:     &validComm,
 						IsTimestamped:  true,
-
 					},
 				},
 				NumActiveFps:     2,

--- a/x/finality/types/power_table_test.go
+++ b/x/finality/types/power_table_test.go
@@ -18,6 +18,8 @@ var (
 	fpPrivKey2, _ = btcec.NewPrivateKey()
 	fpPubKey1     = bbn.NewBIP340PubKeyFromBTCPK(fpPrivKey1.PubKey())
 	fpPubKey2     = bbn.NewBIP340PubKeyFromBTCPK(fpPrivKey2.PubKey())
+	fpAddr1       = datagen.GenRandomAccount().GetAddress().String()
+	fpAddr2       = datagen.GenRandomAccount().GetAddress().String()
 )
 
 func TestVotingPowerDistCache(t *testing.T) {
@@ -373,6 +375,7 @@ func TestVotingPowerDistCache_Validate(t *testing.T) {
 					{
 						BtcPk:          fpPubKey1,
 						TotalBondedSat: 100,
+						Addr:           []byte(fpAddr1),
 					},
 				},
 				NumActiveFps:     2,
@@ -387,10 +390,12 @@ func TestVotingPowerDistCache_Validate(t *testing.T) {
 					{
 						BtcPk:          fpPubKey1,
 						TotalBondedSat: 100,
+						Addr:           []byte(fpAddr1),
 					},
 					{
 						BtcPk:          fpPubKey1,
 						TotalBondedSat: 200,
+						Addr:           []byte(fpAddr1),
 					},
 				},
 				NumActiveFps:     2,
@@ -405,6 +410,7 @@ func TestVotingPowerDistCache_Validate(t *testing.T) {
 					{
 						BtcPk:          &bbn.BIP340PubKey{},
 						TotalBondedSat: 100,
+						Addr:           []byte(fpAddr1),
 					},
 				},
 				NumActiveFps:     1,
@@ -419,10 +425,12 @@ func TestVotingPowerDistCache_Validate(t *testing.T) {
 					{
 						BtcPk:          fpPubKey1,
 						TotalBondedSat: 100,
+						Addr:           []byte(fpAddr1),
 					},
 					{
 						BtcPk:          fpPubKey2,
 						TotalBondedSat: 100,
+						Addr:           []byte(fpAddr2),
 					},
 				},
 				NumActiveFps:     2,
@@ -431,16 +439,27 @@ func TestVotingPowerDistCache_Validate(t *testing.T) {
 			expErrMsg: "invalid voting power distribution cache. Provided TotalVotingPower 150 is different than FPs accumulated voting power 200",
 		},
 		{
+			name: "no address",
+			vpdc: types.VotingPowerDistCache{
+				FinalityProviders: []*types.FinalityProviderDistInfo{
+					{BtcPk: fpPubKey1, TotalBondedSat: 100},
+				},
+			},
+			expErrMsg: "invalid fp dist info. empty finality provider address",
+		},
+		{
 			name: "valid case",
 			vpdc: types.VotingPowerDistCache{
 				FinalityProviders: []*types.FinalityProviderDistInfo{
 					{
 						BtcPk:          fpPubKey1,
 						TotalBondedSat: 100,
+						Addr:           []byte(fpAddr1),
 					},
 					{
 						BtcPk:          fpPubKey2,
 						TotalBondedSat: 200,
+						Addr:           []byte(fpAddr2),
 					},
 				},
 				NumActiveFps:     2,


### PR DESCRIPTION
Address needed to be validated if empty and if it is indeed a bech32 type