### PR TITLE
chore: reduced ibc `MaxAddressSize` to max value of bech 32 addr (90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,8 +110,9 @@ check of rewards
 - [#1136](https://github.com/babylonlabs-io/babylon/pull/1136) Fix `SubmissionEntry` duplicate validation in `InitGenesis`
 - [#1147](https://github.com/babylonlabs-io/babylon/pull/1147) chore: vp dist cache count active fps
 - [#1151](https://github.com/babylonlabs-io/babylon/pull/1151) Add whitelisted channels to add rate limit in `v2` upgrade.
-- [#1152](https://github.com/babylonlabs-io/babylon/pull/1152) chore: validate power non negative
-- [#1168](https://github.com/babylonlabs-io/babylon/pull/1168) chore: removed duplicated addr len check in `SetAddressVerifier`
+- [#1152](https://github.com/babylonlabs-io/babylon/pull/1152) chore: validate power non negative.
+- [#1168](https://github.com/babylonlabs-io/babylon/pull/1168) chore: removed duplicated addr len check in `SetAddressVerifier`.
+- [#1174](https://github.com/babylonlabs-io/babylon/pull/1174) chore: reduced ibc `MaxAddressSize` to max value of bech 32 addr (90).
 
 ### State Machine Breaking
 

--- a/app/ante/ibc_msg_size.go
+++ b/app/ante/ibc_msg_size.go
@@ -12,7 +12,7 @@ import (
 const (
 	MaxMsgSize     = 500_000 // 500 KB
 	MaxMemoSize    = 400_000 // 400 KB
-	MaxAddressSize = 65_000  // 65 KB
+	MaxAddressSize = 90      // 90 chars
 )
 
 // IBCMsgSizeDecorator checks that IBC messages size is within the accepted size


### PR DESCRIPTION
43. The MaxAddressSize constant is excessively large