### PR TITLE
chore: remove `x/crisis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ check of rewards
 - [#402](https://github.com/babylonlabs-io/babylon/pull/402) **Babylon multi-staking support**.
 This PR contains a series of PRs on multi-staking support and BTC staking integration.
 - [#944](https://github.com/babylonlabs-io/babylon/pull/944) Add max_multi_staked_fps validation and single FP per consumer constraint in BTC delegations.
+- [#1146](https://github.com/babylonlabs-io/babylon/pull/1146) Remove deprecated `x/crisis` module.
 
 ### Bug fixes
 

--- a/app/app.go
+++ b/app/app.go
@@ -60,8 +60,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/consensus"
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
-	"github.com/cosmos/cosmos-sdk/x/crisis"
-	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distr "github.com/cosmos/cosmos-sdk/x/distribution"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
@@ -284,10 +282,6 @@ func NewBabylonApp(
 
 	/****  Module Options ****/
 
-	// NOTE: we may consider parsing `appOpts` inside module constructors. For the moment
-	// we prefer to be more strict in what arguments the modules expect.
-	var skipGenesisInvariants = cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
-
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
 	app.ModuleManager = module.NewManager(
@@ -300,7 +294,6 @@ func NewBabylonApp(
 		auth.NewAppModule(appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
 		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper),
 		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, app.GetSubspace(banktypes.ModuleName)),
-		crisis.NewAppModule(app.CrisisKeeper, skipGenesisInvariants, app.GetSubspace(crisistypes.ModuleName)),
 		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
 		gov.NewAppModule(appCodec, &app.GovKeeper, app.AccountKeeper, app.BankKeeper, app.GetSubspace(govtypes.ModuleName)),
 		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
@@ -374,7 +367,7 @@ func NewBabylonApp(
 		minttypes.ModuleName, incentivetypes.ModuleName, distrtypes.ModuleName,
 		slashingtypes.ModuleName,
 		evidencetypes.ModuleName, stakingtypes.ModuleName,
-		authtypes.ModuleName, banktypes.ModuleName, govtypes.ModuleName, crisistypes.ModuleName, genutiltypes.ModuleName,
+		authtypes.ModuleName, banktypes.ModuleName, govtypes.ModuleName, genutiltypes.ModuleName,
 		authz.ModuleName, feegrant.ModuleName,
 		paramstypes.ModuleName, vestingtypes.ModuleName, consensusparamtypes.ModuleName, circuittypes.ModuleName,
 		// Token factory
@@ -405,7 +398,7 @@ func NewBabylonApp(
 	// app.mm.OrderBeginBlockers = append(app.mm.OrderBeginBlockers[:4], app.mm.OrderBeginBlockers[4+1:]...) // remove slashingtypes.ModuleName
 	// app.mm.OrderBeginBlockers = append(app.mm.OrderBeginBlockers[:4], app.mm.OrderBeginBlockers[4+1:]...) // remove evidencetypes.ModuleName
 
-	app.ModuleManager.SetOrderEndBlockers(crisistypes.ModuleName, govtypes.ModuleName, stakingtypes.ModuleName,
+	app.ModuleManager.SetOrderEndBlockers(govtypes.ModuleName, stakingtypes.ModuleName,
 		capabilitytypes.ModuleName, authtypes.ModuleName, banktypes.ModuleName, distrtypes.ModuleName,
 		slashingtypes.ModuleName, minttypes.ModuleName,
 		genutiltypes.ModuleName, evidencetypes.ModuleName, authz.ModuleName,
@@ -445,7 +438,7 @@ func NewBabylonApp(
 	// can do so safely.
 	genesisModuleOrder := []string{
 		capabilitytypes.ModuleName, authtypes.ModuleName, banktypes.ModuleName, distrtypes.ModuleName, stakingtypes.ModuleName,
-		slashingtypes.ModuleName, govtypes.ModuleName, minttypes.ModuleName, crisistypes.ModuleName,
+		slashingtypes.ModuleName, govtypes.ModuleName, minttypes.ModuleName,
 		genutiltypes.ModuleName, evidencetypes.ModuleName, authz.ModuleName,
 		feegrant.ModuleName,
 		paramstypes.ModuleName, upgradetypes.ModuleName, vestingtypes.ModuleName, consensusparamtypes.ModuleName, circuittypes.ModuleName,
@@ -481,7 +474,6 @@ func NewBabylonApp(
 	// Uncomment if you want to set a custom migration order here.
 	// app.mm.SetOrderMigrations(custom order)
 
-	app.ModuleManager.RegisterInvariants(app.CrisisKeeper)
 	app.configurator = module.NewConfigurator(app.appCodec, app.MsgServiceRouter(), app.GRPCQueryRouter())
 	app.RegisterServicesWithoutStaking()
 	autocliv1.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))

--- a/app/export.go
+++ b/app/export.go
@@ -70,9 +70,6 @@ func (app *BabylonApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 		allowedAddrsMap[addr] = true
 	}
 
-	/* Just to be safe, assert the invariants on current state. */
-	app.CrisisKeeper.AssertInvariants(ctx)
-
 	/* Handle fee distribution state. */
 
 	// withdraw all validator commission

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -58,8 +58,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	consensusparamkeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
-	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
-	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
@@ -140,7 +138,6 @@ type AppKeepers struct {
 	MintKeeper            mintkeeper.Keeper
 	DistrKeeper           distrkeeper.Keeper
 	GovKeeper             govkeeper.Keeper
-	CrisisKeeper          *crisiskeeper.Keeper
 	UpgradeKeeper         *upgradekeeper.Keeper
 	ParamsKeeper          paramskeeper.Keeper
 	AuthzKeeper           authzkeeper.Keeper
@@ -219,7 +216,7 @@ func (ak *AppKeepers) InitKeepers(
 
 	// set persistent store keys
 	keys := storetypes.NewKVStoreKeys(
-		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey, crisistypes.StoreKey,
+		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
 		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
 		govtypes.StoreKey, paramstypes.StoreKey, consensusparamtypes.StoreKey, upgradetypes.StoreKey, feegrant.StoreKey,
 		evidencetypes.StoreKey, circuittypes.StoreKey, capabilitytypes.StoreKey,
@@ -398,16 +395,6 @@ func (ak *AppKeepers) InitKeepers(
 		runtime.NewKVStoreService(keys[slashingtypes.StoreKey]),
 		ak.StakingKeeper,
 		appparams.AccGov.String(),
-	)
-
-	ak.CrisisKeeper = crisiskeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[crisistypes.StoreKey]),
-		invCheckPeriod,
-		ak.BankKeeper,
-		authtypes.FeeCollectorName,
-		appparams.AccGov.String(),
-		ak.AccountKeeper.AddressCodec(),
 	)
 
 	ak.FeeGrantKeeper = feegrantkeeper.NewKeeper(

--- a/app/upgrades/v2/upgrades.go
+++ b/app/upgrades/v2/upgrades.go
@@ -46,6 +46,9 @@ const (
 	//
 	// To fully decouple from the module now, we hardcode the store name here.
 	InterchainQueryStoreName = "interchainquery"
+	// CrisisStoreName `x/crisis` module is deprecated at cosmos-sdk v0.53 and
+	// will be removed in the next release.
+	CrisisStoreName = "crisis"
 )
 
 var (
@@ -67,7 +70,7 @@ func CreateUpgrade(includeAsyncICQ bool) upgrades.Upgrade {
 		CreateUpgradeHandler: CreateUpgradeHandler,
 		StoreUpgrades: store.StoreUpgrades{
 			Added:   addedStoreUpgrades,
-			Deleted: []string{ibcfeetypes.StoreKey},
+			Deleted: []string{ibcfeetypes.StoreKey, CrisisStoreName},
 		},
 	}
 }

--- a/app/upgrades/v2/upgrades_test.go
+++ b/app/upgrades/v2/upgrades_test.go
@@ -147,4 +147,8 @@ func (s *UpgradeTestSuite) PostUpgrade() {
 		s.Require().Zero(rl.Flow.Inflow.Int64())
 		s.Require().Zero(rl.Flow.Outflow.Int64())
 	}
+
+	// crisis store and module name are the same
+	_, found := s.app.ModuleManager.Modules[v2.CrisisStoreName]
+	s.Require().False(found, "x/crisis modules shouldn't be found")
 }

--- a/app/upgrades/v2rc2/testnet/upgrade.go
+++ b/app/upgrades/v2rc2/testnet/upgrade.go
@@ -18,7 +18,7 @@ var Upgrade = upgrades.Upgrade{
 	CreateUpgradeHandler: CreateUpgradeHandler,
 	StoreUpgrades: store.StoreUpgrades{
 		Added:   []string{},
-		Deleted: []string{v2.InterchainQueryStoreName},
+		Deleted: []string{v2.InterchainQueryStoreName, v2.CrisisStoreName},
 	},
 }
 

--- a/cmd/babylond/cmd/genesis.go
+++ b/cmd/babylond/cmd/genesis.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
@@ -214,11 +213,6 @@ func PrepareGenesis(
 	govGenState.Params = &genesisParams.GovParams
 	genesisState[govtypes.ModuleName] = cdc.MustMarshalJSON(govGenState)
 
-	// crisis module genesis
-	crisisGenState := crisistypes.DefaultGenesisState()
-	crisisGenState.ConstantFee = genesisParams.CrisisConstantFee
-	genesisState[crisistypes.ModuleName] = cdc.MustMarshalJSON(crisisGenState)
-
 	// auth module genesis
 	authGenState := authtypes.DefaultGenesisState()
 	authGenState.Accounts = genesisParams.AuthAccounts
@@ -254,7 +248,6 @@ type GenesisParams struct {
 	DistributionParams distributiontypes.Params
 	GovParams          govv1.Params
 
-	CrisisConstantFee    sdk.Coin
 	AuthAccounts         []*cdctypes.Any
 	BankGenBalances      []banktypes.Balance
 	CheckpointingGenKeys []*checkpointingtypes.GenesisKey
@@ -345,11 +338,6 @@ func TestnetGenesisParams(
 		genParams.NativeCoinMetadatas[0].Base,
 		sdkmath.NewInt(10_000_000_000),
 	))
-
-	genParams.CrisisConstantFee = sdk.NewCoin(
-		genParams.NativeCoinMetadatas[0].Base,
-		sdkmath.NewInt(500_000_000_000),
-	)
 
 	genParams.BtccheckpointParams = btccheckpointtypes.DefaultParams()
 	genParams.BtccheckpointParams.BtcConfirmationDepth = btcConfirmationDepth

--- a/cmd/babylond/cmd/root.go
+++ b/cmd/babylond/cmd/root.go
@@ -36,7 +36,6 @@ import (
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cast"
@@ -233,7 +232,6 @@ func initRootCmd(rootCmd *cobra.Command, txConfig client.TxEncodingConfig, basic
 }
 
 func addModuleInitFlags(startCmd *cobra.Command) {
-	crisis.AddModuleInitFlags(startCmd)
 	wasm.AddModuleInitFlags(startCmd)
 
 	startCmd.Flags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|kwallet|pass|test)")

--- a/test/e2e/initialization/config.go
+++ b/test/e2e/initialization/config.go
@@ -11,7 +11,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -233,11 +232,6 @@ func initGenesis(
 		return err
 	}
 
-	err = updateModuleGenesis(appGenState, crisistypes.ModuleName, &crisistypes.GenesisState{}, updateCrisisGenesis)
-	if err != nil {
-		return err
-	}
-
 	err = updateModuleGenesis(appGenState, genutiltypes.ModuleName, &genutiltypes.GenesisState{}, updateGenUtilGenesis(chain))
 	if err != nil {
 		return err
@@ -321,10 +315,6 @@ func updateStakeGenesis(stakeGenState *staketypes.GenesisState) {
 		UnbondingTime:     staketypes.DefaultUnbondingTime,
 		MinCommissionRate: sdkmath.LegacyZeroDec(),
 	}
-}
-
-func updateCrisisGenesis(crisisGenState *crisistypes.GenesisState) {
-	crisisGenState.ConstantFee.Denom = BabylonDenom
 }
 
 func updateBtcLightClientGenesis(btcHeaders []*btclighttypes.BTCHeaderInfo) func(blcGenState *blctypes.GenesisState) {


### PR DESCRIPTION
`x/crisis` module became [deprecated](https://github.com/cosmos/cosmos-sdk/blob/810d15dd6d16084c9ba6dfc018e9431172cd4786/x/crisis/README.md?plain=1#L7)

sec 9. Usage of deprecated x/crisis module allows attackers to DoS the chain