### PR TITLE
fix: register tokenfactory bindings

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -85,6 +85,7 @@ import (
 	ibccallbacks "github.com/cosmos/ibc-go/v10/modules/apps/callbacks"
 	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v10/modules/core/keeper"
+	tokenfactorybindings "github.com/strangelove-ventures/tokenfactory/x/tokenfactory/bindings"
 	tokenfactorykeeper "github.com/strangelove-ventures/tokenfactory/x/tokenfactory/keeper"
 	tokenfactorytypes "github.com/strangelove-ventures/tokenfactory/x/tokenfactory/types"
 
@@ -511,6 +512,15 @@ func (ak *AppKeepers) InitKeepers(
 			&ak.CheckpointingKeeper,
 			&ak.BTCLightClientKeeper,
 			&ak.ZoneConciergeKeeper,
+		),
+		wasmOpts...,
+	)
+
+	// Register custom plugins for the tokenfactory module
+	wasmOpts = append(
+		tokenfactorybindings.RegisterCustomPlugins(
+			ak.BankKeeper,
+			&ak.TokenFactoryKeeper,
 		),
 		wasmOpts...,
 	)


### PR DESCRIPTION
attempted to interact with the tokenfactory module via cosmwasm and got this response:

> failed to execute message; message index: 0: dispatch: no handler found: unknown message from the contract [CosmWasm/wasmd@v0.54.1/x/wasm/keeper/handler_plugin.go:173]

<del>i'm not sure if this is the best way to register the module, nor if it actually works correctly as i cannot test it locally, but the node builds and runs 👍</del> update: i was able to get a babylond localnet running and can confirm this works correctly