### PR TITLE
fix(zoneconcierge): sort map keysbefore iterating to avoid AppHash errors.

### DIFF
--- a/x/btcstaking/keeper/genesis.go
+++ b/x/btcstaking/keeper/genesis.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"sort"
 
 	"cosmossdk.io/store/prefix"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -273,9 +274,19 @@ func (k Keeper) consumerEvents(ctx context.Context) []*types.ConsumerEvent {
 	eventsMap := k.GetAllBTCStakingConsumerIBCPackets(ctx)
 	entriesCount := len(eventsMap)
 	res := make([]*types.ConsumerEvent, 0, entriesCount)
-	for consumerId, events := range eventsMap {
+
+	// Extract keys and sort them for deterministic iteration
+	consumerIDs := make([]string, 0, entriesCount)
+	for consumerID := range eventsMap {
+		consumerIDs = append(consumerIDs, consumerID)
+	}
+	sort.Strings(consumerIDs)
+
+	// Iterate through consumer IDs in sorted order
+	for _, consumerID := range consumerIDs {
+		events := eventsMap[consumerID]
 		res = append(res, &types.ConsumerEvent{
-			ConsumerId: consumerId,
+			ConsumerId: consumerID,
 			Events:     events,
 		})
 	}

--- a/x/zoneconcierge/keeper/ibc_packet_btc_staking_consumer_event.go
+++ b/x/zoneconcierge/keeper/ibc_packet_btc_staking_consumer_event.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	bbn "github.com/babylonlabs-io/babylon/v3/types"
 	bsctypes "github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
@@ -39,7 +40,18 @@ func (k Keeper) BroadcastBTCStakingConsumerEvents(
 
 	// Iterate through all consumer events and send them to the corresponding open IBC channel.
 	consumerIBCPacketMap := k.bsKeeper.GetAllBTCStakingConsumerIBCPackets(ctx)
-	for consumerID, ibcPacket := range consumerIBCPacketMap {
+
+	// Extract keys and sort them for deterministic iteration
+	consumerIDs := make([]string, 0, len(consumerIBCPacketMap))
+	for consumerID := range consumerIBCPacketMap {
+		consumerIDs = append(consumerIDs, consumerID)
+	}
+	sort.Strings(consumerIDs)
+
+	// Iterate through consumer IDs in sorted order
+	for _, consumerID := range consumerIDs {
+		ibcPacket := consumerIBCPacketMap[consumerID]
+
 		// Check if there are open channels for the current consumer ID.
 		channels, ok := consumerChannelMap[consumerID]
 		if !ok {


### PR DESCRIPTION
Due to the nature of map iterating in Go being indeterministic we need to first sort the map by it's keys. Closes https://github.com/babylonlabs-io/babylon/issues/1251