### PR TITLE
chore: add whitelisted channels to add rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ check of rewards
 - [#1126](https://github.com/babylonlabs-io/babylon/pull/1126) chore: add bls key validation
 - [#1135](https://github.com/babylonlabs-io/babylon/pull/1135) Add validation to `LastProcessedHeightEventRewardTracker` on `InitGenesis`
 - [#1147](https://github.com/babylonlabs-io/babylon/pull/1147) chore: vp dist cache count active fps
+- [#1151](https://github.com/babylonlabs-io/babylon/pull/1151) Add whitelisted channels to add rate limit in `v2` upgrade.
 
 ### State Machine Breaking
 

--- a/app/include_upgrade_mainnet.go
+++ b/app/include_upgrade_mainnet.go
@@ -10,9 +10,19 @@ import (
 	v2 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v2"
 )
 
+var WhitelistedChannelsID = map[string]struct{}{
+	"channel-0": struct{}{},
+	"channel-1": struct{}{},
+	"channel-2": struct{}{},
+	"channel-3": struct{}{},
+	"channel-4": struct{}{},
+	"channel-5": struct{}{},
+	"channel-6": struct{}{},
+}
+
 // init is used to include v1 upgrade for mainnet data
 func init() {
-	Upgrades = []upgrades.Upgrade{v2.CreateUpgrade(false), v1_1.Upgrade, v1.CreateUpgrade(v1.UpgradeDataString{
+	Upgrades = []upgrades.Upgrade{v2.CreateUpgrade(false, WhitelistedChannelsID), v1_1.Upgrade, v1.CreateUpgrade(v1.UpgradeDataString{
 		BtcStakingParamsStr:       mainnet.BtcStakingParamsStr,
 		FinalityParamStr:          mainnet.FinalityParamStr,
 		IncentiveParamStr:         mainnet.IncentiveParamStr,

--- a/app/include_upgrade_testnet.go
+++ b/app/include_upgrade_testnet.go
@@ -19,7 +19,7 @@ import (
 func init() {
 	Upgrades = []upgrades.Upgrade{
 		v2rc2.Upgrade,
-		v2.CreateUpgrade(true),
+		v2.CreateUpgrade(true, map[string]struct{}{}),
 		v1_1.Upgrade,
 		v1.CreateUpgrade(v1.UpgradeDataString{
 			BtcStakingParamsStr:       testnet.BtcStakingParamsStr,

--- a/app/upgrades/v2/upgrades.go
+++ b/app/upgrades/v2/upgrades.go
@@ -52,19 +52,10 @@ var (
 	// durations in hours
 	DailyDurationHours uint64 = 24
 	// limits (percentages)
-	DefaultDailyLimit     = sdkmath.NewInt(10)
-	WhitelistedChannelsID = map[string]struct{}{
-		"channel-0": struct{}{},
-		"channel-1": struct{}{},
-		"channel-2": struct{}{},
-		"channel-3": struct{}{},
-		"channel-4": struct{}{},
-		"channel-5": struct{}{},
-		"channel-6": struct{}{},
-	}
+	DefaultDailyLimit = sdkmath.NewInt(10)
 )
 
-func CreateUpgrade(includeAsyncICQ bool) upgrades.Upgrade {
+func CreateUpgrade(includeAsyncICQ bool, whitelistedChannelsByID map[string]struct{}) upgrades.Upgrade {
 	addedStoreUpgrades := []string{tokenfactorytypes.StoreKey, pfmroutertypes.StoreKey, icacontrollertypes.StoreKey, icahosttypes.StoreKey, ratelimittypes.StoreKey}
 
 	if includeAsyncICQ {
@@ -73,7 +64,7 @@ func CreateUpgrade(includeAsyncICQ bool) upgrades.Upgrade {
 
 	return upgrades.Upgrade{
 		UpgradeName:          UpgradeName,
-		CreateUpgradeHandler: CreateUpgradeHandler,
+		CreateUpgradeHandler: CreateUpgradeHandler(whitelistedChannelsByID),
 		StoreUpgrades: store.StoreUpgrades{
 			Added:   addedStoreUpgrades,
 			Deleted: []string{ibcfeetypes.StoreKey},
@@ -81,65 +72,71 @@ func CreateUpgrade(includeAsyncICQ bool) upgrades.Upgrade {
 	}
 }
 
-func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
-	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// Run migrations before applying any other state changes.
-		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
-		if err != nil {
-			return nil, err
+func CreateUpgradeHandler(whitelistedChannelsByID map[string]struct{}) upgrades.UpgradeHandlerCreator {
+	return func(mm *module.Manager, configurator module.Configurator, keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
+		return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			// Run migrations before applying any other state changes.
+			migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
+			if err != nil {
+				return nil, err
+			}
+
+			sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+			// Add a default rate limit to existing channels on port 'transfer'
+			if err := addRateLimits(sdkCtx, keepers.IBCKeeper.ChannelKeeper, keepers.RatelimitKeeper, whitelistedChannelsByID); err != nil {
+				return nil, err
+			}
+
+			// By default, ICQ allowed queries are empty. So no queries will be allowed until
+			// the allowed list is populated via gov proposal.
+			// For ICA host, by default all messages are allowed (using '*' wildcard),
+			// so we set allow list to empty and messages can be added later when needed via gov proposal
+			icaHostParams := icahosttypes.DefaultParams()
+			icaHostParams.AllowMessages = nil
+			if err := icaHostParams.Validate(); err != nil {
+				return nil, err
+			}
+			keepers.ICAHostKeeper.SetParams(sdkCtx, icaHostParams)
+
+			// update reward distribution events
+			err = UpdateRewardTrackerEventLastProcessedHeight(ctx, keepers.IncentiveKeeper)
+			if err != nil {
+				return nil, err
+			}
+
+			// Set the denom creation fee to ubbn
+			params := tokenfactorytypes.DefaultParams()
+			params.DenomCreationFee = sdk.NewCoins(sdk.NewInt64Coin(minttypes.DefaultBondDenom, 10_000_000))
+
+			if err := params.Validate(); err != nil {
+				return nil, err
+			}
+
+			if err := keepers.TokenFactoryKeeper.SetParams(ctx, params); err != nil {
+				return nil, err
+			}
+
+			return migrations, nil
 		}
-
-		sdkCtx := sdk.UnwrapSDKContext(ctx)
-
-		// Add a default rate limit to existing channels on port 'transfer'
-		if err := addRateLimits(sdkCtx, keepers.IBCKeeper.ChannelKeeper, keepers.RatelimitKeeper); err != nil {
-			return nil, err
-		}
-
-		// By default, ICQ allowed queries are empty. So no queries will be allowed until
-		// the allowed list is populated via gov proposal.
-		// For ICA host, by default all messages are allowed (using '*' wildcard),
-		// so we set allow list to empty and messages can be added later when needed via gov proposal
-		icaHostParams := icahosttypes.DefaultParams()
-		icaHostParams.AllowMessages = nil
-		if err := icaHostParams.Validate(); err != nil {
-			return nil, err
-		}
-		keepers.ICAHostKeeper.SetParams(sdkCtx, icaHostParams)
-
-		// update reward distribution events
-		err = UpdateRewardTrackerEventLastProcessedHeight(ctx, keepers.IncentiveKeeper)
-		if err != nil {
-			return nil, err
-		}
-
-		// Set the denom creation fee to ubbn
-		params := tokenfactorytypes.DefaultParams()
-		params.DenomCreationFee = sdk.NewCoins(sdk.NewInt64Coin(minttypes.DefaultBondDenom, 10_000_000))
-
-		if err := params.Validate(); err != nil {
-			return nil, err
-		}
-
-		if err := keepers.TokenFactoryKeeper.SetParams(ctx, params); err != nil {
-			return nil, err
-		}
-
-		return migrations, nil
 	}
 }
 
 // addRateLimits adds rate limit to the native denom ('ubbn') to all channels registered on the channel keeper
-func addRateLimits(ctx sdk.Context, chk transfertypes.ChannelKeeper, rlk ratelimitkeeper.Keeper) error {
+func addRateLimits(ctx sdk.Context, chk transfertypes.ChannelKeeper, rlk ratelimitkeeper.Keeper, whitelistedChannelsByID map[string]struct{}) error {
 	logger := ctx.Logger().With("upgrade", UpgradeName)
 	channels := chk.GetAllChannelsWithPortPrefix(ctx, transfertypes.PortID)
 	logger.Info("adding limits to channels", "channels_count", len(channels))
 	for _, ch := range channels {
-		_, isWhitelisted := WhitelistedChannelsID[ch.ChannelId]
-		if !isWhitelisted {
-			continue
+		// if there is no whitelisted channel it sets to all the available transfer channels
+		if len(whitelistedChannelsByID) != 0 {
+			_, isWhitelisted := whitelistedChannelsByID[ch.ChannelId]
+			if !isWhitelisted {
+				continue
+			}
 		}
 
+		logger.Info("adding limits to whitelist channel", "channel_id", ch.ChannelId)
 		if err := addRateLimit(ctx, rlk, appparams.DefaultBondDenom, ch.ChannelId, DefaultDailyLimit, DailyDurationHours); err != nil {
 			return err
 		}

--- a/app/upgrades/v2/upgrades.go
+++ b/app/upgrades/v2/upgrades.go
@@ -52,7 +52,16 @@ var (
 	// durations in hours
 	DailyDurationHours uint64 = 24
 	// limits (percentages)
-	DefaultDailyLimit = sdkmath.NewInt(10)
+	DefaultDailyLimit     = sdkmath.NewInt(10)
+	WhitelistedChannelsID = map[string]struct{}{
+		"channel-0": struct{}{},
+		"channel-1": struct{}{},
+		"channel-2": struct{}{},
+		"channel-3": struct{}{},
+		"channel-4": struct{}{},
+		"channel-5": struct{}{},
+		"channel-6": struct{}{},
+	}
 )
 
 func CreateUpgrade(includeAsyncICQ bool) upgrades.Upgrade {
@@ -126,6 +135,11 @@ func addRateLimits(ctx sdk.Context, chk transfertypes.ChannelKeeper, rlk ratelim
 	channels := chk.GetAllChannelsWithPortPrefix(ctx, transfertypes.PortID)
 	logger.Info("adding limits to channels", "channels_count", len(channels))
 	for _, ch := range channels {
+		_, isWhitelisted := WhitelistedChannelsID[ch.ChannelId]
+		if !isWhitelisted {
+			continue
+		}
+
 		if err := addRateLimit(ctx, rlk, appparams.DefaultBondDenom, ch.ChannelId, DefaultDailyLimit, DailyDurationHours); err != nil {
 			return err
 		}

--- a/app/upgrades/v2/upgrades_test.go
+++ b/app/upgrades/v2/upgrades_test.go
@@ -51,47 +51,87 @@ func TestUpgradeTestSuite(t *testing.T) {
 }
 
 func (s *UpgradeTestSuite) TestUpgrade() {
+	mainnetWhitelistedChannels := make(map[string]struct{}, 0)
+	for _, c := range usedChannels {
+		if strings.EqualFold(c.ChannelId, NotWhitelistedChannelID) {
+			continue
+		}
+		mainnetWhitelistedChannels[c.ChannelId] = struct{}{}
+	}
+
 	testCases := []struct {
-		msg             string
-		baseBtcHeader   *btclighttypes.BTCHeaderInfo
-		preUpgrade      func()
-		upgrade         func()
-		postUpgrade     func()
-		includeAsyncICQ bool
+		msg                     string
+		baseBtcHeader           *btclighttypes.BTCHeaderInfo
+		preUpgrade              func()
+		upgrade                 func()
+		postUpgrade             func()
+		includeAsyncICQ         bool
+		whitelistedChannelsByID map[string]struct{}
 	}{
 		{
-			"Test launch software upgrade v2 with async ICQ not included",
+			"Test launch software upgrade v2 with async ICQ not included and mainnet whitelisted rate limit channels",
 			sample.MainnetBtcHeader854784(s.T()),
 			s.PreUpgrade,
 			s.Upgrade,
 			func() {
-				s.PostUpgrade()
+				// check rate limits are set
+				res, err := s.app.RatelimitKeeper.AllRateLimits(s.ctx, &ratelimittypes.QueryAllRateLimitsRequest{})
+				s.Require().NoError(err)
+				s.Require().NotNil(res)
+				s.Require().Len(res.RateLimits, len(usedChannels)-1) // one is not whitelisted and was not rate limited
+
+				for _, rl := range res.RateLimits {
+					if strings.EqualFold(rl.Path.ChannelId, NotWhitelistedChannelID) {
+						s.Require().FailNowf("channel ID: %s shouldn't have a rate limit", rl.Path.ChannelId)
+					}
+					s.Require().Equal(v2.DefaultDailyLimit, rl.Quota.MaxPercentRecv)
+					s.Require().Equal(v2.DefaultDailyLimit, rl.Quota.MaxPercentSend)
+					s.Require().Equal(v2.DailyDurationHours, rl.Quota.DurationHours)
+					s.Require().Zero(rl.Flow.Inflow.Int64())
+					s.Require().Zero(rl.Flow.Outflow.Int64())
+				}
+
 				// check the reward tracker event last processed height
 				lastProcessedHeight, err := s.app.IncentiveKeeper.GetRewardTrackerEventLastProcessedHeight(s.ctx)
 				s.NoError(err)
 				s.EqualValues(DummyUpgradeHeight-1, lastProcessedHeight)
 			},
 			false,
+			mainnetWhitelistedChannels,
 		},
 		{
-			"Test launch software upgrade v2 with async ICQ included",
+			"Test launch software upgrade v2 with async ICQ included and empty whitelisted (all channels should rate limit)",
 			sample.MainnetBtcHeader854784(s.T()),
 			s.PreUpgrade,
 			s.Upgrade,
 			func() {
-				s.PostUpgrade()
+				// check rate limits are set
+				res, err := s.app.RatelimitKeeper.AllRateLimits(s.ctx, &ratelimittypes.QueryAllRateLimitsRequest{})
+				s.Require().NoError(err)
+				s.Require().NotNil(res)
+				s.Require().Len(res.RateLimits, len(usedChannels))
+
+				for _, rl := range res.RateLimits {
+					s.Require().Equal(v2.DefaultDailyLimit, rl.Quota.MaxPercentRecv)
+					s.Require().Equal(v2.DefaultDailyLimit, rl.Quota.MaxPercentSend)
+					s.Require().Equal(v2.DailyDurationHours, rl.Quota.DurationHours)
+					s.Require().Zero(rl.Flow.Inflow.Int64())
+					s.Require().Zero(rl.Flow.Outflow.Int64())
+				}
+
 				// check the reward tracker event last processed height
 				lastProcessedHeight, err := s.app.IncentiveKeeper.GetRewardTrackerEventLastProcessedHeight(s.ctx)
 				s.NoError(err)
 				s.EqualValues(DummyUpgradeHeight-1, lastProcessedHeight)
 			},
 			true,
+			map[string]struct{}{},
 		},
 	}
 
 	for _, tc := range testCases {
 		s.Run(fmt.Sprintf("Case %s", tc.msg), func() {
-			s.SetupTest(tc.includeAsyncICQ) // reset
+			s.SetupTest(tc.includeAsyncICQ, tc.whitelistedChannelsByID) // reset
 
 			tc.preUpgrade()
 			tc.upgrade()
@@ -100,9 +140,9 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	}
 }
 
-func (s *UpgradeTestSuite) SetupTest(includeAsyncICQ bool) {
+func (s *UpgradeTestSuite) SetupTest(includeAsyncICQ bool, whitelistedChannelsByID map[string]struct{}) {
 	// add the upgrade plan
-	app.Upgrades = []upgrades.Upgrade{v2.CreateUpgrade(includeAsyncICQ)}
+	app.Upgrades = []upgrades.Upgrade{v2.CreateUpgrade(includeAsyncICQ, whitelistedChannelsByID)}
 
 	// set up app
 	s.app = app.SetupWithBitcoinConf(s.T(), false, bbn.BtcSignet)
@@ -136,23 +176,4 @@ func (s *UpgradeTestSuite) Upgrade() {
 		_, err := s.preModule.PreBlock(s.ctx)
 		s.Require().NoError(err)
 	})
-}
-
-func (s *UpgradeTestSuite) PostUpgrade() {
-	// check rate limits are set
-	res, err := s.app.RatelimitKeeper.AllRateLimits(s.ctx, &ratelimittypes.QueryAllRateLimitsRequest{})
-	s.Require().NoError(err)
-	s.Require().NotNil(res)
-	s.Require().Len(res.RateLimits, len(usedChannels)-1) // one is not whitelisted and was not rate limited
-
-	for _, rl := range res.RateLimits {
-		if strings.EqualFold(rl.Path.ChannelId, NotWhitelistedChannelID) {
-			s.Require().FailNowf("channel ID: %s shouldn't have a rate limit", rl.Path.ChannelId)
-		}
-		s.Require().Equal(v2.DefaultDailyLimit, rl.Quota.MaxPercentRecv)
-		s.Require().Equal(v2.DefaultDailyLimit, rl.Quota.MaxPercentSend)
-		s.Require().Equal(v2.DailyDurationHours, rl.Quota.DurationHours)
-		s.Require().Zero(rl.Flow.Inflow.Int64())
-		s.Require().Zero(rl.Flow.Outflow.Int64())
-	}
 }


### PR DESCRIPTION
32. Upgrade handler channel rate limiting enables denial of service via channel spam