### PR TITLE
fix: zoneconcierge ibc router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ This PR contains a series of PRs on multi-staking support and BTC staking integr
 - [#525](https://github.com/babylonlabs-io/babylon/pull/525) fix: add back `NewIBCHeaderDecorator` post handler
 - [#964](https://github.com/babylonlabs-io/babylon/pull/964) fix: stateless validation `ValidateBasic` of
 `MsgWrappedCreateValidator` to avoid panic in transaction submission
+- [#1247](https://github.com/babylonlabs-io/babylon/pull/1247) fix: zoneconcierge ibc router
 
 ## v2.0.0-rc.4
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -253,8 +253,6 @@ func (ak *AppKeepers) InitKeepers(
 		icahosttypes.StoreKey,
 		icacontrollertypes.StoreKey,
 		ratelimittypes.StoreKey,
-		// ZoneConcierge
-		zctypes.StoreKey,
 		// Integration related modules
 		bsctypes.ModuleName,
 		zctypes.ModuleName,
@@ -851,6 +849,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
 	paramsKeeper.Subspace(tokenfactorytypes.ModuleName)
 	paramsKeeper.Subspace(ratelimittypes.ModuleName)
+	paramsKeeper.Subspace(zctypes.ModuleName)
 
 	return paramsKeeper
 }

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -56,6 +56,7 @@ import (
 	minttypes "github.com/babylonlabs-io/babylon/v3/x/mint/types"
 	monitorkeeper "github.com/babylonlabs-io/babylon/v3/x/monitor/keeper"
 	monitortypes "github.com/babylonlabs-io/babylon/v3/x/monitor/types"
+	zoneconcierge "github.com/babylonlabs-io/babylon/v3/x/zoneconcierge"
 	zckeeper "github.com/babylonlabs-io/babylon/v3/x/zoneconcierge/keeper"
 	zctypes "github.com/babylonlabs-io/babylon/v3/x/zoneconcierge/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -252,6 +253,8 @@ func (ak *AppKeepers) InitKeepers(
 		icahosttypes.StoreKey,
 		icacontrollertypes.StoreKey,
 		ratelimittypes.StoreKey,
+		// ZoneConcierge
+		zctypes.StoreKey,
 		// Integration related modules
 		bsctypes.ModuleName,
 		zctypes.ModuleName,
@@ -813,10 +816,14 @@ func (ak *AppKeepers) InitKeepers(
 	// channel.RecvPacket -> fee.OnRecvPacket -> icaHost.OnRecvPacket
 	icaHostStack := icahost.NewIBCModule(*ak.ICAHostKeeper)
 
+	// Create ZoneConcierge IBC module
+	zoneConciergeIBCModule := zoneconcierge.NewIBCModule(ak.ZoneConciergeKeeper)
+
 	// Create static IBC router, add ibc-transfer module route,
 	// and the other routes (ICA, wasm, zoneconcierge), then set and seal it
 	ibcRouter := porttypes.NewRouter().
 		AddRoute(ibctransfertypes.ModuleName, transferStack).
+		AddRoute(zctypes.PortID, zoneConciergeIBCModule).
 		AddRoute(wasmtypes.ModuleName, wasmStack).
 		AddRoute(icacontrollertypes.SubModuleName, icaControllerStack).
 		AddRoute(icahosttypes.SubModuleName, icaHostStack)

--- a/x/zoneconcierge/module_ibc.go
+++ b/x/zoneconcierge/module_ibc.go
@@ -152,7 +152,7 @@ func (im IBCModule) OnChanCloseConfirm(
 // OnRecvPacket implements the IBCModule interface
 func (im IBCModule) OnRecvPacket(
 	ctx sdk.Context,
-	channelID string,
+	channelVersion string,
 	modulePacket channeltypes.Packet,
 	relayer sdk.AccAddress,
 ) ibcexported.Acknowledgement {
@@ -181,7 +181,7 @@ func (im IBCModule) OnRecvPacket(
 // OnAcknowledgementPacket implements the IBCModule interface
 func (im IBCModule) OnAcknowledgementPacket(
 	ctx sdk.Context,
-	channelID string,
+	channelVersion string,
 	modulePacket channeltypes.Packet,
 	acknowledgement []byte,
 	relayer sdk.AccAddress,
@@ -227,7 +227,7 @@ func (im IBCModule) OnAcknowledgementPacket(
 // OnTimeoutPacket implements the IBCModule interface
 func (im IBCModule) OnTimeoutPacket(
 	ctx sdk.Context,
-	channelID string,
+	channelVersion string,
 	modulePacket channeltypes.Packet,
 	relayer sdk.AccAddress,
 ) error {

--- a/x/zoneconcierge/module_ibc.go
+++ b/x/zoneconcierge/module_ibc.go
@@ -8,7 +8,6 @@ import (
 	"github.com/babylonlabs-io/babylon/v3/x/zoneconcierge/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
 	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/v10/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
@@ -31,7 +30,6 @@ func (im IBCModule) OnChanOpenInit(
 	connectionHops []string,
 	portID string,
 	channelID string,
-	chanCap *capabilitytypes.Capability,
 	counterparty channeltypes.Counterparty,
 	version string,
 ) (string, error) {
@@ -73,7 +71,6 @@ func (im IBCModule) OnChanOpenTry(
 	connectionHops []string,
 	portID,
 	channelID string,
-	chanCap *capabilitytypes.Capability,
 	counterparty channeltypes.Counterparty,
 	counterpartyVersion string,
 ) (string, error) {
@@ -155,6 +152,7 @@ func (im IBCModule) OnChanCloseConfirm(
 // OnRecvPacket implements the IBCModule interface
 func (im IBCModule) OnRecvPacket(
 	ctx sdk.Context,
+	channelID string,
 	modulePacket channeltypes.Packet,
 	relayer sdk.AccAddress,
 ) ibcexported.Acknowledgement {
@@ -183,6 +181,7 @@ func (im IBCModule) OnRecvPacket(
 // OnAcknowledgementPacket implements the IBCModule interface
 func (im IBCModule) OnAcknowledgementPacket(
 	ctx sdk.Context,
+	channelID string,
 	modulePacket channeltypes.Packet,
 	acknowledgement []byte,
 	relayer sdk.AccAddress,
@@ -228,6 +227,7 @@ func (im IBCModule) OnAcknowledgementPacket(
 // OnTimeoutPacket implements the IBCModule interface
 func (im IBCModule) OnTimeoutPacket(
 	ctx sdk.Context,
+	channelID string,
 	modulePacket channeltypes.Packet,
 	relayer sdk.AccAddress,
 ) error {

--- a/x/zoneconcierge/types/mocked_keepers.go
+++ b/x/zoneconcierge/types/mocked_keepers.go
@@ -16,10 +16,9 @@ import (
 	types4 "github.com/babylonlabs-io/babylon/v3/x/checkpointing/types"
 	types5 "github.com/babylonlabs-io/babylon/v3/x/epoching/types"
 	types6 "github.com/cosmos/cosmos-sdk/types"
-	types7 "github.com/cosmos/ibc-go/modules/capability/types"
-	types8 "github.com/cosmos/ibc-go/v10/modules/core/02-client/types"
-	types9 "github.com/cosmos/ibc-go/v10/modules/core/03-connection/types"
-	types10 "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	types7 "github.com/cosmos/ibc-go/v10/modules/core/02-client/types"
+	types8 "github.com/cosmos/ibc-go/v10/modules/core/03-connection/types"
+	types9 "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
 	exported "github.com/cosmos/ibc-go/v10/modules/core/exported"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -206,18 +205,18 @@ func (m *MockICS4Wrapper) EXPECT() *MockICS4WrapperMockRecorder {
 }
 
 // SendPacket mocks base method.
-func (m *MockICS4Wrapper) SendPacket(ctx types6.Context, channelCap *types7.Capability, sourcePort, sourceChannel string, timeoutHeight types8.Height, timeoutTimestamp uint64, data []byte) (uint64, error) {
+func (m *MockICS4Wrapper) SendPacket(ctx types6.Context, sourcePort, sourceChannel string, timeoutHeight types7.Height, timeoutTimestamp uint64, data []byte) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendPacket", ctx, channelCap, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, data)
+	ret := m.ctrl.Call(m, "SendPacket", ctx, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, data)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SendPacket indicates an expected call of SendPacket.
-func (mr *MockICS4WrapperMockRecorder) SendPacket(ctx, channelCap, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, data interface{}) *gomock.Call {
+func (mr *MockICS4WrapperMockRecorder) SendPacket(ctx, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendPacket", reflect.TypeOf((*MockICS4Wrapper)(nil).SendPacket), ctx, channelCap, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendPacket", reflect.TypeOf((*MockICS4Wrapper)(nil).SendPacket), ctx, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, data)
 }
 
 // MockChannelKeeper is a mock of ChannelKeeper interface.
@@ -244,10 +243,10 @@ func (m *MockChannelKeeper) EXPECT() *MockChannelKeeperMockRecorder {
 }
 
 // GetAllChannels mocks base method.
-func (m *MockChannelKeeper) GetAllChannels(ctx types6.Context) []types10.IdentifiedChannel {
+func (m *MockChannelKeeper) GetAllChannels(ctx types6.Context) []types9.IdentifiedChannel {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllChannels", ctx)
-	ret0, _ := ret[0].([]types10.IdentifiedChannel)
+	ret0, _ := ret[0].([]types9.IdentifiedChannel)
 	return ret0
 }
 
@@ -258,10 +257,10 @@ func (mr *MockChannelKeeperMockRecorder) GetAllChannels(ctx interface{}) *gomock
 }
 
 // GetChannel mocks base method.
-func (m *MockChannelKeeper) GetChannel(ctx types6.Context, srcPort, srcChan string) (types10.Channel, bool) {
+func (m *MockChannelKeeper) GetChannel(ctx types6.Context, srcPort, srcChan string) (types9.Channel, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetChannel", ctx, srcPort, srcChan)
-	ret0, _ := ret[0].(types10.Channel)
+	ret0, _ := ret[0].(types9.Channel)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
@@ -377,10 +376,10 @@ func (m *MockConnectionKeeper) EXPECT() *MockConnectionKeeperMockRecorder {
 }
 
 // GetConnection mocks base method.
-func (m *MockConnectionKeeper) GetConnection(ctx types6.Context, connectionID string) (types9.ConnectionEnd, bool) {
+func (m *MockConnectionKeeper) GetConnection(ctx types6.Context, connectionID string) (types8.ConnectionEnd, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConnection", ctx, connectionID)
-	ret0, _ := ret[0].(types9.ConnectionEnd)
+	ret0, _ := ret[0].(types8.ConnectionEnd)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }


### PR DESCRIPTION
was getting this in local deployment then realized, ibc router is missing for zc

```
  → Creating IBC channel for zoneconcierge...
2025-06-19T19:17:39.981605Z	info	Starting event processor for channel handshake	{"src_chain_id": "chain-test", "src_port_id": "zoneconcierge", "dst_chain_id": "bcd-test", "dst_port_id": "wasm.bbnc14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9syx25zf"}
2025-06-19T19:17:39.983040Z	info	Chain is in sync	{"chain_name": "bcd", "chain_id": "bcd-test"}
2025-06-19T19:17:39.983944Z	info	Chain is in sync	{"chain_name": "babylon", "chain_id": "chain-test"}
2025-06-19T19:17:50.222487Z	error	Error sending messages	{"path_name": "bcd", "src_chain_id": "bcd-test", "dst_chain_id": "chain-test", "src_client_id": "07-tendermint-0", "dst_client_id": "07-tendermint-0", "error": "rpc error: code = Unknown desc = rpc error: code = Unknown desc = failed to execute message; message index: 1: route not found to portID: zoneconcierge: route not found [cosmos/ibc-go/v10@v10.2.0/modules/core/keeper/msg_server.go:237] with gas used: '110088': unknown request"}
2025-06-19T19:18:22.278320Z	error	Error sending messages	{"path_name": "bcd", "src_chain_id": "bcd-test", "dst_chain_id": "chain-test", "src_client_id": "07-tendermint-0", "dst_client_id": "07-tendermint-0", "error": "rpc error: code = Unknown desc = rpc error: code = Unknown desc = failed to execute message; message index: 1: route not found to portID: zoneconcierge: route not found [cosmos/ibc-go/v10@v10.2.0/modules/core/keeper/msg_server.go:237] with gas used: '110138': unknown request"}
2025-06-19T19:18:54.326563Z	error	Error sending messages	{"path_name": "bcd", "src_chain_id": "bcd-test", "dst_chain_id": "chain-test", "src_client_id": "07-tendermint-0", "dst_client_id": "07-tendermint-0", "error": "rpc error: code = Unknown desc = rpc error: code = Unknown desc = failed to execute message; message index: 1: route not found to portID: zoneconcierge: route not found [cosmos/ibc-go/v10@v10.2.0/modules/core/keeper/msg_server.go:237] with gas used: '110088': unknown request"}
2025-06-19T19:19:26.378973Z	error	Error sending messages	{"path_name": "bcd", "src_chain_id": "bcd-test", "dst_chain_id": "chain-test", "src_client_id": "07-tendermint-0", "dst_client_id": "07-tendermint-0", "error": "rpc error: code = Unknown desc = rpc error: code = Unknown desc = failed to execute message; message index: 1: route not found to portID: zoneconcierge: route not found [cosmos/ibc-go/v10@v10.2.0/modules/core/keeper/msg_server.go:237] with gas used: '110306': unknown request"}
```

referred to Konrad's original commit which removed x/zoneconcierge - [link](https://github.com/babylonlabs-io/babylon/commit/d64059107f22914ce124e8a1bc4da1a3e2bb381d)