### PR TITLE
migration of FP data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ remove send restrictions
 BSNs to incentive reward tracker.
 - [#1390](https://github.com/babylonlabs-io/babylon/pull/1390) Add additional gas
 cost per multi-staked finality provider
+- [#1394](https://github.com/babylonlabs-io/babylon/pull/1394) Add migration for
+FP data
 
 
 ### Bug fixes

--- a/x/btcstaking/keeper/finality_providers.go
+++ b/x/btcstaking/keeper/finality_providers.go
@@ -372,21 +372,3 @@ func (k Keeper) UpdateFinalityProviderCommission(goCtx context.Context, newCommi
 	return nil
 }
 
-// migrateBabylonFinalityProviders migrates all existing Babylon finality providers
-// to to have the BSN ID set to Babylon's chain ID. It also indexes the finality
-// provider in the BSN index store.
-func (k Keeper) migrateBabylonFinalityProviders(ctx sdk.Context) {
-	babylonBSNID := ctx.ChainID()
-
-	store := k.finalityProviderStore(ctx)
-	iter := store.Iterator(nil, nil)
-	defer iter.Close()
-
-	for ; iter.Valid(); iter.Next() {
-		var fp types.FinalityProvider
-		k.cdc.MustUnmarshal(iter.Value(), &fp)
-		fp.BsnId = babylonBSNID
-		k.SetFinalityProvider(ctx, &fp)
-		k.bsnIndexFinalityProvider(ctx, &fp)
-	}
-}

--- a/x/btcstaking/keeper/genesis.go
+++ b/x/btcstaking/keeper/genesis.go
@@ -26,7 +26,7 @@ func (k Keeper) InitGenesis(ctx context.Context, gs types.GenesisState) error {
 	}
 
 	for _, fp := range gs.FinalityProviders {
-		k.setFinalityProvider(ctx, fp)
+		k.SetFinalityProvider(ctx, fp)
 	}
 
 	for _, btcDel := range gs.BtcDelegations {

--- a/x/btcstaking/keeper/migrations.go
+++ b/x/btcstaking/keeper/migrations.go
@@ -36,3 +36,22 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 		m.keeper.migrateBabylonFinalityProviders,
 	)
 }
+
+// migrateBabylonFinalityProviders migrates all existing Babylon finality providers
+// to to have the BSN ID set to Babylon's chain ID. It also indexes the finality
+// provider in the BSN index store.
+func (k Keeper) migrateBabylonFinalityProviders(ctx sdk.Context) {
+	babylonBSNID := ctx.ChainID()
+
+	store := k.finalityProviderStore(ctx)
+	iter := store.Iterator(nil, nil)
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		var fp types.FinalityProvider
+		k.cdc.MustUnmarshal(iter.Value(), &fp)
+		fp.BsnId = babylonBSNID
+		k.SetFinalityProvider(ctx, &fp)
+		k.bsnIndexFinalityProvider(ctx, &fp)
+	}
+}

--- a/x/btcstaking/keeper/migrations.go
+++ b/x/btcstaking/keeper/migrations.go
@@ -33,5 +33,6 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 			return nil
 		},
 		m.keeper.IndexAllowedMultiStakingTransaction,
+		m.keeper.migrateBabylonFinalityProviders,
 	)
 }

--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -110,7 +110,7 @@ func (ms msgServer) EditFinalityProvider(goCtx context.Context, req *types.MsgEd
 	// all good, update the finality provider and set back
 	fp.Description = req.Description
 
-	ms.setFinalityProvider(goCtx, fp)
+	ms.SetFinalityProvider(goCtx, fp)
 
 	// notify subscriber
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/btcstaking/migrations/v2/store.go
+++ b/x/btcstaking/migrations/v2/store.go
@@ -20,6 +20,7 @@ func MigrateStore(
 	c codec.BinaryCodec,
 	modifyParams func(ctx context.Context, p *types.Params) error,
 	indexTxHash func(ctx context.Context, txHash *chainhash.Hash),
+	migrateBabylonFinalityProviders func(ctx sdk.Context),
 ) error {
 	if err := migrateParams(ctx, s, c, modifyParams); err != nil {
 		return err
@@ -28,6 +29,8 @@ func MigrateStore(
 	if err := indexAllowedMultiStakingTxs(ctx, indexTxHash); err != nil {
 		return err
 	}
+
+	migrateBabylonFinalityProviders(ctx)
 
 	return nil
 }

--- a/x/btcstaking/migrations/v2/store_test.go
+++ b/x/btcstaking/migrations/v2/store_test.go
@@ -22,6 +22,8 @@ func TestMigrateStore(t *testing.T) {
 		storeKey              = storetypes.NewKVStoreKey(types.StoreKey)
 		btcStakingKeeper, ctx = keepertest.BTCStakingKeeperWithStoreKey(t, storeKey, nil, nil, nil)
 		paramsVersions        = 10
+		testChainID           = "test-chain-id"
+		nFps                  = 10
 	)
 
 	for i := 0; i < paramsVersions; i++ {
@@ -32,9 +34,17 @@ func TestMigrateStore(t *testing.T) {
 		require.NoError(t, btcStakingKeeper.SetParams(ctx, params))
 	}
 
+	var generatedRandomFps []*types.FinalityProvider
+	for i := 0; i < nFps; i++ {
+		fp, err := datagen.GenRandomFinalityProvider(r, "", "")
+		require.NoError(t, err)
+		btcStakingKeeper.SetFinalityProvider(ctx, fp)
+		generatedRandomFps = append(generatedRandomFps, fp)
+	}
+
 	// Perform migration
 	m := keeper.NewMigrator(*btcStakingKeeper)
-	require.NoError(t, m.Migrate1to2(ctx))
+	require.NoError(t, m.Migrate1to2(ctx.WithChainID(testChainID)))
 
 	// after migration, all params should have max finality providers set to 1
 	for i := 0; i < paramsVersions; i++ {
@@ -50,5 +60,22 @@ func TestMigrateStore(t *testing.T) {
 		allowed, err := btcStakingKeeper.IsMultiStakingAllowed(ctx, txHash)
 		require.NoError(t, err)
 		require.True(t, allowed, "tx hash %s should be indexed in the allow list", txHash.String())
+	}
+
+	// check if all finality providers have the BSN ID set to the test chain ID
+	for _, fp := range generatedRandomFps {
+		fp, err := btcStakingKeeper.GetFinalityProvider(ctx, fp.BtcPk.MustMarshal())
+		require.NoError(t, err)
+		require.Equal(t, testChainID, fp.BsnId)
+	}
+
+	// check if all finality providers are properly indexed
+	fpResp, err := btcStakingKeeper.FinalityProviders(ctx, &types.QueryFinalityProvidersRequest{
+		BsnId: testChainID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, len(generatedRandomFps), len(fpResp.FinalityProviders))
+	for _, fp := range fpResp.FinalityProviders {
+		require.Equal(t, testChainID, fp.BsnId)
 	}
 }

--- a/x/btcstkconsumer/keeper/msg_server.go
+++ b/x/btcstkconsumer/keeper/msg_server.go
@@ -34,6 +34,12 @@ func (ms msgServer) RegisterConsumer(goCtx context.Context, req *types.MsgRegist
 		return nil, err
 	}
 
+	sdkCtx := sdk.UnwrapSDKContext(goCtx)
+
+	if req.ConsumerId == sdkCtx.ChainID() {
+		return nil, types.ErrInvalidConsumerIDs.Wrap("consumer id cannot be the same as the Babylon Genesis chain id")
+	}
+
 	var consumerType types.ConsumerType
 	if len(req.RollupFinalityContractAddress) > 0 {
 		// this is a rollup consumer

--- a/x/btcstkconsumer/types/consumer_register.go
+++ b/x/btcstkconsumer/types/consumer_register.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"unicode/utf8"
 
 	"cosmossdk.io/math"
 )
@@ -9,6 +10,9 @@ import (
 func (m *MsgRegisterConsumer) ValidateBasic() error {
 	if len(m.ConsumerId) == 0 {
 		return fmt.Errorf("ConsumerId must be non-empty")
+	}
+	if !utf8.ValidString(m.ConsumerId) {
+		return fmt.Errorf("ConsumerId must be valid UTF-8")
 	}
 	if len(m.ConsumerName) == 0 {
 		return fmt.Errorf("ConsumerName must be non-empty")


### PR DESCRIPTION
Closes: https://github.com/babylonlabs-io/babylon/issues/1306

After multi-staking launch, finality providers that secure Babylon should be identifies by Babylon Genesis chain-id. To achieve that for pre-upgrade FPs migration is needed.

This pr:
- adds proper migration for FP data
- add migration to add Babylon FPs to newly added index
- add additional validation that `ConsumerId` is valid utf8 string. This is needed as the field is used as key in index.
- add additional validation that registered `ConsumerId` is not Babylon chain id.