### PR TITLE
chore: ci/cd: Run builds on forked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '**'
+  pull_request:
+    branches:
+      - '**'
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}


### PR DESCRIPTION
The current setting will only run builds for branches created directly on the babylon repo. Adding this condition ensures that CI will run on all PRs, originating either from this repo or forked ones.