### PR TITLE
feat(callbacks): Create incentive callbacks PoC for rewards distribution.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -167,20 +167,21 @@ var (
 	DefaultNodeHome string
 	// fee collector account, module accounts and their permissions
 	maccPerms = map[string][]string{
-		authtypes.FeeCollectorName:     {authtypes.Burner}, // fee collector account, needs Burner role for feemarket burning of BaseFee
-		distrtypes.ModuleName:          nil,
-		minttypes.ModuleName:           {authtypes.Minter},
-		stakingtypes.BondedPoolName:    {authtypes.Burner, authtypes.Staking},
-		stakingtypes.NotBondedPoolName: {authtypes.Burner, authtypes.Staking},
-		govtypes.ModuleName:            {authtypes.Burner},
-		ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
-		incentivetypes.ModuleName:      nil, // this line is needed to create an account for incentive module
-		tokenfactorytypes.ModuleName:   {authtypes.Minter, authtypes.Burner},
-		icatypes.ModuleName:            nil,
-		evmtypes.ModuleName:            {authtypes.Minter, authtypes.Burner},
-		feemarkettypes.ModuleName:      nil,
-		erc20types.ModuleName:          {authtypes.Minter, authtypes.Burner}, // Allows erc20 module to mint/burn for token pairs
-		precisebanktypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
+		authtypes.FeeCollectorName:         {authtypes.Burner}, // fee collector account, needs Burner role for feemarket burning of BaseFee
+		distrtypes.ModuleName:              nil,
+		minttypes.ModuleName:               {authtypes.Minter},
+		stakingtypes.BondedPoolName:        {authtypes.Burner, authtypes.Staking},
+		stakingtypes.NotBondedPoolName:     {authtypes.Burner, authtypes.Staking},
+		govtypes.ModuleName:                {authtypes.Burner},
+		ibctransfertypes.ModuleName:        {authtypes.Minter, authtypes.Burner},
+		incentivetypes.ModuleName:          nil, // this line is needed to create an account for incentive module
+		incentivetypes.BSNFeeCollectorName: nil, // module account for collecting BSN fees from IBC transfers
+		tokenfactorytypes.ModuleName:       {authtypes.Minter, authtypes.Burner},
+		icatypes.ModuleName:                nil,
+		evmtypes.ModuleName:                {authtypes.Minter, authtypes.Burner},
+		feemarkettypes.ModuleName:          nil,
+		erc20types.ModuleName:              {authtypes.Minter, authtypes.Burner}, // Allows erc20 module to mint/burn for token pairs
+		precisebanktypes.ModuleName:        {authtypes.Minter, authtypes.Burner},
 	}
 
 	// software upgrades and forks
@@ -954,6 +955,9 @@ func BlockedAddresses() map[string]bool {
 
 	// allow the following addresses to receive funds
 	delete(blockedAddrs, appparams.AccGov.String())
+	// Allow BSN fee collector to receive IBC transfer funds
+	delete(blockedAddrs, authtypes.NewModuleAddress(incentivetypes.BSNFeeCollectorName).String())
+	delete(blockedAddrs, authtypes.NewModuleAddress(distrtypes.ModuleName).String())
 
 	// Block precompiled contracts
 	blockedPrecompilesHex := evmtypes.AvailableStaticPrecompiles

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -36,20 +36,21 @@ import (
 
 var (
 	expectedMaccPerms = map[string][]string{
-		authtypes.FeeCollectorName:   {authtypes.Burner}, // fee collector account
-		distrtypes.ModuleName:        nil,
-		minttypes.ModuleName:         {authtypes.Minter},
-		stktypes.BondedPoolName:      {authtypes.Burner, authtypes.Staking},
-		stktypes.NotBondedPoolName:   {authtypes.Burner, authtypes.Staking},
-		govtypes.ModuleName:          {authtypes.Burner},
-		ibctransfertypes.ModuleName:  {authtypes.Minter, authtypes.Burner},
-		incentivetypes.ModuleName:    nil, // this line is needed to create an account for incentive module
-		tokenfactorytypes.ModuleName: {authtypes.Minter, authtypes.Burner},
-		icatypes.ModuleName:          nil,
-		evmtypes.ModuleName:          {authtypes.Minter, authtypes.Burner},
-		erc20types.ModuleName:        {authtypes.Minter, authtypes.Burner},
-		feemarkettypes.ModuleName:    nil,
-		precisebanktypes.ModuleName:  {authtypes.Minter, authtypes.Burner},
+		authtypes.FeeCollectorName:         {authtypes.Burner}, // fee collector account
+		distrtypes.ModuleName:              nil,
+		minttypes.ModuleName:               {authtypes.Minter},
+		stktypes.BondedPoolName:            {authtypes.Burner, authtypes.Staking},
+		stktypes.NotBondedPoolName:         {authtypes.Burner, authtypes.Staking},
+		govtypes.ModuleName:                {authtypes.Burner},
+		ibctransfertypes.ModuleName:        {authtypes.Minter, authtypes.Burner},
+		incentivetypes.ModuleName:          nil, // this line is needed to create an account for incentive module
+		incentivetypes.BSNFeeCollectorName: nil, // module account for collecting BSN fees from IBC transfers
+		tokenfactorytypes.ModuleName:       {authtypes.Minter, authtypes.Burner},
+		icatypes.ModuleName:                nil,
+		evmtypes.ModuleName:                {authtypes.Minter, authtypes.Burner},
+		erc20types.ModuleName:              {authtypes.Minter, authtypes.Burner},
+		feemarkettypes.ModuleName:          nil,
+		precisebanktypes.ModuleName:        {authtypes.Minter, authtypes.Burner},
 	}
 )
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -800,7 +800,10 @@ func (ak *AppKeepers) InitKeepers(
 	var transferStack porttypes.IBCModule
 	transferStack = transfer.NewIBCModule(ak.TransferKeeper)
 
-	cbStack := ibccallbacks.NewIBCMiddleware(transferStack, ak.PFMRouterKeeper, wasmStackIBCHandler, appparams.MaxIBCCallbackGas)
+	// Add incentive callback middleware for BSN fee collection
+	cbStack := ibccallbacks.NewIBCMiddleware(transferStack, ak.PFMRouterKeeper, &ak.IncentiveKeeper, appparams.MaxIBCCallbackGas)
+	// Add WASM callback middleware for existing WASM contracts
+	//cbStack = ibccallbacks.NewIBCMiddleware(cbStack, ak.IBCKeeper.ChannelKeeper, wasmStackIBCHandler, appparams.MaxIBCCallbackGas)
 	transferStack = pfmrouter.NewIBCMiddleware(
 		cbStack,
 		ak.PFMRouterKeeper,
@@ -808,15 +811,18 @@ func (ak *AppKeepers) InitKeepers(
 		pfmrouterkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
 	)
 	transferStack = ratelimiter.NewIBCMiddleware(ak.RatelimitKeeper, transferStack)
+
+	// Set the ICS4Wrapper to use the outermost callback stack
 	ak.TransferKeeper.WithICS4Wrapper(cbStack)
 
 	// Transfer Stack for IBC V2
 	var transferStackV2 ibcapi.IBCModule
 	transferStackV2 = transferv2.NewIBCModule(ak.TransferKeeper)
+	// Add incentive callback middleware for BSN fee collection (IBC v2)
 	transferStackV2 = ibccallbacksv2.NewIBCMiddleware(
 		transferStackV2,
 		ak.IBCKeeper.ChannelKeeperV2,
-		wasmStackIBCHandler,
+		&ak.IncentiveKeeper,
 		ak.IBCKeeper.ChannelKeeperV2,
 		appparams.MaxIBCCallbackGas,
 	)

--- a/test/e2e/bsn_fee_collection_e2e_test.go
+++ b/test/e2e/bsn_fee_collection_e2e_test.go
@@ -1,0 +1,179 @@
+package e2e
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/babylonlabs-io/babylon/v3/test/e2e/configurer"
+	incentivetypes "github.com/babylonlabs-io/babylon/v3/x/incentive/types"
+)
+
+type BSNFeeCollectionTestSuite struct {
+	suite.Suite
+
+	configurer configurer.Configurer
+	senderAddr string
+}
+
+const (
+	bsnRewardDistributionMemo = "bsn_reward_distribution"
+	transferAmount            = int64(100_000) // 100k custom tokens
+	customDenomName           = "testcoin"     // Custom token name
+)
+
+// getTestDistributionAddress returns the same deterministic test address used in the keeper
+func getTestDistributionAddress() sdk.AccAddress {
+	hash := sha256.Sum256([]byte("test_distribution_account"))
+	return sdk.AccAddress(hash[:20])
+}
+
+func (s *BSNFeeCollectionTestSuite) SetupSuite() {
+	s.T().Log("setting up BSN fee collection test suite...")
+	var err error
+
+	s.configurer, err = configurer.NewIBCTransferConfigurer(s.T(), true)
+	s.Require().NoError(err)
+
+	err = s.configurer.ConfigureChains()
+	s.Require().NoError(err)
+
+	err = s.configurer.RunSetup()
+	s.Require().NoError(err)
+}
+
+func (s *BSNFeeCollectionTestSuite) TearDownSuite() {
+	err := s.configurer.ClearResources()
+	if err != nil {
+		s.T().Logf("error to clear resources %s", err.Error())
+	}
+}
+
+// TestBSNFeeCollectionWithCorrectMemo tests BSN fee collection with the correct memo
+func (s *BSNFeeCollectionTestSuite) TestBSNFeeCollectionWithCorrectMemo() {
+	bbnChainA := s.configurer.GetChainConfig(0)
+	bbnChainB := s.configurer.GetChainConfig(1)
+
+	nA, err := bbnChainA.GetNodeAtIndex(2)
+	s.NoError(err)
+	nB, err := bbnChainB.GetNodeAtIndex(2)
+	s.NoError(err)
+
+	// Create and fund sender account
+	s.senderAddr = nA.KeysAdd("bsn-sender")
+	nA.BankSendFromNode(s.senderAddr, "15000000ubbn") // Give enough ubbn for tokenfactory creation fee (10M) + tx fees
+	nA.WaitForNextBlock()
+
+	// Create custom denom using tokenfactory
+	customDenom := fmt.Sprintf("factory/%s/%s", s.senderAddr, customDenomName)
+	s.T().Logf("Creating custom denom: %s", customDenom)
+
+	// Create the denom
+	nA.CreateDenom(s.senderAddr, customDenomName)
+	nA.WaitForNextBlock()
+
+	// Mint custom tokens to sender
+	mintAmount := fmt.Sprintf("%d", transferAmount*10) // Mint 10x what we need
+	nA.MintDenom(s.senderAddr, mintAmount, customDenom)
+	nA.WaitForNextBlock()
+
+	// Verify sender has the custom tokens
+	balanceBeforeSend, err := nA.QueryBalances(s.senderAddr)
+	s.Require().NoError(err)
+
+	// Check custom denom balance specifically
+	customBalance := balanceBeforeSend.AmountOf(customDenom)
+	s.Require().True(customBalance.GT(sdkmath.ZeroInt()), "Should have custom tokens after minting")
+
+	// Get BSN fee collector module account address on chain B
+	bsnFeeCollectorAddr, err := nB.QueryModuleAddress(incentivetypes.BSNFeeCollectorName)
+	s.Require().NoError(err)
+
+	// Get test distribution account address (instead of distribution module which can't receive custom tokens)
+	testDistributionAddr := getTestDistributionAddress()
+
+	// Get initial balances
+	initialBSNBalance, err := nB.QueryBalances(bsnFeeCollectorAddr.String())
+	s.Require().NoError(err)
+
+	initialTestDistributionBalance, err := nB.QueryBalances(testDistributionAddr.String())
+	s.Require().NoError(err)
+
+	// Create transfer coin using custom denom
+	transferCoin := sdk.NewInt64Coin(customDenom, transferAmount)
+
+	// Create JSON callback memo for IBC callback middleware with BSN action
+	callbackMemo := fmt.Sprintf(`{
+		"dest_callback": {
+			"address": "%s"
+		},
+		"action": "%s"
+	}`, bsnFeeCollectorAddr.String(), bsnRewardDistributionMemo)
+
+	txHash := nA.SendIBCTransfer(s.senderAddr, bsnFeeCollectorAddr.String(), callbackMemo, transferCoin)
+	nA.WaitForNextBlock()
+
+	// Query transaction to ensure it was successful
+	txRes, _, err := nA.QueryTxWithError(txHash)
+	s.Require().NoError(err)
+	s.Require().Zero(txRes.Code, fmt.Sprintf("Transaction failed with code %d: %s", txRes.Code, txRes.RawLog))
+
+	// Calculate expected amounts after 50% distribution
+	expectedDistributionAmount := transferAmount / 2 // 50% goes to distribution
+	expectedBSNAmount := transferAmount / 2          // 50% remains in BSN fee collector
+
+	// Check BSN fee collector balance - should have received 50% of transfer
+	s.Require().Eventually(func() bool {
+		finalBSNBalance, err := nB.QueryBalances(bsnFeeCollectorAddr.String())
+		if err != nil {
+			s.T().Logf("Failed to query BSN fee collector balance: %s", err.Error())
+			return false
+		}
+
+		// Look for the IBC denom
+		ibcDenom := getFirstIBCDenom(finalBSNBalance)
+		if ibcDenom == "" {
+			s.T().Logf("No IBC denom found in BSN fee collector balance: %s", finalBSNBalance.String())
+			return false
+		}
+		s.T().Logf("Found IBC denom: %s", ibcDenom)
+
+		// Calculate received amount (final - initial)
+		initialIBCAmount := initialBSNBalance.AmountOf(ibcDenom).Int64()
+		finalIBCAmount := finalBSNBalance.AmountOf(ibcDenom).Int64()
+		actualBSNAmount := finalIBCAmount - initialIBCAmount
+
+		return actualBSNAmount == expectedBSNAmount
+	}, 2*time.Minute, 5*time.Second, "BSN fee collector did not receive expected amount")
+
+	// Check test distribution account balance - should have received 50% of transfer
+	s.Require().Eventually(func() bool {
+		finalTestDistributionBalance, err := nB.QueryBalances(testDistributionAddr.String())
+		if err != nil {
+			s.T().Logf("Failed to query test distribution balance: %s", err.Error())
+			return false
+		}
+
+		// Look for the IBC denom
+		ibcDenom := getFirstIBCDenom(finalTestDistributionBalance)
+		if ibcDenom == "" {
+			s.T().Logf("No IBC denom found in test distribution balance: %s", finalTestDistributionBalance.String())
+			return false
+		}
+		s.T().Logf("Found IBC denom in test distribution: %s", ibcDenom)
+
+		// Calculate received amount (final - initial)
+		initialIBCAmount := initialTestDistributionBalance.AmountOf(ibcDenom).Int64()
+		finalIBCAmount := finalTestDistributionBalance.AmountOf(ibcDenom).Int64()
+		actualDistributionAmount := finalIBCAmount - initialIBCAmount
+
+		return actualDistributionAmount == expectedDistributionAmount
+	}, 2*time.Minute, 5*time.Second, "Test distribution account did not receive expected amount")
+
+	s.T().Logf("BSN fee collector received: %d custom tokens (50%% of transfer)", expectedBSNAmount)
+	s.T().Logf("Test distribution account received: %d custom tokens (50%% of transfer)", expectedDistributionAmount)
+}

--- a/test/e2e/configurer/chain/commands.go
+++ b/test/e2e/configurer/chain/commands.go
@@ -572,3 +572,27 @@ func (n *NodeConfig) FailICASendTx(from, connectionID, packetMsgPath string) {
 
 	n.LogActionF("Failed to perform ICA send (as expected)")
 }
+
+// CreateDenom creates a new tokenfactory denom
+func (n *NodeConfig) CreateDenom(from, subdenom string) {
+	n.LogActionF("creating tokenfactory denom %s from %s", subdenom, from)
+
+	cmd := []string{"babylond", "tx", "tokenfactory", "create-denom", subdenom, fmt.Sprintf("--from=%s", from)}
+	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
+
+	require.NoError(n.t, err)
+
+	n.LogActionF("successfully created tokenfactory denom %s", subdenom)
+}
+
+// MintDenom mints tokens of a tokenfactory denom
+func (n *NodeConfig) MintDenom(from, amount, denom string) {
+	n.LogActionF("minting tokenfactory tokens %s%s from %s", amount, denom, from)
+
+	cmd := []string{"babylond", "tx", "tokenfactory", "mint", amount + denom, fmt.Sprintf("--from=%s", from)}
+	_, _, err := n.containerManager.ExecTxCmd(n.t, n.chainId, n.Name, cmd)
+
+	require.NoError(n.t, err)
+
+	n.LogActionF("successfully minted tokenfactory tokens %s%s", amount, denom)
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -53,3 +53,8 @@ func TestSoftwareUpgradeV2TestSuite(t *testing.T) {
 func TestFinalityContractTestSuite(t *testing.T) {
 	suite.Run(t, new(FinalityContractTestSuite))
 }
+
+// TestBSNFeeCollectionTestSuite tests BSN fee collection via IBC callbacks end-to-end
+func TestBSNFeeCollectionTestSuite(t *testing.T) {
+	suite.Run(t, new(BSNFeeCollectionTestSuite))
+}

--- a/test/e2e/initialization/config.go
+++ b/test/e2e/initialization/config.go
@@ -17,6 +17,7 @@ import (
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	staketypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/gogoproto/proto"
+	tokenfactorytypes "github.com/strangelove-ventures/tokenfactory/x/tokenfactory/types"
 
 	"github.com/babylonlabs-io/babylon/v3/test/e2e/util"
 	bbn "github.com/babylonlabs-io/babylon/v3/types"
@@ -257,6 +258,11 @@ func initGenesis(
 		return fmt.Errorf("failed to update rate limiter genesis state: %w", err)
 	}
 
+	err = updateModuleGenesis(appGenState, tokenfactorytypes.ModuleName, &tokenfactorytypes.GenesisState{}, updateTokenFactoryGenesis)
+	if err != nil {
+		return fmt.Errorf("failed to update tokenfactory genesis state: %w", err)
+	}
+
 	bz, err := json.MarshalIndent(appGenState, "", "  ")
 	if err != nil {
 		return err
@@ -404,4 +410,10 @@ func applyRateLimitsToChainConfig(rateLimiterGenState *ratelimiter.GenesisState)
 	}
 
 	rateLimiterGenState.RateLimits = append(rateLimiterGenState.RateLimits, rateLimit)
+}
+
+func updateTokenFactoryGenesis(tokenfactoryGenState *tokenfactorytypes.GenesisState) {
+	tokenfactoryGenState.Params = tokenfactorytypes.Params{
+		DenomCreationFee: sdk.NewCoins(sdk.NewCoin(BabylonDenom, sdkmath.NewInt(10000))),
+	}
 }

--- a/x/incentive/keeper/ibc_callbacks.go
+++ b/x/incentive/keeper/ibc_callbacks.go
@@ -1,0 +1,168 @@
+package keeper
+
+import (
+	errorsmod "cosmossdk.io/errors"
+	"cosmossdk.io/math"
+	"crypto/sha256"
+	"encoding/json"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	transfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v10/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
+
+	"github.com/babylonlabs-io/babylon/v3/x/incentive/types"
+)
+
+// Ensure that the incentive Keeper implements the ContractKeeper interface
+var _ types.ContractKeeper = (*Keeper)(nil)
+
+const (
+	// BSNRewardDistributionMemo is the memo string indicating BSN reward distribution
+	BSNRewardDistributionMemo = "bsn_reward_distribution"
+)
+
+// CallbackMemo defines the structure for callback memo in IBC transfers
+// TODO: We can add the fp distribution here in the future
+type CallbackMemo struct {
+	DestCallback *CallbackInfo `json:"dest_callback,omitempty"`
+	Action       string        `json:"action,omitempty"`
+}
+
+// CallbackInfo contains the callback information
+type CallbackInfo struct {
+	Address string `json:"address"`
+}
+
+// IBCSendPacketCallback is called when a packet is sent
+// Not needed for BSN fee collection scenario
+func (k Keeper) IBCSendPacketCallback(
+	_ sdk.Context,
+	_ string,
+	_ string,
+	_ clienttypes.Height,
+	_ uint64,
+	_ []byte,
+	_ string,
+	_ string,
+	_ string,
+) error {
+	return nil
+}
+
+// IBCOnAcknowledgementPacketCallback is called when a packet acknowledgement is received
+// Not needed for BSN fee collection scenario (this runs on source chain)
+func (k Keeper) IBCOnAcknowledgementPacketCallback(
+	_ sdk.Context,
+	_ channeltypes.Packet,
+	_ []byte,
+	_ sdk.AccAddress,
+	_ string,
+	_ string,
+	_ string,
+) error {
+	return nil
+}
+
+// IBCOnTimeoutPacketCallback is called when a packet times out
+// Not needed for BSN fee collection scenario
+func (k Keeper) IBCOnTimeoutPacketCallback(
+	_ sdk.Context,
+	_ channeltypes.Packet,
+	_ sdk.AccAddress,
+	_ string,
+	_ string,
+	_ string,
+) error {
+	return nil
+}
+
+// IBCReceivePacketCallback is called when a packet is received
+// This is where we handle ICS20 transfers to the bsn_fee_collector account
+func (k Keeper) IBCReceivePacketCallback(
+	cachedCtx sdk.Context,
+	packet ibcexported.PacketI,
+	ack ibcexported.Acknowledgement,
+	_ string,
+	_ string,
+) error {
+	// Parse packet data as ICS20 transfer first (before checking ack success)
+	transferData, err := k.parseTransferData(packet)
+	if err != nil {
+		return nil
+	}
+
+	// Early return if acknowledgement is not successful
+	if !ack.Success() {
+		return nil
+	}
+
+	// Check for JSON callback format
+	var callbackMemo CallbackMemo
+	if err := json.Unmarshal([]byte(transferData.Memo), &callbackMemo); err != nil {
+		return nil
+	}
+
+	// TODO: Here we can directly distribute to BTC stakers and do whatever with the rest.
+	// Process the BSN fee distribution
+	return k.processBSNFeeDistribution(cachedCtx, packet.GetDestPort(), packet.GetDestChannel(), transferData)
+}
+
+// parseTransferData parses the packet data as ICS20 transfer data
+func (k Keeper) parseTransferData(packet ibcexported.PacketI) (*transfertypes.FungibleTokenPacketData, error) {
+	var transferData transfertypes.FungibleTokenPacketData
+	if err := transfertypes.ModuleCdc.UnmarshalJSON(packet.GetData(), &transferData); err != nil {
+		return nil, err
+	}
+	return &transferData, nil
+}
+
+// getTestDistributionAddress returns a deterministic test address for distribution
+// This is used instead of the distribution module which can't receive custom tokens
+func (k Keeper) getTestDistributionAddress() sdk.AccAddress {
+	// Create a deterministic address based on a fixed seed
+	// This ensures the same address is used across test runs
+	hash := sha256.Sum256([]byte("test_distribution_account"))
+	return sdk.AccAddress(hash[:20])
+}
+
+// processBSNFeeDistribution processes the BSN fee distribution
+func (k Keeper) processBSNFeeDistribution(
+	ctx sdk.Context,
+	destPort string,
+	destChannel string,
+	transferData *transfertypes.FungibleTokenPacketData,
+) error {
+	// Parse the transfer amount
+	transferAmount, ok := math.NewIntFromString(transferData.Amount)
+	if !ok {
+		return errorsmod.Wrapf(types.ErrInvalidAmount, "invalid transfer amount: %s", transferData.Amount)
+	}
+
+	// Calculate the IBC denom representation.
+	ibcDenom := transfertypes.NewDenom(transferData.Denom, transfertypes.NewHop(destPort, destChannel)).IBCDenom()
+
+	// NOTE: This is a PoC implementation. Where just split 50/50 between
+	// a random address and the bsn_fee_collector account.
+
+	// Calculate distribution amount (50% of transfer)
+	distributionAmount := transferAmount.QuoRaw(2)
+	distributionPortion := sdk.NewCoins(sdk.NewCoin(ibcDenom, distributionAmount))
+
+	// Send portion to a test account (since distribution module can't receive custom tokens)
+	// Use a deterministic test address for consistent testing
+	testDistributionAddr := k.getTestDistributionAddress()
+
+	if err := k.bankKeeper.SendCoinsFromModuleToAccount(
+		ctx,
+		types.BSNFeeCollectorName,
+		testDistributionAddr,
+		distributionPortion,
+	); err != nil {
+		return errorsmod.Wrapf(err, "failed to send portion to test distribution account")
+	}
+
+	// TODO: Emit some events for traceability
+
+	return nil
+}

--- a/x/incentive/types/errors.go
+++ b/x/incentive/types/errors.go
@@ -14,4 +14,5 @@ var (
 	ErrBTCDelegationRewardsTrackerNotFound       = errorsmod.Register(ModuleName, 1105, "BTC delegation rewards tracker not found")
 	ErrBTCDelegationRewardsTrackerNegativeAmount = errorsmod.Register(ModuleName, 1106, "BTC delegation rewards tracker has a negative amount of TotalActiveSat")
 	ErrFPCurrentRewardsTrackerNegativeAmount     = errorsmod.Register(ModuleName, 1107, "FP current rewards tracker has a negative amount of TotalActiveSat")
+	ErrInvalidAmount                             = errorsmod.Register(ModuleName, 1108, "invalid amount")
 )

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -6,6 +6,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	epochingtypes "github.com/babylonlabs-io/babylon/v3/x/epoching/types"
+	clienttypes "github.com/cosmos/ibc-go/v10/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
 )
 
 type AccountKeeper interface {
@@ -23,4 +26,50 @@ type BankKeeper interface {
 
 type EpochingKeeper interface {
 	GetEpoch(ctx context.Context) *epochingtypes.Epoch
+}
+
+// ContractKeeper defines the entry points exposed to the IBC callbacks middleware
+type ContractKeeper interface {
+	// IBCSendPacketCallback is called in the source chain when a PacketSend is executed
+	IBCSendPacketCallback(
+		cachedCtx sdk.Context,
+		sourcePort string,
+		sourceChannel string,
+		timeoutHeight clienttypes.Height,
+		timeoutTimestamp uint64,
+		packetData []byte,
+		contractAddress,
+		packetSenderAddress string,
+		version string,
+	) error
+
+	// IBCOnAcknowledgementPacketCallback is called in the source chain when a packet acknowledgement is received
+	IBCOnAcknowledgementPacketCallback(
+		cachedCtx sdk.Context,
+		packet channeltypes.Packet,
+		acknowledgement []byte,
+		relayer sdk.AccAddress,
+		contractAddress,
+		packetSenderAddress string,
+		version string,
+	) error
+
+	// IBCOnTimeoutPacketCallback is called in the source chain when a packet times out
+	IBCOnTimeoutPacketCallback(
+		cachedCtx sdk.Context,
+		packet channeltypes.Packet,
+		relayer sdk.AccAddress,
+		contractAddress,
+		packetSenderAddress string,
+		version string,
+	) error
+
+	// IBCReceivePacketCallback is called in the destination chain when a packet is received
+	IBCReceivePacketCallback(
+		cachedCtx sdk.Context,
+		packet ibcexported.PacketI,
+		ack ibcexported.Acknowledgement,
+		contractAddress string,
+		version string,
+	) error
 }

--- a/x/incentive/types/keys.go
+++ b/x/incentive/types/keys.go
@@ -18,6 +18,9 @@ const (
 
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_incentive"
+
+	// BSNFeeCollectorName defines the module account for collecting BSN fees from IBC transfers
+	BSNFeeCollectorName = "bsn_fee_collector"
 )
 
 var (


### PR DESCRIPTION
PoC for IBC callbacks in the incentive module for rewards distribution. It achieves the following:

- Callback after the ICS20 transfer is completed and tokens are available at the target address which is the `bsn_fee_collector` account.
- Processing of the `memo` field in on the `IBCReceivePacketCallback` where further calculations and  distribution can be done.
- For the PoC we just make a 50/50 split between the `bsn_fee_collector` and a deterministic test distribution account.