### PR TITLE
fix: validate genesis fp historic reward entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ check of rewards
 - [#1046](https://github.com/babylonlabs-io/babylon/pull/1046) Update genesis & validations `x/btcstaking` module
 - [#1050](https://github.com/babylonlabs-io/babylon/pull/1050) Add query to get btc delegations at specific block height
 - [#1040](https://github.com/babylonlabs-io/babylon/pull/1040) Rename ETH L2 to rollup
+- [#1061](https://github.com/babylonlabs-io/babylon/pull/1061) Add size and hex decode in
+`RefundableMsgHashes` validate genesis
 
 ### State Machine Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#1128](https://github.com/babylonlabs-io/babylon/pull/1128) Validate genesis fp historic reward entries.
 - [#1015](https://github.com/babylonlabs-io/babylon/pull/1015) Add finality contract e2e tests follup-up.
 - [#970](https://github.com/babylonlabs-io/babylon/pull/970) Add finality contract e2e tests follup-up.
 - [#946](https://github.com/babylonlabs-io/babylon/pull/946) Add finality contract e2e tests follup-up.

--- a/x/incentive/keeper/genesis_test.go
+++ b/x/incentive/keeper/genesis_test.go
@@ -344,11 +344,11 @@ func setupTest(t *testing.T, seed int64) (sdk.Context, *keeper.Keeper, *storetyp
 		wa         = make([]types.WithdrawAddressEntry, l)
 		mh         = make([]string, l)
 		fpCurrRwd  = make([]types.FinalityProviderCurrentRewardsEntry, l)
-		fpHistRwd  = make([]types.FinalityProviderHistoricalRewardsEntry, l)
 		bdrt       = make([]types.BTCDelegationRewardsTrackerEntry, l)
 		d2fp       = make([]types.BTCDelegatorToFpEntry, l)
 		eventsRwd  = make([]types.EventsPowerUpdateAtHeightEntry, l)
 		currHeight = datagen.RandomInt(r, 100000) + 100
+		fpHistRwd  []types.FinalityProviderHistoricalRewardsEntry
 	)
 	defer ctrl.Finish()
 	ctx = ctx.WithBlockHeight(int64(currHeight))

--- a/x/incentive/keeper/genesis_test.go
+++ b/x/incentive/keeper/genesis_test.go
@@ -261,19 +261,6 @@ func FuzzTestExportGenesis(f *testing.F) {
 			require.NoError(t, err)
 			require.NoError(t, store.Set(fpCurrRwdKeyBz, currRwdBz))
 
-			// FP historical rewards
-			fphrKey := collections.Join(
-				sdk.MustAccAddressFromBech32(gs.FinalityProvidersHistoricalRewards[i].Address).Bytes(),
-				gs.FinalityProvidersHistoricalRewards[i].Period,
-			)
-
-			fphrKeyBz, err := collections.EncodeKeyWithPrefix(types.FinalityProviderHistoricalRewardsKeyPrefix.Bytes(), collections.PairKeyCodec(collections.BytesKey, collections.Uint64Key), fphrKey)
-			require.NoError(t, err)
-
-			histRwdBz, err := codec.CollValue[types.FinalityProviderHistoricalRewards](encConfig.Codec).Encode(*gs.FinalityProvidersHistoricalRewards[i].Rewards)
-			require.NoError(t, err)
-			require.NoError(t, store.Set(fphrKeyBz, histRwdBz))
-
 			// BTCDelegationRewardsTracker
 			bdrtKey := collections.Join(
 				sdk.MustAccAddressFromBech32(gs.BtcDelegationRewardsTrackers[i].FinalityProviderAddress).Bytes(),
@@ -295,6 +282,20 @@ func FuzzTestExportGenesis(f *testing.F) {
 			delStore.Set(fpAcc.Bytes(), []byte{0x00})
 
 			require.NoError(t, k.SetRewardTrackerEvent(ctx, gs.EventRewardTracker[i].Height, gs.EventRewardTracker[i].Events))
+		}
+
+		for _, fpHistRwd := range gs.FinalityProvidersHistoricalRewards {
+			fphrKey := collections.Join(
+				sdk.MustAccAddressFromBech32(fpHistRwd.Address).Bytes(),
+				fpHistRwd.Period,
+			)
+
+			fphrKeyBz, err := collections.EncodeKeyWithPrefix(types.FinalityProviderHistoricalRewardsKeyPrefix.Bytes(), collections.PairKeyCodec(collections.BytesKey, collections.Uint64Key), fphrKey)
+			require.NoError(t, err)
+
+			histRwdBz, err := codec.CollValue[types.FinalityProviderHistoricalRewards](encConfig.Codec).Encode(*fpHistRwd.Rewards)
+			require.NoError(t, err)
+			require.NoError(t, store.Set(fphrKeyBz, histRwdBz))
 		}
 
 		require.NoError(t, k.SetRewardTrackerEventLastProcessedHeight(ctx, gs.LastProcessedHeightEventRewardTracker))
@@ -354,17 +355,32 @@ func setupTest(t *testing.T, seed int64) (sdk.Context, *keeper.Keeper, *storetyp
 
 	// make sure that BTC staking gauge are unique per height
 	usedHeights := make(map[uint64]bool)
+
+	// Pre-generate all current periods to ensure consistency
+	currentPeriods := make([]uint64, l)
+	totalHistoricalRewards := 0
+	for i := 0; i < l; i++ {
+		currentPeriods[i] = uint64(r.Intn(4)) + 1
+		totalHistoricalRewards += int(currentPeriods[i])
+	}
+
+	fpHistRwd = make([]types.FinalityProviderHistoricalRewardsEntry, totalHistoricalRewards)
+
+	histIdx := 0
 	for i := 0; i < l; i++ {
 		blkHeight := getUniqueHeight(currHeight, usedHeights)
+		acc1 := datagen.GenRandomAccount()
+		acc2 := datagen.GenRandomAccount()
+		currentPeriod := currentPeriods[i]
+
+		// mock account keeper to return an account on GetAccount calls
+		ak.EXPECT().GetAccount(gomock.Any(), acc1.GetAddress()).Return(acc1).AnyTimes()
+		ak.EXPECT().GetAccount(gomock.Any(), acc2.GetAddress()).Return(acc2).AnyTimes()
+
 		bsg[i] = types.BTCStakingGaugeEntry{
 			Height: blkHeight,
 			Gauge:  datagen.GenRandomGauge(r),
 		}
-		acc1 := datagen.GenRandomAccount()
-		acc2 := datagen.GenRandomAccount()
-		// mock account keeper to return an account on GetAccount calls
-		ak.EXPECT().GetAccount(gomock.Any(), acc1.GetAddress()).Return(acc1).AnyTimes()
-		ak.EXPECT().GetAccount(gomock.Any(), acc2.GetAddress()).Return(acc2).AnyTimes()
 
 		rg[i] = types.RewardGaugeEntry{
 			StakeholderType: datagen.GenRandomStakeholderType(r),
@@ -376,26 +392,38 @@ func setupTest(t *testing.T, seed int64) (sdk.Context, *keeper.Keeper, *storetyp
 			WithdrawAddress:  datagen.GenRandomAccount().Address,
 		}
 		mh[i] = genRandomMsgHashStr()
+
 		fpCurrRwd[i] = types.FinalityProviderCurrentRewardsEntry{
 			Address: acc1.Address,
 			Rewards: func() *types.FinalityProviderCurrentRewards {
 				val := datagen.GenRandomFinalityProviderCurrentRewards(r)
+				val.Period = currentPeriod
 				return &val
 			}(),
 		}
-		fpHistRwd[i] = types.FinalityProviderHistoricalRewardsEntry{
-			Address: acc1.Address,
-			Period:  getUniqueHeight(currHeight, usedHeights),
-			Rewards: func() *types.FinalityProviderHistoricalRewards {
-				val := datagen.GenRandomFPHistRwd(r)
-				return &val
-			}(),
+
+		for period := uint64(0); period < currentPeriod; period++ {
+			fpHistRwd[histIdx] = types.FinalityProviderHistoricalRewardsEntry{
+				Address: acc1.Address,
+				Period:  period,
+				Rewards: func() *types.FinalityProviderHistoricalRewards {
+					val := datagen.GenRandomFPHistRwd(r)
+					return &val
+				}(),
+			}
+			histIdx++
 		}
+
 		bdrt[i] = types.BTCDelegationRewardsTrackerEntry{
 			FinalityProviderAddress: acc1.Address,
 			DelegatorAddress:        acc2.Address,
 			Tracker: func() *types.BTCDelegationRewardsTracker {
 				val := datagen.GenRandomBTCDelegationRewardsTracker(r)
+				if currentPeriod > 0 {
+					val.StartPeriodCumulativeReward = uint64(r.Intn(int(currentPeriod)))
+				} else {
+					val.StartPeriodCumulativeReward = 0
+				}
 				return &val
 			}(),
 		}

--- a/x/incentive/types/genesis.go
+++ b/x/incentive/types/genesis.go
@@ -52,7 +52,13 @@ func (gs GenesisState) Validate() error {
 		return fmt.Errorf("invalid finality providers current rewards: %w", err)
 	}
 
-	if err := validateFPHistoricalRewards(gs.FinalityProvidersHistoricalRewards); err != nil {
+	// Create a map of FP addresses to their current periods for validation
+	fpCurrentPeriods := make(map[string]uint64)
+	for _, fpcr := range gs.FinalityProvidersCurrentRewards {
+		fpCurrentPeriods[fpcr.Address] = fpcr.Rewards.Period
+	}
+
+	if err := validateFPHistoricalRewards(gs.FinalityProvidersHistoricalRewards, fpCurrentPeriods); err != nil {
 		return fmt.Errorf("invalid finality providers historical rewards: %w", err)
 	}
 
@@ -60,7 +66,7 @@ func (gs GenesisState) Validate() error {
 		return fmt.Errorf("invalid events from reward tracker: %w", err)
 	}
 
-	btcRewardsAddrMap, err := validateBTCDelegationsRewardsTrackers(gs.BtcDelegationRewardsTrackers)
+	btcRewardsAddrMap, err := validateBTCDelegationsRewardsTrackers(gs.BtcDelegationRewardsTrackers, fpCurrentPeriods)
 	if err != nil {
 		return fmt.Errorf("invalid BTC delegations rewards trackers: %w", err)
 	}
@@ -251,7 +257,7 @@ func validateFPCurrentRewards(entries []FinalityProviderCurrentRewardsEntry) err
 	})
 }
 
-func validateFPHistoricalRewards(entries []FinalityProviderHistoricalRewardsEntry) error {
+func validateFPHistoricalRewards(entries []FinalityProviderHistoricalRewardsEntry, fpCurrentPeriods map[string]uint64) error {
 	addressPeriodMap := make(map[string]map[uint64]bool) // Map of FpAddr -> map of period
 
 	for _, entry := range entries {
@@ -269,10 +275,41 @@ func validateFPHistoricalRewards(entries []FinalityProviderHistoricalRewardsEntr
 			return err
 		}
 	}
+
+	// Validate that each FP with current rewards has all historical periods from 0 to currentPeriod-1
+	for fpAddr, currentPeriod := range fpCurrentPeriods {
+		if currentPeriod > 0 {
+			periods, exists := addressPeriodMap[fpAddr]
+			if !exists {
+				return fmt.Errorf("finality provider %s has current rewards with period %d but no historical rewards", fpAddr, currentPeriod)
+			}
+
+			// Check for all periods from 0 to currentPeriod-1
+			for period := uint64(0); period < currentPeriod; period++ {
+				if !periods[period] {
+					return fmt.Errorf("finality provider %s is missing historical rewards for period %d (current period is %d)", fpAddr, period, currentPeriod)
+				}
+			}
+		}
+	}
+
+	// Check that no FP has historical rewards beyond their current period
+	for fpAddr, periods := range addressPeriodMap {
+		currentPeriod, exists := fpCurrentPeriods[fpAddr]
+		if !exists {
+			return fmt.Errorf("finality provider %s has historical rewards but no current rewards", fpAddr)
+		}
+
+		for period := range periods {
+			if period >= currentPeriod {
+				return fmt.Errorf("finality provider %s has historical rewards for period %d which is >= current period %d", fpAddr, period, currentPeriod)
+			}
+		}
+	}
 	return nil
 }
 
-func validateBTCDelegationsRewardsTrackers(entries []BTCDelegationRewardsTrackerEntry) (map[string]map[string]bool, error) {
+func validateBTCDelegationsRewardsTrackers(entries []BTCDelegationRewardsTrackerEntry, fpCurrentPeriods map[string]uint64) (map[string]map[string]bool, error) {
 	addressAddressMap := make(map[string]map[string]bool) // Map of FpAddr -> map of delAddr
 
 	for _, entry := range entries {
@@ -288,6 +325,17 @@ func validateBTCDelegationsRewardsTrackers(entries []BTCDelegationRewardsTracker
 
 		if err := entry.Validate(); err != nil {
 			return nil, err
+		}
+
+		// Validate that the tracker's StartPeriodCumulativeReward is less than the FP's current period
+		currentPeriod, exists := fpCurrentPeriods[entry.FinalityProviderAddress]
+		if !exists {
+			return nil, fmt.Errorf("delegation tracker for finality provider %s exists but FP has no current rewards", entry.FinalityProviderAddress)
+		}
+
+		if entry.Tracker.StartPeriodCumulativeReward >= currentPeriod {
+			return nil, fmt.Errorf("delegation tracker for FP %s and delegator %s has StartPeriodCumulativeReward %d >= FP's current period %d",
+				entry.FinalityProviderAddress, entry.DelegatorAddress, entry.Tracker.StartPeriodCumulativeReward, currentPeriod)
 		}
 	}
 	return addressAddressMap, nil

--- a/x/incentive/types/genesis.go
+++ b/x/incentive/types/genesis.go
@@ -1,12 +1,14 @@
 package types
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"reflect"
 	"sort"
 
 	"github.com/babylonlabs-io/babylon/v4/types"
+	"github.com/cometbft/cometbft/crypto/tmhash"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -227,6 +229,13 @@ func validateMsgHashes(hashes []string) error {
 	for _, hash := range hashes {
 		if hash == "" {
 			return errors.New("empty hash")
+		}
+		bz, err := hex.DecodeString(hash)
+		if err != nil {
+			return fmt.Errorf("error decoding msg hash: %w", err)
+		}
+		if len(bz) != tmhash.Size {
+			return fmt.Errorf("hash size should be %d characters: %s", tmhash.Size, hash)
 		}
 		if _, exists := hashMap[hash]; exists {
 			return fmt.Errorf("duplicate hash: %s", hash)

--- a/x/incentive/types/genesis_test.go
+++ b/x/incentive/types/genesis_test.go
@@ -250,7 +250,7 @@ func TestGenesisState_Validate(t *testing.T) {
 						Address: addrStr1,
 						Rewards: func() *types.FinalityProviderCurrentRewards {
 							r := datagen.GenRandomFinalityProviderCurrentRewards(r)
-							r.Period = 3 // Current period is 3, so historical periods 1 and 2 are valid
+							r.Period = 3
 							return &r
 						}(),
 					},

--- a/x/incentive/types/genesis_test.go
+++ b/x/incentive/types/genesis_test.go
@@ -240,13 +240,30 @@ func TestGenesisState_Validate(t *testing.T) {
 		{
 			desc: "Genesis with 2 historical rewards for same finality provider and different period",
 			genState: &types.GenesisState{
-				Params:                          types.DefaultParams(),
-				BtcStakingGauges:                []types.BTCStakingGaugeEntry{},
-				RewardGauges:                    []types.RewardGaugeEntry{},
-				WithdrawAddresses:               []types.WithdrawAddressEntry{},
-				RefundableMsgHashes:             []string{},
-				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{},
+				Params:              types.DefaultParams(),
+				BtcStakingGauges:    []types.BTCStakingGaugeEntry{},
+				RewardGauges:        []types.RewardGaugeEntry{},
+				WithdrawAddresses:   []types.WithdrawAddressEntry{},
+				RefundableMsgHashes: []string{},
+				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{
+					{
+						Address: addrStr1,
+						Rewards: func() *types.FinalityProviderCurrentRewards {
+							r := datagen.GenRandomFinalityProviderCurrentRewards(r)
+							r.Period = 3 // Current period is 3, so historical periods 1 and 2 are valid
+							return &r
+						}(),
+					},
+				},
 				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{
+					{
+						Address: addrStr1,
+						Period:  0,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
 					{
 						Address: addrStr1,
 						Period:  1,
@@ -306,46 +323,104 @@ func TestGenesisState_Validate(t *testing.T) {
 		},
 		{
 			desc: "Genesis with valid BTC delegation rewards tracker but no delegator to fps data",
-			genState: &types.GenesisState{
-				Params:                             types.DefaultParams(),
-				BtcStakingGauges:                   []types.BTCStakingGaugeEntry{},
-				RewardGauges:                       []types.RewardGaugeEntry{},
-				WithdrawAddresses:                  []types.WithdrawAddressEntry{},
-				RefundableMsgHashes:                []string{},
-				FinalityProvidersCurrentRewards:    []types.FinalityProviderCurrentRewardsEntry{},
-				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{},
-				BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{
-					{
-						FinalityProviderAddress: datagen.GenRandomAccount().Address,
-						DelegatorAddress:        datagen.GenRandomAccount().Address,
-						Tracker: func() *types.BTCDelegationRewardsTracker {
-							v := datagen.GenRandomBTCDelegationRewardsTracker(r)
-							return &v
-						}(),
+			genState: func() *types.GenesisState {
+				fpAddr := datagen.GenRandomAccount().Address
+				delAddr := datagen.GenRandomAccount().Address
+				return &types.GenesisState{
+					Params:              types.DefaultParams(),
+					BtcStakingGauges:    []types.BTCStakingGaugeEntry{},
+					RewardGauges:        []types.RewardGaugeEntry{},
+					WithdrawAddresses:   []types.WithdrawAddressEntry{},
+					RefundableMsgHashes: []string{},
+					FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{
+						{
+							Address: fpAddr,
+							Rewards: func() *types.FinalityProviderCurrentRewards {
+								r := datagen.GenRandomFinalityProviderCurrentRewards(r)
+								r.Period = 2
+								return &r
+							}(),
+						},
 					},
-				},
-				BtcDelegatorsToFps: []types.BTCDelegatorToFpEntry{},
-				EventRewardTracker: []types.EventsPowerUpdateAtHeightEntry{},
-			},
+					FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{
+						{
+							Address: fpAddr,
+							Period:  0,
+							Rewards: func() *types.FinalityProviderHistoricalRewards {
+								v := datagen.GenRandomFPHistRwdWithDecimals(r)
+								return &v
+							}(),
+						},
+						{
+							Address: fpAddr,
+							Period:  1,
+							Rewards: func() *types.FinalityProviderHistoricalRewards {
+								v := datagen.GenRandomFPHistRwdWithDecimals(r)
+								return &v
+							}(),
+						},
+					},
+					BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{
+						{
+							FinalityProviderAddress: fpAddr,
+							DelegatorAddress:        delAddr,
+							Tracker: func() *types.BTCDelegationRewardsTracker {
+								v := datagen.GenRandomBTCDelegationRewardsTracker(r)
+								v.StartPeriodCumulativeReward = 0
+								return &v
+							}(),
+						},
+					},
+					BtcDelegatorsToFps: []types.BTCDelegatorToFpEntry{},
+					EventRewardTracker: []types.EventsPowerUpdateAtHeightEntry{},
+				}
+			}(),
 			valid:  false,
 			errMsg: "BTC delegators to finality providers map is not equal to the btc delegations data",
 		},
 		{
 			desc: "Genesis with duplicated BTC delegation rewards tracker",
 			genState: &types.GenesisState{
-				Params:                             types.DefaultParams(),
-				BtcStakingGauges:                   []types.BTCStakingGaugeEntry{},
-				RewardGauges:                       []types.RewardGaugeEntry{},
-				WithdrawAddresses:                  []types.WithdrawAddressEntry{},
-				RefundableMsgHashes:                []string{},
-				FinalityProvidersCurrentRewards:    []types.FinalityProviderCurrentRewardsEntry{},
-				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{},
+				Params:              types.DefaultParams(),
+				BtcStakingGauges:    []types.BTCStakingGaugeEntry{},
+				RewardGauges:        []types.RewardGaugeEntry{},
+				WithdrawAddresses:   []types.WithdrawAddressEntry{},
+				RefundableMsgHashes: []string{},
+				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{
+					{
+						Address: addrStr1,
+						Rewards: func() *types.FinalityProviderCurrentRewards {
+							r := datagen.GenRandomFinalityProviderCurrentRewards(r)
+							r.Period = 2
+							return &r
+						}(),
+					},
+				},
+				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{
+					{
+						Address: addrStr1,
+						Period:  0,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+					{
+						Address: addrStr1,
+						Period:  1,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+				},
 				BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{
 					{
 						FinalityProviderAddress: addrStr1,
 						DelegatorAddress:        addrStr2,
 						Tracker: func() *types.BTCDelegationRewardsTracker {
 							v := datagen.GenRandomBTCDelegationRewardsTracker(r)
+							v.StartPeriodCumulativeReward = 0
 							return &v
 						}(),
 					},
@@ -354,6 +429,7 @@ func TestGenesisState_Validate(t *testing.T) {
 						DelegatorAddress:        addrStr2,
 						Tracker: func() *types.BTCDelegationRewardsTracker {
 							v := datagen.GenRandomBTCDelegationRewardsTracker(r)
+							v.StartPeriodCumulativeReward = 0
 							return &v
 						}(),
 					},
@@ -370,19 +446,46 @@ func TestGenesisState_Validate(t *testing.T) {
 		{
 			desc: "Genesis with duplicated BTC delegator to fp entry",
 			genState: &types.GenesisState{
-				Params:                             types.DefaultParams(),
-				BtcStakingGauges:                   []types.BTCStakingGaugeEntry{},
-				RewardGauges:                       []types.RewardGaugeEntry{},
-				WithdrawAddresses:                  []types.WithdrawAddressEntry{},
-				RefundableMsgHashes:                []string{},
-				FinalityProvidersCurrentRewards:    []types.FinalityProviderCurrentRewardsEntry{},
-				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{},
+				Params:              types.DefaultParams(),
+				BtcStakingGauges:    []types.BTCStakingGaugeEntry{},
+				RewardGauges:        []types.RewardGaugeEntry{},
+				WithdrawAddresses:   []types.WithdrawAddressEntry{},
+				RefundableMsgHashes: []string{},
+				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{
+					{
+						Address: addrStr1,
+						Rewards: func() *types.FinalityProviderCurrentRewards {
+							r := datagen.GenRandomFinalityProviderCurrentRewards(r)
+							r.Period = 2
+							return &r
+						}(),
+					},
+				},
+				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{
+					{
+						Address: addrStr1,
+						Period:  0,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+					{
+						Address: addrStr1,
+						Period:  1,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+				},
 				BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{
 					{
 						FinalityProviderAddress: addrStr1,
 						DelegatorAddress:        addrStr2,
 						Tracker: func() *types.BTCDelegationRewardsTracker {
 							v := datagen.GenRandomBTCDelegationRewardsTracker(r)
+							v.StartPeriodCumulativeReward = 0
 							return &v
 						}(),
 					},
@@ -459,6 +562,351 @@ func TestGenesisState_Validate(t *testing.T) {
 						},
 					},
 				},
+			},
+			valid: true,
+		},
+		{
+			desc: "Genesis with FP current rewards but missing historical rewards",
+			genState: &types.GenesisState{
+				Params:              types.DefaultParams(),
+				BtcStakingGauges:    []types.BTCStakingGaugeEntry{},
+				RewardGauges:        []types.RewardGaugeEntry{},
+				WithdrawAddresses:   []types.WithdrawAddressEntry{},
+				RefundableMsgHashes: []string{},
+				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{
+					{
+						Address: addrStr1,
+						Rewards: func() *types.FinalityProviderCurrentRewards {
+							r := datagen.GenRandomFinalityProviderCurrentRewards(r)
+							r.Period = 3
+							return &r
+						}(),
+					},
+				},
+				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{},
+				BtcDelegationRewardsTrackers:       []types.BTCDelegationRewardsTrackerEntry{},
+				BtcDelegatorsToFps:                 []types.BTCDelegatorToFpEntry{},
+				EventRewardTracker:                 []types.EventsPowerUpdateAtHeightEntry{},
+			},
+			valid:  false,
+			errMsg: fmt.Sprintf("finality provider %s has current rewards with period 3 but no historical rewards", addrStr1),
+		},
+		{
+			desc: "Genesis with FP missing some historical reward periods",
+			genState: &types.GenesisState{
+				Params:              types.DefaultParams(),
+				BtcStakingGauges:    []types.BTCStakingGaugeEntry{},
+				RewardGauges:        []types.RewardGaugeEntry{},
+				WithdrawAddresses:   []types.WithdrawAddressEntry{},
+				RefundableMsgHashes: []string{},
+				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{
+					{
+						Address: addrStr1,
+						Rewards: func() *types.FinalityProviderCurrentRewards {
+							r := datagen.GenRandomFinalityProviderCurrentRewards(r)
+							r.Period = 3
+							return &r
+						}(),
+					},
+				},
+				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{
+					{
+						Address: addrStr1,
+						Period:  0,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+					{
+						Address: addrStr1,
+						Period:  2,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+				},
+				BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{},
+				BtcDelegatorsToFps:           []types.BTCDelegatorToFpEntry{},
+				EventRewardTracker:           []types.EventsPowerUpdateAtHeightEntry{},
+			},
+			valid:  false,
+			errMsg: fmt.Sprintf("finality provider %s is missing historical rewards for period 1 (current period is 3)", addrStr1),
+		},
+		{
+			desc: "Genesis with FP historical rewards beyond current period",
+			genState: &types.GenesisState{
+				Params:              types.DefaultParams(),
+				BtcStakingGauges:    []types.BTCStakingGaugeEntry{},
+				RewardGauges:        []types.RewardGaugeEntry{},
+				WithdrawAddresses:   []types.WithdrawAddressEntry{},
+				RefundableMsgHashes: []string{},
+				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{
+					{
+						Address: addrStr1,
+						Rewards: func() *types.FinalityProviderCurrentRewards {
+							r := datagen.GenRandomFinalityProviderCurrentRewards(r)
+							r.Period = 2
+							return &r
+						}(),
+					},
+				},
+				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{
+					{
+						Address: addrStr1,
+						Period:  0,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+					{
+						Address: addrStr1,
+						Period:  1,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+					{
+						Address: addrStr1,
+						Period:  3,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+				},
+				BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{},
+				BtcDelegatorsToFps:           []types.BTCDelegatorToFpEntry{},
+				EventRewardTracker:           []types.EventsPowerUpdateAtHeightEntry{},
+			},
+			valid:  false,
+			errMsg: fmt.Sprintf("finality provider %s has historical rewards for period 3 which is >= current period 2", addrStr1),
+		},
+		{
+			desc: "Genesis with FP historical rewards but no current rewards",
+			genState: &types.GenesisState{
+				Params:                          types.DefaultParams(),
+				BtcStakingGauges:                []types.BTCStakingGaugeEntry{},
+				RewardGauges:                    []types.RewardGaugeEntry{},
+				WithdrawAddresses:               []types.WithdrawAddressEntry{},
+				RefundableMsgHashes:             []string{},
+				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{},
+				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{
+					{
+						Address: addrStr1,
+						Period:  0,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+				},
+				BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{},
+				BtcDelegatorsToFps:           []types.BTCDelegatorToFpEntry{},
+				EventRewardTracker:           []types.EventsPowerUpdateAtHeightEntry{},
+			},
+			valid:  false,
+			errMsg: fmt.Sprintf("finality provider %s has historical rewards but no current rewards", addrStr1),
+		},
+		{
+			desc: "Genesis with complete and valid FP rewards",
+			genState: &types.GenesisState{
+				Params:              types.DefaultParams(),
+				BtcStakingGauges:    []types.BTCStakingGaugeEntry{},
+				RewardGauges:        []types.RewardGaugeEntry{},
+				WithdrawAddresses:   []types.WithdrawAddressEntry{},
+				RefundableMsgHashes: []string{},
+				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{
+					{
+						Address: addrStr1,
+						Rewards: func() *types.FinalityProviderCurrentRewards {
+							r := datagen.GenRandomFinalityProviderCurrentRewards(r)
+							r.Period = 3
+							return &r
+						}(),
+					},
+				},
+				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{
+					{
+						Address: addrStr1,
+						Period:  0,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+					{
+						Address: addrStr1,
+						Period:  1,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+					{
+						Address: addrStr1,
+						Period:  2,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+				},
+				BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{},
+				BtcDelegatorsToFps:           []types.BTCDelegatorToFpEntry{},
+				EventRewardTracker:           []types.EventsPowerUpdateAtHeightEntry{},
+			},
+			valid: true,
+		},
+		{
+			desc: "Genesis with delegation tracker for FP without current rewards",
+			genState: &types.GenesisState{
+				Params:                             types.DefaultParams(),
+				BtcStakingGauges:                   []types.BTCStakingGaugeEntry{},
+				RewardGauges:                       []types.RewardGaugeEntry{},
+				WithdrawAddresses:                  []types.WithdrawAddressEntry{},
+				RefundableMsgHashes:                []string{},
+				FinalityProvidersCurrentRewards:    []types.FinalityProviderCurrentRewardsEntry{},
+				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{},
+				BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{
+					{
+						FinalityProviderAddress: addrStr1,
+						DelegatorAddress:        addrStr2,
+						Tracker: func() *types.BTCDelegationRewardsTracker {
+							v := datagen.GenRandomBTCDelegationRewardsTracker(r)
+							v.StartPeriodCumulativeReward = 1
+							return &v
+						}(),
+					},
+				},
+				BtcDelegatorsToFps: []types.BTCDelegatorToFpEntry{{
+					FinalityProviderAddress: addrStr1,
+					DelegatorAddress:        addrStr2,
+				}},
+				EventRewardTracker: []types.EventsPowerUpdateAtHeightEntry{},
+			},
+			valid:  false,
+			errMsg: fmt.Sprintf("delegation tracker for finality provider %s exists but FP has no current rewards", addrStr1),
+		},
+		{
+			desc: "Genesis with delegation tracker StartPeriodCumulativeReward >= FP current period",
+			genState: &types.GenesisState{
+				Params:              types.DefaultParams(),
+				BtcStakingGauges:    []types.BTCStakingGaugeEntry{},
+				RewardGauges:        []types.RewardGaugeEntry{},
+				WithdrawAddresses:   []types.WithdrawAddressEntry{},
+				RefundableMsgHashes: []string{},
+				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{
+					{
+						Address: addrStr1,
+						Rewards: func() *types.FinalityProviderCurrentRewards {
+							r := datagen.GenRandomFinalityProviderCurrentRewards(r)
+							r.Period = 2
+							return &r
+						}(),
+					},
+				},
+				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{
+					{
+						Address: addrStr1,
+						Period:  0,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+					{
+						Address: addrStr1,
+						Period:  1,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+				},
+				BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{
+					{
+						FinalityProviderAddress: addrStr1,
+						DelegatorAddress:        addrStr2,
+						Tracker: func() *types.BTCDelegationRewardsTracker {
+							v := datagen.GenRandomBTCDelegationRewardsTracker(r)
+							v.StartPeriodCumulativeReward = 2
+							return &v
+						}(),
+					},
+				},
+				BtcDelegatorsToFps: []types.BTCDelegatorToFpEntry{{
+					FinalityProviderAddress: addrStr1,
+					DelegatorAddress:        addrStr2,
+				}},
+				EventRewardTracker: []types.EventsPowerUpdateAtHeightEntry{},
+			},
+			valid:  false,
+			errMsg: fmt.Sprintf("delegation tracker for FP %s and delegator %s has StartPeriodCumulativeReward 2 >= FP's current period 2", addrStr1, addrStr2),
+		},
+		{
+			desc: "Genesis with valid delegation tracker",
+			genState: &types.GenesisState{
+				Params:              types.DefaultParams(),
+				BtcStakingGauges:    []types.BTCStakingGaugeEntry{},
+				RewardGauges:        []types.RewardGaugeEntry{},
+				WithdrawAddresses:   []types.WithdrawAddressEntry{},
+				RefundableMsgHashes: []string{},
+				FinalityProvidersCurrentRewards: []types.FinalityProviderCurrentRewardsEntry{
+					{
+						Address: addrStr1,
+						Rewards: func() *types.FinalityProviderCurrentRewards {
+							r := datagen.GenRandomFinalityProviderCurrentRewards(r)
+							r.Period = 3
+							return &r
+						}(),
+					},
+				},
+				FinalityProvidersHistoricalRewards: []types.FinalityProviderHistoricalRewardsEntry{
+					{
+						Address: addrStr1,
+						Period:  0,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+					{
+						Address: addrStr1,
+						Period:  1,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+					{
+						Address: addrStr1,
+						Period:  2,
+						Rewards: func() *types.FinalityProviderHistoricalRewards {
+							v := datagen.GenRandomFPHistRwdWithDecimals(r)
+							return &v
+						}(),
+					},
+				},
+				BtcDelegationRewardsTrackers: []types.BTCDelegationRewardsTrackerEntry{
+					{
+						FinalityProviderAddress: addrStr1,
+						DelegatorAddress:        addrStr2,
+						Tracker: func() *types.BTCDelegationRewardsTracker {
+							v := datagen.GenRandomBTCDelegationRewardsTracker(r)
+							v.StartPeriodCumulativeReward = 1
+							return &v
+						}(),
+					},
+				},
+				BtcDelegatorsToFps: []types.BTCDelegatorToFpEntry{{
+					FinalityProviderAddress: addrStr1,
+					DelegatorAddress:        addrStr2,
+				}},
+				EventRewardTracker: []types.EventsPowerUpdateAtHeightEntry{},
 			},
 			valid: true,
 		},


### PR DESCRIPTION
validation to ensure each finality provider has historical rewards entries for all periods from 0 through `FinalityProviderCurrentRewards.Period - 1`