### PR TITLE
docs: Create chain-semantics doc

### DIFF
--- a/docs/chain-semantics.md
+++ b/docs/chain-semantics.md
@@ -145,7 +145,7 @@ A finality provider _must_ submit a vote if:
 - Loses power → `INACTIVE`
 - Double-signs → `SLASHED` (permanently)
 
-## Checkpoint State Transitions
+### Checkpoint State Transitions
 
 Checkpoints progress through Bitcoin confirmation states as defined in:
 


### PR DESCRIPTION
There is a missing document that outlines semantics for the chain, this provides details on important processes, states and transitions