### PR TITLE
fix: do not add multistaked fps to voting table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,8 @@ secret key in slashing
 - [#1337](https://github.com/babylonlabs-io/babylon/pull/1337) fix: update proto gen
 - [#1355](https://github.com/babylonlabs-io/babylon/pull/1355) Allow empty fees on genesis transactions
 - [#1361](https://github.com/babylonlabs-io/babylon/pull/1361) Fix typo on makefile
+- [#1366](https://github.com/babylonlabs-io/babylon/pull/1366) fix: not add consumer fps
+to Babylon voting power table
 
 ## v2.2.0
 

--- a/test/replay/btcstaking_test.go
+++ b/test/replay/btcstaking_test.go
@@ -1,7 +1,6 @@
 package replay
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -22,7 +21,6 @@ import (
 	bstypes "github.com/babylonlabs-io/babylon/v3/x/btcstaking/types"
 	btcstakingtypes "github.com/babylonlabs-io/babylon/v3/x/btcstaking/types"
 	"github.com/babylonlabs-io/babylon/v3/x/checkpointing/types"
-	ibctmtypes "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
 )
 
 // TestEpochFinalization checks whether we can finalize some epochs
@@ -575,126 +573,6 @@ func MakeInnerMsg(t *testing.T) *stakingtypes.MsgCreateValidator {
 	)
 	require.NoError(t, err)
 	return msg
-}
-
-func TestMultiConsumerDelegation(t *testing.T) {
-	t.Parallel()
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	driverTempDir := t.TempDir()
-	replayerTempDir := t.TempDir()
-	driver := NewBabylonAppDriver(r, t, driverTempDir, replayerTempDir)
-
-	consumerID1 := "consumer1"
-	consumerID2 := "consumer2"
-	consumerID3 := "consumer3"
-
-	// 1. Set up mock IBC clients for each consumer before registering consumers
-	ctx := driver.App.BaseApp.NewContext(false)
-	driver.App.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID1, &ibctmtypes.ClientState{})
-	driver.App.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID2, &ibctmtypes.ClientState{})
-	driver.App.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID3, &ibctmtypes.ClientState{})
-	driver.GenerateNewBlock()
-
-	// 2. Register consumers
-	consumer1 := driver.RegisterConsumer(consumerID1)
-	consumer2 := driver.RegisterConsumer(consumerID2)
-	consumer3 := driver.RegisterConsumer(consumerID3)
-	// Create a Babylon FP (registered without consumer ID)
-	babylonFp := driver.CreateNFinalityProviderAccounts(1)[0]
-	babylonFp.RegisterFinalityProvider("")
-
-	// 3. Create finality providers for each consumer
-	fp1s := []*FinalityProvider{
-		// Create 2 FPs for consumer1
-		driver.CreateFinalityProviderForConsumer(consumer1),
-		driver.CreateFinalityProviderForConsumer(consumer1),
-	}
-	fp2 := driver.CreateFinalityProviderForConsumer(consumer2)
-	fp3 := driver.CreateFinalityProviderForConsumer(consumer3)
-	// Generate blocks to process registrations
-	driver.GenerateNewBlockAssertExecutionSuccess()
-	staker := driver.CreateNStakerAccounts(1)[0]
-
-	// 4. Create a delegation with three consumer FPs and one Babylon FP
-	staker.CreatePreApprovalDelegation(
-		[]*bbn.BIP340PubKey{fp1s[0].BTCPublicKey(), fp2.BTCPublicKey(), fp3.BTCPublicKey(), babylonFp.BTCPublicKey()},
-		1000,
-		100000000,
-	)
-
-	// 5. Create a valid delegation with 2 FPs (including Babylon FP)
-	staker.CreatePreApprovalDelegation(
-		[]*bbn.BIP340PubKey{babylonFp.BTCPublicKey(), fp1s[0].BTCPublicKey()},
-		1000,
-		100000000,
-	)
-	driver.GenerateNewBlockAssertExecutionSuccess()
-
-	// 6. Replay all blocks and verify state
-	replayer := NewBlockReplayer(t, replayerTempDir)
-
-	// Set up IBC client states in the replayer before replaying blocks
-	replayerCtx := replayer.App.BaseApp.NewContext(false)
-	replayer.App.IBCKeeper.ClientKeeper.SetClientState(replayerCtx, consumerID1, &ibctmtypes.ClientState{})
-	replayer.App.IBCKeeper.ClientKeeper.SetClientState(replayerCtx, consumerID2, &ibctmtypes.ClientState{})
-	replayer.App.IBCKeeper.ClientKeeper.SetClientState(replayerCtx, consumerID3, &ibctmtypes.ClientState{})
-
-	// Replay all the blocks from driver and check appHash
-	replayer.ReplayBlocks(t, driver.GetFinalizedBlocks())
-	// After replay we should have the same apphash and last block height
-	require.Equal(t, driver.GetLastState().LastBlockHeight, replayer.LastState.LastBlockHeight)
-	require.Equal(t, driver.GetLastState().AppHash, replayer.LastState.AppHash)
-}
-
-func TestMultiConsumerDelegationTooManyKeys(t *testing.T) {
-	t.Parallel()
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	driverTempDir := t.TempDir()
-	replayerTempDir := t.TempDir()
-	driver := NewBabylonAppDriver(r, t, driverTempDir, replayerTempDir)
-
-	consumerID1 := "consumer1"
-
-	// 1. Set up mock IBC clients for each consumer before registering consumers
-	ctx := driver.App.BaseApp.NewContext(false)
-	driver.App.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID1, &ibctmtypes.ClientState{})
-	driver.GenerateNewBlock()
-
-	// 2. Register consumers
-	consumer1 := driver.RegisterConsumer(consumerID1)
-	// Create a Babylon FP (registered without consumer ID)
-	babylonFp := driver.CreateNFinalityProviderAccounts(1)[0]
-	babylonFp.RegisterFinalityProvider("")
-
-	params := driver.GetBTCStakingParams(t)
-
-	var fps []*FinalityProvider
-	for i := 0; i < int(params.MaxFinalityProviders); i++ {
-		fps = append(fps, driver.CreateFinalityProviderForConsumer(consumer1))
-	}
-
-	// Generate blocks to process registrations
-	driver.GenerateNewBlockAssertExecutionSuccess()
-	staker := driver.CreateNStakerAccounts(1)[0]
-
-	var bbnFpKeys []*bbn.BIP340PubKey
-	bbnFpKeys = append(bbnFpKeys, babylonFp.BTCPublicKey())
-	for _, fp := range fps {
-		bbnFpKeys = append(bbnFpKeys, fp.BTCPublicKey())
-	}
-
-	// 4. Create a delegation with three consumer FPs and one Babylon FP
-	staker.CreatePreApprovalDelegation(
-		bbnFpKeys,
-		1000,
-		100000000,
-	)
-	expectedLog := fmt.Sprintf("failed to execute message; message index: 0: number of finality providers %d is greater than max finality providers %d: the BTC staking tx is not valid", len(bbnFpKeys), params.MaxFinalityProviders)
-
-	txResults := driver.GenerateNewBlockAssertExecutionFailure()
-	require.Len(t, txResults, 1)
-	require.Equal(t, uint32(1108), txResults[0].Code)
-	require.Contains(t, txResults[0].Log, expectedLog)
 }
 
 func TestBadUnbondingFeeParams(t *testing.T) {

--- a/test/replay/finality_test.go
+++ b/test/replay/finality_test.go
@@ -1,6 +1,7 @@
 package replay
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -343,7 +344,10 @@ func TestOnlyBabylonFpCanCommitRandomness(t *testing.T) {
 
 	consumerFp.CommitRandomness()
 
+	msg := fmt.Sprintf("failed to execute message; message index: 0: the finality provider with BTC PK %s is not a Babylon Genesis finality provider: the public randomness list is invalid", consumerFp.BTCPublicKey().MarshalHex())
+
 	txResults := driver.GenerateNewBlockAssertExecutionFailure()
 	require.Len(t, txResults, 1)
-	require.NotEqual(t, txResults[0].Code, uint32(0))
+	require.Equal(t, txResults[0].Code, uint32(1106))
+	require.Contains(t, txResults[0].Log, msg)
 }

--- a/test/replay/finality_test.go
+++ b/test/replay/finality_test.go
@@ -326,7 +326,7 @@ func TestOnlyBabylonFpCanCommitRandomness(t *testing.T) {
 	replayerTempDir := t.TempDir()
 	driver := NewBabylonAppDriver(r, t, driverTempDir, replayerTempDir)
 
-	consumerID1 := "consumer1"
+	const consumerID1 = "consumer1"
 
 	// 1. Set up mock IBC clients for each consumer before registering consumers
 	ctx := driver.App.BaseApp.NewContext(false)

--- a/test/replay/multistaking_test.go
+++ b/test/replay/multistaking_test.go
@@ -1,0 +1,133 @@
+package replay
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	ibctmtypes "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
+
+	bbn "github.com/babylonlabs-io/babylon/v3/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiConsumerDelegation(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	driverTempDir := t.TempDir()
+	replayerTempDir := t.TempDir()
+	driver := NewBabylonAppDriver(r, t, driverTempDir, replayerTempDir)
+
+	consumerID1 := "consumer1"
+	consumerID2 := "consumer2"
+	consumerID3 := "consumer3"
+
+	// 1. Set up mock IBC clients for each consumer before registering consumers
+	ctx := driver.App.BaseApp.NewContext(false)
+	driver.App.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID1, &ibctmtypes.ClientState{})
+	driver.App.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID2, &ibctmtypes.ClientState{})
+	driver.App.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID3, &ibctmtypes.ClientState{})
+	driver.GenerateNewBlock()
+
+	// 2. Register consumers
+	consumer1 := driver.RegisterConsumer(consumerID1)
+	consumer2 := driver.RegisterConsumer(consumerID2)
+	consumer3 := driver.RegisterConsumer(consumerID3)
+	// Create a Babylon FP (registered without consumer ID)
+	babylonFp := driver.CreateNFinalityProviderAccounts(1)[0]
+	babylonFp.RegisterFinalityProvider("")
+
+	// 3. Create finality providers for each consumer
+	fp1s := []*FinalityProvider{
+		// Create 2 FPs for consumer1
+		driver.CreateFinalityProviderForConsumer(consumer1),
+		driver.CreateFinalityProviderForConsumer(consumer1),
+	}
+	fp2 := driver.CreateFinalityProviderForConsumer(consumer2)
+	fp3 := driver.CreateFinalityProviderForConsumer(consumer3)
+	// Generate blocks to process registrations
+	driver.GenerateNewBlockAssertExecutionSuccess()
+	staker := driver.CreateNStakerAccounts(1)[0]
+
+	// 4. Create a delegation with three consumer FPs and one Babylon FP
+	staker.CreatePreApprovalDelegation(
+		[]*bbn.BIP340PubKey{fp1s[0].BTCPublicKey(), fp2.BTCPublicKey(), fp3.BTCPublicKey(), babylonFp.BTCPublicKey()},
+		1000,
+		100000000,
+	)
+
+	// 5. Create a valid delegation with 2 FPs (including Babylon FP)
+	staker.CreatePreApprovalDelegation(
+		[]*bbn.BIP340PubKey{babylonFp.BTCPublicKey(), fp1s[0].BTCPublicKey()},
+		1000,
+		100000000,
+	)
+	driver.GenerateNewBlockAssertExecutionSuccess()
+
+	// 6. Replay all blocks and verify state
+	replayer := NewBlockReplayer(t, replayerTempDir)
+
+	// Set up IBC client states in the replayer before replaying blocks
+	replayerCtx := replayer.App.BaseApp.NewContext(false)
+	replayer.App.IBCKeeper.ClientKeeper.SetClientState(replayerCtx, consumerID1, &ibctmtypes.ClientState{})
+	replayer.App.IBCKeeper.ClientKeeper.SetClientState(replayerCtx, consumerID2, &ibctmtypes.ClientState{})
+	replayer.App.IBCKeeper.ClientKeeper.SetClientState(replayerCtx, consumerID3, &ibctmtypes.ClientState{})
+
+	// Replay all the blocks from driver and check appHash
+	replayer.ReplayBlocks(t, driver.GetFinalizedBlocks())
+	// After replay we should have the same apphash and last block height
+	require.Equal(t, driver.GetLastState().LastBlockHeight, replayer.LastState.LastBlockHeight)
+	require.Equal(t, driver.GetLastState().AppHash, replayer.LastState.AppHash)
+}
+
+func TestMultiConsumerDelegationTooManyKeys(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	driverTempDir := t.TempDir()
+	replayerTempDir := t.TempDir()
+	driver := NewBabylonAppDriver(r, t, driverTempDir, replayerTempDir)
+
+	consumerID1 := "consumer1"
+
+	// 1. Set up mock IBC clients for each consumer before registering consumers
+	ctx := driver.App.BaseApp.NewContext(false)
+	driver.App.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID1, &ibctmtypes.ClientState{})
+	driver.GenerateNewBlock()
+
+	// 2. Register consumers
+	consumer1 := driver.RegisterConsumer(consumerID1)
+	// Create a Babylon FP (registered without consumer ID)
+	babylonFp := driver.CreateNFinalityProviderAccounts(1)[0]
+	babylonFp.RegisterFinalityProvider("")
+
+	params := driver.GetBTCStakingParams(t)
+
+	var fps []*FinalityProvider
+	for i := 0; i < int(params.MaxFinalityProviders); i++ {
+		fps = append(fps, driver.CreateFinalityProviderForConsumer(consumer1))
+	}
+
+	// Generate blocks to process registrations
+	driver.GenerateNewBlockAssertExecutionSuccess()
+	staker := driver.CreateNStakerAccounts(1)[0]
+
+	var bbnFpKeys []*bbn.BIP340PubKey
+	bbnFpKeys = append(bbnFpKeys, babylonFp.BTCPublicKey())
+	for _, fp := range fps {
+		bbnFpKeys = append(bbnFpKeys, fp.BTCPublicKey())
+	}
+
+	// 4. Create a delegation with three consumer FPs and one Babylon FP
+	staker.CreatePreApprovalDelegation(
+		bbnFpKeys,
+		1000,
+		100000000,
+	)
+	expectedLog := fmt.Sprintf("failed to execute message; message index: 0: number of finality providers %d is greater than max finality providers %d: the BTC staking tx is not valid", len(bbnFpKeys), params.MaxFinalityProviders)
+
+	txResults := driver.GenerateNewBlockAssertExecutionFailure()
+	require.Len(t, txResults, 1)
+	require.Equal(t, uint32(1108), txResults[0].Code)
+	require.Contains(t, txResults[0].Log, expectedLog)
+}

--- a/x/btcstaking/keeper/finality_providers.go
+++ b/x/btcstaking/keeper/finality_providers.go
@@ -121,6 +121,16 @@ func (k Keeper) GetFinalityProvider(ctx context.Context, fpBTCPK []byte) (*types
 	return &fp, nil
 }
 
+// IsBabylonGenesisFinalityProvider checks if the finality provider is a Babylon Genesis finality provider
+func (k Keeper) BabylonFinalityProviderExists(ctx context.Context, fpBTCPK []byte) bool {
+	fp, err := k.GetFinalityProvider(ctx, fpBTCPK)
+	if err != nil {
+		// if the finality provider is not found, then there is no such Babylon finality provider
+		return false
+	}
+	return fp.SecuresBabylonGenesis(sdk.UnwrapSDKContext(ctx))
+}
+
 // SlashFinalityProvider slashes a finality provider with the given PK
 // A slashed finality provider will not have voting power
 // This function handles both Babylon FPs and consumer FPs

--- a/x/finality/keeper/grpc_query.go
+++ b/x/finality/keeper/grpc_query.go
@@ -31,7 +31,7 @@ func (k Keeper) FinalityProviderPowerAtHeight(ctx context.Context, req *types.Qu
 		return nil, status.Errorf(codes.InvalidArgument, "failed to unmarshal finality provider BTC PK hex: %v", err)
 	}
 
-	if !k.BTCStakingKeeper.HasFinalityProvider(ctx, *fpBTCPK) {
+	if !k.BTCStakingKeeper.BabylonFinalityProviderExists(ctx, *fpBTCPK) {
 		return nil, bstypes.ErrFpNotFound
 	}
 

--- a/x/finality/keeper/grpc_query_test.go
+++ b/x/finality/keeper/grpc_query_test.go
@@ -68,7 +68,7 @@ func FuzzFinalityProviderPowerAtHeight(f *testing.F) {
 		keeper.SetVotingPower(ctx, fp.BtcPk.MustMarshal(), randomHeight, randomPower)
 
 		// happy case
-		bk.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Any()).Return(true).Times(1)
+		bk.EXPECT().BabylonFinalityProviderExists(gomock.Any(), gomock.Any()).Return(true).Times(1)
 		req1 := &types.QueryFinalityProviderPowerAtHeightRequest{
 			FpBtcPkHex: fp.BtcPk.MarshalHex(),
 			Height:     randomHeight,
@@ -79,7 +79,7 @@ func FuzzFinalityProviderPowerAtHeight(f *testing.F) {
 
 		// case where the voting power store is not updated in
 		// the given height
-		bk.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Any()).Return(true).Times(1)
+		bk.EXPECT().BabylonFinalityProviderExists(gomock.Any(), gomock.Any()).Return(true).Times(1)
 		requestHeight := randomHeight + datagen.RandomInt(r, 10) + 1
 		req2 := &types.QueryFinalityProviderPowerAtHeightRequest{
 			FpBtcPkHex: fp.BtcPk.MarshalHex(),
@@ -89,7 +89,7 @@ func FuzzFinalityProviderPowerAtHeight(f *testing.F) {
 		require.ErrorIs(t, err, types.ErrVotingPowerTableNotUpdated)
 
 		// case where the given fp pk does not exist
-		bk.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Any()).Return(false).Times(1)
+		bk.EXPECT().BabylonFinalityProviderExists(gomock.Any(), gomock.Any()).Return(false).Times(1)
 		randPk, err := datagen.GenRandomBIP340PubKey(r)
 		require.NoError(t, err)
 		req3 := &types.QueryFinalityProviderPowerAtHeightRequest{
@@ -110,7 +110,7 @@ func FuzzFinalityProviderCurrentVotingPower(f *testing.F) {
 
 		// Setup keeper and context
 		bk := types.NewMockBTCStakingKeeper(ctrl)
-		bk.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+		bk.EXPECT().BabylonFinalityProviderExists(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		keeper, ctx := testkeeper.FinalityKeeper(t, bk, nil, nil)
 
 		// random finality provider
@@ -406,7 +406,7 @@ func FuzzListPubRandCommit(f *testing.F) {
 		fp, err := datagen.GenRandomFinalityProviderWithBTCSK(r, sk, "", "")
 		require.NoError(t, err)
 		bsKeeper.EXPECT().GetFinalityProvider(gomock.Any(), gomock.Eq(bip340PK.MustMarshal())).Return(fp, nil).AnyTimes()
-		bsKeeper.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Eq(bip340PK.MustMarshal())).Return(true).AnyTimes()
+		bsKeeper.EXPECT().BabylonFinalityProviderExists(gomock.Any(), gomock.Eq(bip340PK.MustMarshal())).Return(true).AnyTimes()
 		cKeeper.EXPECT().GetEpoch(gomock.Any()).Return(&epochingtypes.Epoch{EpochNumber: 1}).AnyTimes()
 
 		commitCtxString := signingcontext.FpRandCommitContextV0(ctx.ChainID(), fKeeper.ModuleAddress())

--- a/x/finality/keeper/msg_server.go
+++ b/x/finality/keeper/msg_server.go
@@ -289,8 +289,10 @@ func (ms msgServer) CommitPubRandList(goCtx context.Context, req *types.MsgCommi
 		return nil, types.ErrInvalidPubRand.Wrap("empty finality provider public key")
 	}
 	fpBTCPKBytes := req.FpBtcPk.MustMarshal()
-	if !ms.BTCStakingKeeper.HasFinalityProvider(ctx, fpBTCPKBytes) {
-		return nil, bstypes.ErrFpNotFound.Wrapf("the finality provider with BTC PK %v is not registered", fpBTCPKBytes)
+
+	isBabylonFp := ms.BTCStakingKeeper.BabylonFinalityProviderExists(ctx, fpBTCPKBytes)
+	if !isBabylonFp {
+		return nil, types.ErrInvalidPubRand.Wrapf("the finality provider with BTC PK %s is not a Babylon Genesis finality provider", req.FpBtcPk.MarshalHex())
 	}
 
 	signingContext := signingcontext.FpRandCommitContextV0(ctx.ChainID(), ms.finalityModuleAddress)

--- a/x/finality/keeper/msg_server_test.go
+++ b/x/finality/keeper/msg_server_test.go
@@ -66,7 +66,7 @@ func FuzzCommitPubRandList(f *testing.F) {
 		signingContext := signingcontext.FpRandCommitContextV0(ctx.ChainID(), fKeeper.ModuleAddress())
 
 		// Case 1: fail if the finality provider is not registered
-		bsKeeper.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(false).Times(1)
+		bsKeeper.EXPECT().BabylonFinalityProviderExists(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(false).Times(1)
 		startHeight := datagen.RandomInt(r, 10)
 		numPubRand := uint64(200)
 		_, msg, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, signingContext, startHeight, numPubRand)
@@ -74,7 +74,7 @@ func FuzzCommitPubRandList(f *testing.F) {
 		_, err = ms.CommitPubRandList(ctx, msg)
 		require.Error(t, err)
 		// register the finality provider
-		bsKeeper.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(true).AnyTimes()
+		bsKeeper.EXPECT().BabylonFinalityProviderExists(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(true).AnyTimes()
 
 		// Case 2: commit a list of <minPubRand pubrand and it should fail
 		startHeight = datagen.RandomInt(r, 10)
@@ -159,7 +159,7 @@ func FuzzAddFinalitySig(f *testing.F) {
 		fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(btcPK)
 		fpBTCPKBytes := fpBTCPK.MustMarshal()
 		require.NoError(t, err)
-		bsKeeper.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(true).AnyTimes()
+		bsKeeper.EXPECT().BabylonFinalityProviderExists(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(true).AnyTimes()
 
 		// set committed epoch num
 		committedEpochNum := datagen.GenRandomEpochNum(r) + 1
@@ -383,7 +383,7 @@ func TestVoteForConflictingHashShouldRetrieveEvidenceAndSlash(t *testing.T) {
 	fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(btcPK)
 	fpBTCPKBytes := fpBTCPK.MustMarshal()
 	require.NoError(t, err)
-	bsKeeper.EXPECT().HasFinalityProvider(gomock.Any(),
+	bsKeeper.EXPECT().BabylonFinalityProviderExists(gomock.Any(),
 		gomock.Eq(fpBTCPKBytes)).Return(true).AnyTimes()
 	cKeeper.EXPECT().GetEpoch(gomock.Any()).Return(&epochingtypes.Epoch{EpochNumber: 1}).AnyTimes()
 	cKeeper.EXPECT().GetLastFinalizedEpoch(gomock.Any()).Return(uint64(1)).AnyTimes()
@@ -478,7 +478,7 @@ func TestDoNotPanicOnNilProof(t *testing.T) {
 	fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(btcPK)
 	fpBTCPKBytes := fpBTCPK.MustMarshal()
 	require.NoError(t, err)
-	bsKeeper.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(true).AnyTimes()
+	bsKeeper.EXPECT().BabylonFinalityProviderExists(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(true).AnyTimes()
 
 	// set committed epoch num
 	committedEpochNum := datagen.GenRandomEpochNum(r) + 1

--- a/x/finality/keeper/power_dist_change.go
+++ b/x/finality/keeper/power_dist_change.go
@@ -215,7 +215,7 @@ func (k Keeper) ProcessAllPowerDistUpdateEvents(
 				// add the BTC delegation to each multi-staked finality provider
 				for _, fpBTCPK := range btcDel.FpBtcPkList {
 					fpBTCPKHex := fpBTCPK.MarshalHex()
-					if !k.BTCStakingKeeper.HasFinalityProvider(ctx, fpBTCPK) {
+					if !k.BTCStakingKeeper.BabylonFinalityProviderExists(ctx, fpBTCPK) {
 						// This is a consumer FP rather than Babylon FP, skip it
 						continue
 					}
@@ -415,7 +415,7 @@ func (k Keeper) processPowerDistUpdateEventUnbond(
 ) {
 	for _, fpBTCPK := range btcDel.FpBtcPkList {
 		fpBTCPKHex := fpBTCPK.MarshalHex()
-		if !k.BTCStakingKeeper.HasFinalityProvider(ctx, fpBTCPK) {
+		if !k.BTCStakingKeeper.BabylonFinalityProviderExists(ctx, fpBTCPK) {
 			// This is a consumer FP rather than Babylon FP, skip it
 			continue
 		}

--- a/x/finality/keeper/power_table.go
+++ b/x/finality/keeper/power_table.go
@@ -52,7 +52,7 @@ func (k Keeper) GetCurrentVotingPower(ctx context.Context, fpBTCPK []byte) (uint
 	storeAtHeight := prefix.NewStore(store, sdk.Uint64ToBigEndian(lastHeight))
 
 	// if the finality provider is not known, return 0 voting power
-	if !k.BTCStakingKeeper.HasFinalityProvider(ctx, fpBTCPK) {
+	if !k.BTCStakingKeeper.BabylonFinalityProviderExists(ctx, fpBTCPK) {
 		return lastHeight, 0
 	}
 

--- a/x/finality/types/expected_keepers.go
+++ b/x/finality/types/expected_keepers.go
@@ -16,6 +16,7 @@ type BTCStakingKeeper interface {
 	GetBTCHeightAtBabylonHeight(ctx context.Context, babylonHeight uint64) uint32
 	GetFinalityProvider(ctx context.Context, fpBTCPK []byte) (*bstypes.FinalityProvider, error)
 	HasFinalityProvider(ctx context.Context, fpBTCPK []byte) bool
+	BabylonFinalityProviderExists(ctx context.Context, fpBTCPK []byte) bool
 	SlashFinalityProvider(ctx context.Context, fpBTCPK []byte) error
 	PropagateFPSlashingToConsumers(ctx context.Context, fpBTCSK *btcec.PrivateKey) error
 	GetBTCDelegation(ctx context.Context, stakingTxHashStr string) (*bstypes.BTCDelegation, error)

--- a/x/finality/types/mocked_keepers.go
+++ b/x/finality/types/mocked_keepers.go
@@ -38,6 +38,20 @@ func (m *MockBTCStakingKeeper) EXPECT() *MockBTCStakingKeeperMockRecorder {
 	return m.recorder
 }
 
+// BabylonFinalityProviderExists mocks base method.
+func (m *MockBTCStakingKeeper) BabylonFinalityProviderExists(ctx context.Context, fpBTCPK []byte) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BabylonFinalityProviderExists", ctx, fpBTCPK)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BabylonFinalityProviderExists indicates an expected call of BabylonFinalityProviderExists.
+func (mr *MockBTCStakingKeeperMockRecorder) BabylonFinalityProviderExists(ctx, fpBTCPK interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BabylonFinalityProviderExists", reflect.TypeOf((*MockBTCStakingKeeper)(nil).BabylonFinalityProviderExists), ctx, fpBTCPK)
+}
+
 // BtcDelHasCovenantQuorums mocks base method.
 func (m *MockBTCStakingKeeper) BtcDelHasCovenantQuorums(ctx context.Context, btcDel *types.BTCDelegation, quorum uint32) (bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
In some places check `k.BTCStakingKeeper.HasFinalityProvider` was overloaded to mean `is is Babylon finality provider` as only `BTCStakingKeeper` stored Babylon finality providers.  https://github.com/babylonlabs-io/babylon/pull/1300 moved all finality providers to the `BTCStakingKeeper`, so the overloaded check lost its power. 

This could lead to non-Babylon finality providers registering randomness and gaining voting power on Babylon genesis.