### PR TITLE
fix: enforce check tx even without check tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ check of rewards
 - [#1061](https://github.com/babylonlabs-io/babylon/pull/1061) Add size and hex decode in
 `RefundableMsgHashes` validate genesis
 - [#1070](https://github.com/babylonlabs-io/babylon/pull/1070) fix: validation for vp dist cache
+- [#1078](https://github.com/babylonlabs-io/babylon/pull/1078) fix: enforce check ibc msg size in `finalizeBlockState`
 
 ### State Machine Breaking
 

--- a/app/ante/ibc_msg_size.go
+++ b/app/ante/ibc_msg_size.go
@@ -24,20 +24,17 @@ func NewIBCMsgSizeDecorator() IBCMsgSizeDecorator {
 
 // AnteHandle checks that IBC messages size is within the accepted size
 func (IBCMsgSizeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	// Local mempool filter for improper ibc packets
-	if ctx.IsCheckTx() {
-		for _, msg := range tx.GetMsgs() {
-			var err error
-			switch msg := msg.(type) {
-			case *ibctransfertypes.MsgTransfer:
-				err = validateIBCMsgTransfer(msg)
-			// If one of the msgs is from ICA, limit it's size due to current spam potential.
-			case *icacontrollertypes.MsgSendTx:
-				err = validateICAMsgSendTx(msg)
-			}
-			if err != nil {
-				return ctx, err
-			}
+	for _, msg := range tx.GetMsgs() {
+		var err error
+		switch msg := msg.(type) {
+		case *ibctransfertypes.MsgTransfer:
+			err = validateIBCMsgTransfer(msg)
+		// If one of the msgs is from ICA, limit it's size due to current spam potential.
+		case *icacontrollertypes.MsgSendTx:
+			err = validateICAMsgSendTx(msg)
+		}
+		if err != nil {
+			return ctx, err
 		}
 	}
 	return next(ctx, tx, simulate)

--- a/app/ante/ibc_msg_size_test.go
+++ b/app/ante/ibc_msg_size_test.go
@@ -74,6 +74,17 @@ func TestIBCMsgSizeDecorator(t *testing.T) {
 			errMsg:    "memo is too large",
 		},
 		{
+			name: "MsgTransfer memo too long without check tx",
+			msgs: []sdk.Msg{
+				&ibctransfertypes.MsgTransfer{
+					Memo:     longMemo,
+					Receiver: validReceiver,
+				},
+			},
+			isCheckTx: false,
+			errMsg:    "memo is too large",
+		},
+		{
 			name: "MsgTransfer receiver address too long",
 			msgs: []sdk.Msg{
 				&ibctransfertypes.MsgTransfer{


### PR DESCRIPTION
3. Missing message size enforcement in DeliverTx enables
oversized IBC messages payload injection

In babylon:app/ante/ibc_msg_size.go:25-44, the AnteHandle function of the
IBCMsgSizeDecorator validates IBC message size constraints only during the CheckTx
phase.
This validation includes limits on message, memo, and address sizes for MsgTransfer and
MsgSendTx messages.
However, no equivalent enforcement occurs during the DeliverTx phase, which is
responsible for block execution.
As a result, malicious proposers can bypass mempool checks and inject oversized IBC or ICA
messages directly into blocks without the risk of being slashed.
This forces other validators to process potentially resource-exhausting payloads, introducing
a denial of service vector within the consensus mechanism.