### PR TITLE
fix: checks for pagination in `QueryBlsPublicKeyListRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ This PR contains a series of PRs on multi-staking support and BTC staking integr
 - [#525](https://github.com/babylonlabs-io/babylon/pull/525) fix: add back `NewIBCHeaderDecorator` post handler
 - [#964](https://github.com/babylonlabs-io/babylon/pull/964) fix: stateless validation `ValidateBasic` of
 `MsgWrappedCreateValidator` to avoid panic in transaction submission
+- [#1196](https://github.com/babylonlabs-io/babylon/pull/1196) fix: add pagination in `QueryBlsPublicKeyListRequest`.
 
 ## v2.0.0-rc.3
 

--- a/x/checkpointing/types/bls_key.go
+++ b/x/checkpointing/types/bls_key.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/babylonlabs-io/babylon/v4/crypto/bls12381"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Validate checks for duplicate ValidatorAddress or BlsPubKey entries.
@@ -38,6 +39,10 @@ func (vs ValidatorWithBlsKeySet) Validate() error {
 	}
 
 	return nil
+}
+
+func (v ValidatorWithBlsKey) Addr() (sdk.ValAddress, error) {
+	return sdk.ValAddressFromBech32(v.ValidatorAddress)
 }
 
 // ValidateBasic stateless validate if the BlsKey is valid


### PR DESCRIPTION
x/checkpointing/keeper/grpc_query_bls.go

Keeper.BlsPublicKeyList does not validate pagination inputs when there are zero validators for a given epoch. By passing offset > 0 on an empty result set, the code computes total-1 where total == 0, underflows, and proceeds to slice an empty Go slice and triggers a panic.

How to replicate:

```shell
grpcurl -plaintext -d '{"epoch_num":999,"pagination":{"offset":1,"limit":1}}' localhost:9090 babylon.checkpointing.v1.Query/BlsPublicKeyList
```