### PR TITLE
doc: zone concierge IBC channel doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#1463](https://github.com/babylonlabs-io/babylon/pull/1463) doc: zone concierge IBC channel doc
 - [#1437](https://github.com/babylonlabs-io/babylon/pull/1437) Send base headers before the fallback cases.
 - [#1429](https://github.com/babylonlabs-io/babylon/pull/1429) Send base header if no headers were sent previously.
 - [#1406](https://github.com/babylonlabs-io/babylon/pull/1406) Use `collections` for KV store in `x/btcstkconsumer`.

--- a/docs/ibc-zoneconcierge-setup.md
+++ b/docs/ibc-zoneconcierge-setup.md
@@ -1,0 +1,72 @@
+# Zone Concierge IBC Channel
+
+- [Overview](#overview)
+- [IBC Packets](#ibc-packets)
+- [IBC Channel Information](#ibc-channel-information)
+- [Useful Documentations](#useful-documentations)
+
+This page provides instructions for setting up a Zone Conceirge IBC channel
+between Babylon's [ZoneConcierge module](../x/zoneconcierge/) and [Cosmos BSN
+contracts](https://github.com/babylonlabs-io/cosmos-bsn-contracts) deployed on
+Cosmos Bitcoin Supercharged Networks (BSNs) for BTC staking integration.
+
+## Overview
+
+The Zone Concierge module is an IBC-enabled module. It serves as Babylon's
+gateway for communicating with BSNs. It leverages the IBC protocol to
+synchronise information and provide BTC staking security for BSNs. For detailed
+technical information of the Zone Concierge module, refer to
+[`x/zoneconcierge/README.md`](../x/zoneconcierge/README.md).
+
+## IBC Packets
+
+The Zone Concierge module involves the following IBC packets.
+
+**Outbound Packets (Babylon → BSN):**
+
+- `BTCHeaders` - BTC headers
+- `BTCTimestamp` - BTC timestamps for BTC headers
+- `BTCStakingIBCPacket` - BTC staking events related to BSNs
+
+**Inbound Packets (BSN → Babylon):**
+
+- `BSNSlashingIBCPacket` - Slashing evidences from BSNs
+- `BSNBaseBTCHeaderIBCPacket` - Base BTC headers from BSNs
+
+For detailed protocol buffer definitions, see
+[`proto/babylon/zoneconcierge/v1/packet.proto`](../proto/babylon/zoneconcierge/v1/packet.proto).
+
+## IBC Channel Information
+
+The IBC communication uses the following configuration:
+
+| Setting | Value |
+|---------|-------|
+| **Port at Babylon** | `zoneconcierge` |
+| **Port at BSN** | `wasm.$BABYLON_CONTRACT_ADDRESS` |
+| **Channel Ordering** | `ORDERED` |
+| **Protocol Version** | `zoneconcierge-1` |
+
+Here `$BABYLON_CONTRACT_ADDRESS` is the address of the [Babylon
+contract](https://github.com/babylonlabs-io/cosmos-bsn-contracts/tree/main/contracts/babylon)
+deployed on the Cosmos BSN.
+
+**BSN Registration Requirement:** A Cosmos BSN must be registered in Babylon's
+consumer registry via governance proposal before establishing an associated Zone
+Concierge IBC channel. The consumer ID is the BSN's IBC light client ID on
+Babylon. The IBC relayer operator can verify the registration with `babylond
+query btcstkconsumer registered-consumer $IBC_LIGHT_CLIENT_ID` before creating a
+Zone Concierge IBC channel. Creating an IBC channel associated with an
+unregistered BSN will be rejected by the Zone Concierge module. Please refer to
+[x/btcstkconsumer/README.md](../x/btcstkconsumer/README.md) for more details.
+
+## Useful Documentations
+
+- [./ibc-relayer.md](./ibc-relayer.md) - An IBC relayer guide for Babylon
+- [Babylon ZoneConcierge Module](../x/zoneconcierge/README.md) - Zone Concierge
+  module documentation
+- [Cosmos BSN Contracts](https://github.com/babylonlabs-io/cosmos-bsn-contracts)
+  - Cosmos BSN contracts implementation
+- [BSN Integration
+  Deployment](https://github.com/babylonlabs-io/babylon-bsn-integration-deployment)
+  - Integration examples and artifacts

--- a/docs/ibc-zoneconcierge-setup.md
+++ b/docs/ibc-zoneconcierge-setup.md
@@ -52,7 +52,7 @@ contract](https://github.com/babylonlabs-io/cosmos-bsn-contracts/tree/main/contr
 deployed on the Cosmos BSN.
 
 **BSN Registration Requirement:** A Cosmos BSN must be registered in Babylon's
-consumer registry via governance proposal before establishing an associated Zone
+consumer registry before establishing an associated Zone
 Concierge IBC channel. The consumer ID is the BSN's IBC light client ID on
 Babylon. The IBC relayer operator can verify the registration with `babylond
 query btcstkconsumer registered-consumer $IBC_LIGHT_CLIENT_ID` before creating a

--- a/docs/ibc-zoneconcierge-setup.md
+++ b/docs/ibc-zoneconcierge-setup.md
@@ -52,12 +52,12 @@ contract](https://github.com/babylonlabs-io/cosmos-bsn-contracts/tree/main/contr
 deployed on the Cosmos BSN.
 
 **BSN Registration Requirement:** A Cosmos BSN must be registered in Babylon's
-consumer registry before establishing an associated Zone
-Concierge IBC channel. The consumer ID is the BSN's IBC light client ID on
-Babylon. The IBC relayer operator can verify the registration with `babylond
-query btcstkconsumer registered-consumer $IBC_LIGHT_CLIENT_ID` before creating a
-Zone Concierge IBC channel. Creating an IBC channel associated with an
-unregistered BSN will be rejected by the Zone Concierge module. Please refer to
+consumer registry before establishing an associated Zone Concierge IBC channel.
+The consumer ID is the BSN's IBC light client ID on Babylon. The IBC relayer
+operator can verify the registration with `babylond query btcstkconsumer
+registered-consumer $IBC_LIGHT_CLIENT_ID` before creating a Zone Concierge IBC
+channel. Creating an IBC channel associated with an unregistered BSN will be
+rejected by the Zone Concierge module. Please refer to
 [x/btcstkconsumer/README.md](../x/btcstkconsumer/README.md) for more details.
 
 ## Useful Documentations

--- a/docs/ibc-zoneconcierge-setup.md
+++ b/docs/ibc-zoneconcierge-setup.md
@@ -5,7 +5,7 @@
 - [IBC Channel Information](#ibc-channel-information)
 - [Useful Documentations](#useful-documentations)
 
-This page provides instructions for setting up a Zone Conceirge IBC channel
+This page provides instructions for setting up a Zone Concierge IBC channel
 between Babylon's [ZoneConcierge module](../x/zoneconcierge/) and [Cosmos BSN
 contracts](https://github.com/babylonlabs-io/cosmos-bsn-contracts) deployed on
 Cosmos Bitcoin Supercharged Networks (BSNs) for BTC staking integration.

--- a/docs/ibc-zoneconcierge-setup.md
+++ b/docs/ibc-zoneconcierge-setup.md
@@ -53,18 +53,26 @@ deployed on the Cosmos BSN.
 
 **BSN Registration Requirement:** A Cosmos BSN must be registered in Babylon
 Genesis' consumer registry before establishing an associated Zone Concierge IBC
-channel; otherwise, *creating an IBC channel associated with an unregistered
-BSN will be rejected by the Zone Concierge module.*
+channel; otherwise, *creating an IBC channel associated with an unregistered BSN
+will be rejected by the Zone Concierge module.*
 
-That is, to integrate with Babylon Genesis as a Cosmos BSN, one needs to do the following in order:
+That is, to integrate with Babylon Genesis as a Cosmos BSN, one needs to do the
+following in order:
 
-- Create an IBC light client or choose an IBC light client that is actively relayed for this Cosmos chain inside Babylon Genesis chain.
-- Register the Cosmos chain as a BSN with the identifier being the ID of the IBC light client.
-  - If Babylon Genesis chain specifies permissionless integration, the registration can be done through `babylond tx btcstkconsumer register-consumer <consumer-id> <name> <description>` where `<consumer-id>` has to be the IBC light client's ID.
-  - If Babylon Genesis chain specifies permissioned integrtaion, the registration requires a governance proposal.
-  - Please refer to
-[x/btcstkconsumer/README.md](../x/btcstkconsumer/README.md) for more details about registering a Cosmos chain as a BSN.
-- Establish the Zone Concierge IBC channel on top of the IBC light client associated with the registered BSN.
+- Create an IBC light client or choose an IBC light client that is actively
+  relayed for this Cosmos chain inside Babylon Genesis chain.
+- Register the Cosmos chain as a BSN with the identifier being the ID of the IBC
+  light client.
+  - If Babylon Genesis chain specifies permissionless integration, the
+    registration can be done through `babylond tx btcstkconsumer
+    register-consumer <consumer-id> <name> <description>` where `<consumer-id>`
+    has to be the IBC light client's ID.
+  - If Babylon Genesis chain specifies permissioned integrtaion, the
+    registration requires a governance proposal.
+  - Please refer to [x/btcstkconsumer/README.md](../x/btcstkconsumer/README.md)
+for more details about registering a Cosmos chain as a BSN.
+- Establish the Zone Concierge IBC channel on top of the IBC light client
+  associated with the registered BSN.
 
 ## Useful Documentations
 

--- a/docs/ibc-zoneconcierge-setup.md
+++ b/docs/ibc-zoneconcierge-setup.md
@@ -6,14 +6,14 @@
 - [Useful Documentations](#useful-documentations)
 
 This page provides instructions for setting up a Zone Concierge IBC channel
-between Babylon's [ZoneConcierge module](../x/zoneconcierge/) and [Cosmos BSN
-contracts](https://github.com/babylonlabs-io/cosmos-bsn-contracts) deployed on
-Cosmos Bitcoin Supercharged Networks (BSNs) for BTC staking integration.
+between Babylon Genesis' [ZoneConcierge module](../x/zoneconcierge/) and [Cosmos
+BSN contracts](https://github.com/babylonlabs-io/cosmos-bsn-contracts) deployed
+on Cosmos Bitcoin Supercharged Networks (BSNs) for BTC staking integration.
 
 ## Overview
 
-The Zone Concierge module is an IBC-enabled module. It serves as Babylon's
-gateway for communicating with BSNs. It leverages the IBC protocol to
+The Zone Concierge module is an IBC-enabled module. It serves as Babylon
+Genesis' gateway for communicating with BSNs. It leverages the IBC protocol to
 synchronise information and provide BTC staking security for BSNs. For detailed
 technical information of the Zone Concierge module, refer to
 [`x/zoneconcierge/README.md`](../x/zoneconcierge/README.md).
@@ -22,13 +22,13 @@ technical information of the Zone Concierge module, refer to
 
 The Zone Concierge module involves the following IBC packets.
 
-**Outbound Packets (Babylon → BSN):**
+**Outbound Packets (Babylon Genesis → BSN):**
 
 - `BTCHeaders` - BTC headers
 - `BTCTimestamp` - BTC timestamps for BTC headers
 - `BTCStakingIBCPacket` - BTC staking events related to BSNs
 
-**Inbound Packets (BSN → Babylon):**
+**Inbound Packets (BSN → Babylon Genesis):**
 
 - `BSNSlashingIBCPacket` - Slashing evidences from BSNs
 - `BSNBaseBTCHeaderIBCPacket` - Base BTC headers from BSNs
@@ -42,7 +42,7 @@ The IBC communication uses the following configuration:
 
 | Setting | Value |
 |---------|-------|
-| **Port at Babylon** | `zoneconcierge` |
+| **Port at Babylon Genesis** | `zoneconcierge` |
 | **Port at BSN** | `wasm.$BABYLON_CONTRACT_ADDRESS` |
 | **Channel Ordering** | `ORDERED` |
 | **Protocol Version** | `zoneconcierge-1` |
@@ -51,13 +51,13 @@ Here `$BABYLON_CONTRACT_ADDRESS` is the address of the [Babylon
 contract](https://github.com/babylonlabs-io/cosmos-bsn-contracts/tree/main/contracts/babylon)
 deployed on the Cosmos BSN.
 
-**BSN Registration Requirement:** A Cosmos BSN must be registered in Babylon's
-consumer registry before establishing an associated Zone Concierge IBC channel.
-The consumer ID is the BSN's IBC light client ID on Babylon. The IBC relayer
-operator can verify the registration with `babylond query btcstkconsumer
-registered-consumer $IBC_LIGHT_CLIENT_ID` before creating a Zone Concierge IBC
-channel. Creating an IBC channel associated with an unregistered BSN will be
-rejected by the Zone Concierge module. Please refer to
+**BSN Registration Requirement:** A Cosmos BSN must be registered in Babylon
+Genesis' consumer registry before establishing an associated Zone Concierge IBC
+channel. The consumer ID is the BSN's IBC light client ID on Babylon Genesis.
+The IBC relayer operator can verify the registration with `babylond query
+btcstkconsumer registered-consumer $IBC_LIGHT_CLIENT_ID` before creating a Zone
+Concierge IBC channel. Creating an IBC channel associated with an unregistered
+BSN will be rejected by the Zone Concierge module. Please refer to
 [x/btcstkconsumer/README.md](../x/btcstkconsumer/README.md) for more details.
 
 ## Useful Documentations

--- a/docs/ibc-zoneconcierge-setup.md
+++ b/docs/ibc-zoneconcierge-setup.md
@@ -53,12 +53,18 @@ deployed on the Cosmos BSN.
 
 **BSN Registration Requirement:** A Cosmos BSN must be registered in Babylon
 Genesis' consumer registry before establishing an associated Zone Concierge IBC
-channel. The consumer ID is the BSN's IBC light client ID on Babylon Genesis.
-The IBC relayer operator can verify the registration with `babylond query
-btcstkconsumer registered-consumer $IBC_LIGHT_CLIENT_ID` before creating a Zone
-Concierge IBC channel. Creating an IBC channel associated with an unregistered
-BSN will be rejected by the Zone Concierge module. Please refer to
-[x/btcstkconsumer/README.md](../x/btcstkconsumer/README.md) for more details.
+channel; otherwise, *creating an IBC channel associated with an unregistered
+BSN will be rejected by the Zone Concierge module.*
+
+That is, to integrate with Babylon Genesis as a Cosmos BSN, one needs to do the following in order:
+
+- Create an IBC light client or choose an IBC light client that is actively relayed for this Cosmos chain inside Babylon Genesis chain.
+- Register the Cosmos chain as a BSN with the identifier being the ID of the IBC light client.
+  - If Babylon Genesis chain specifies permissionless integration, the registration can be done through `babylond tx btcstkconsumer register-consumer <consumer-id> <name> <description>` where `<consumer-id>` has to be the IBC light client's ID.
+  - If Babylon Genesis chain specifies permissioned integrtaion, the registration requires a governance proposal.
+  - Please refer to
+[x/btcstkconsumer/README.md](../x/btcstkconsumer/README.md) for more details about registering a Cosmos chain as a BSN.
+- Establish the Zone Concierge IBC channel on top of the IBC light client associated with the registered BSN.
 
 ## Useful Documentations
 

--- a/x/zoneconcierge/README.md
+++ b/x/zoneconcierge/README.md
@@ -12,8 +12,8 @@ consumers) via IBC packets:
 - **BTC Headers:** Babylon Genesis forwards the BTC headers maintained by its
   BTC light client to BSNs.  
   This allows BSNs to maintain an image of the Bitcoin chain and verify
-  information included in it through inclusion proofs (e.g., an inclusion
-  proof of a BTC Timestamp containing BSN headers).
+  information included in it through inclusion proofs (e.g., an inclusion proof
+  of a BTC Timestamp containing BSN headers).
 - **BTC Timestamps:** When a Babylon Genesis epoch is finalized, the Babylon
   Genesis chain sends BTC timestamps to BSNs. Each BTC timestamp contains:
   - The latest BSN header that was checkpointed in the finalised epoch
@@ -60,7 +60,9 @@ consumers) via IBC packets:
 
 ## State
 
-The Zone Concierge module maintains a simplified header indexing system with the following KV stores. Consumer registration is handled by the `btcstkconsumer` module.
+The Zone Concierge module maintains a simplified header indexing system with the
+following KV stores. Consumer registration is handled by the `btcstkconsumer`
+module.
 
 ### Parameters
 
@@ -84,16 +86,16 @@ message Params {
 ### LatestEpochHeaders
 
 The [latest epoch headers storage](./keeper/epoch_header_indexer.go) maintains
-the most recent header received from each BSN during the current epoch. The
-key is the BSN's `ConsumerID`, and the value is an `IndexedHeader` object.
-This storage is cleared at the end of each epoch when headers are moved to the
+the most recent header received from each BSN during the current epoch. The key
+is the BSN's `ConsumerID`, and the value is an `IndexedHeader` object. This
+storage is cleared at the end of each epoch when headers are moved to the
 finalized storage.
 
 ### FinalizedEpochHeaders
 
 The [finalized epoch headers storage](./keeper/epoch_header_indexer.go)
-maintains headers that have been finalized for each BSN and epoch. The key
-is the epoch number plus the BSN's `ConsumerID`, and the value is an
+maintains headers that have been finalized for each BSN and epoch. The key is
+the epoch number plus the BSN's `ConsumerID`, and the value is an
 `IndexedHeaderWithProof` object. The `IndexedHeaderWithProof` contains both the
 header metadata and the inclusion proof.
 
@@ -137,10 +139,10 @@ message IndexedHeaderWithProof {
 
 ### BSNBTCState
 
-The [BSN BTC state storage](./keeper/consumer_btc_state.go) maintains
-unified BTC synchronization state for each BSN. The key is the BSN's
-`ConsumerID`, and the value is a `BSNBTCState` object that tracks the base
-BTC header and last sent BTC header segment for each BSN.
+The [BSN BTC state storage](./keeper/consumer_btc_state.go) maintains unified
+BTC synchronization state for each BSN. The key is the BSN's `ConsumerID`, and
+the value is a `BSNBTCState` object that tracks the base BTC header and last
+sent BTC header segment for each BSN.
 
 ```protobuf
 // BSNBTCState stores per-BSN BTC synchronization state
@@ -213,7 +215,8 @@ executes as follows:
 1. Extract the header info and the client state from the message
 2. Determine if the header is on a fork by checking if the client is frozen
 3. Call `HandleHeaderWithValidCommit` to process the header
-4. Check if the BSN is registered through the `btcstkconsumer` module and is a Cosmos BSN; if not, ignore the header
+4. Check if the BSN is registered through the `btcstkconsumer` module and is a
+   Cosmos BSN; if not, ignore the header
 5. Create an `IndexedHeader` with the header metadata and Babylon context
 6. If the header is not on a fork and is newer than the existing latest header,
    update the latest epoch header for the BSN
@@ -234,7 +237,8 @@ The `AfterEpochEnds` hook is triggered when an epoch is ended, i.e., the last
 block in this epoch has been committed by CometBFT. Upon `AfterEpochEnds`, the
 Zone Concierge will:
 
-1. Record all current latest epoch headers as finalized headers for the completed epoch
+1. Record all current latest epoch headers as finalized headers for the
+   completed epoch
 2. Clear the latest epoch headers to prepare for the next epoch
 
 ### Recording proofs upon `AfterRawCheckpointSealed`
@@ -357,20 +361,20 @@ with Babylon Genesis' BTC light client.
 The header selection logic now uses per-BSN BTC state tracking with the
 following enhanced rules:
 
-- **BSN-specific BTC state**: Each BSN has its own `BSNBTCState`
-  that tracks the base BTC header and last sent segment
-- **No BSN base header**: Falls back to sending the last `w+1` BTC headers
-  from the tip (where `w` is the confirmation depth parameter)
-- **BSN base header exists but no headers sent**: Send headers from the
-  BSN's base header to the current tip
+- **BSN-specific BTC state**: Each BSN has its own `BSNBTCState` that tracks the
+  base BTC header and last sent segment
+- **No BSN base header**: Falls back to sending the last `w+1` BTC headers from
+  the tip (where `w` is the confirmation depth parameter)
+- **BSN base header exists but no headers sent**: Send headers from the BSN's
+  base header to the current tip
 - **Headers previously sent**: Send headers from the child of the most recent
   valid header in the last sent segment to the current tip
 - **Reorg detection**: If no header from the last sent segment is still valid
-  (indicating a Bitcoin reorg), fall back to sending from the BSN's base
-  header to the current tip
+  (indicating a Bitcoin reorg), fall back to sending from the BSN's base header
+  to the current tip
 
-This per-BSN approach provides better efficiency and reorg handling
-compared to the previous global broadcast strategy.
+This per-BSN approach provides better efficiency and reorg handling compared to
+the previous global broadcast strategy.
 
 ### Broadcasting BTC Staking Events
 
@@ -412,8 +416,8 @@ of inbound packets.
 
 The [inbound packet structure](proto/babylon/zoneconcierge/v1/packet.proto) is
 defined as follows. Currently, the Zone Concierge module handles one type of
-incoming packet: `BSNSlashingIBCPacket`. This packet type allows BSNs to
-report slashing evidence for finality providers.
+incoming packet: `BSNSlashingIBCPacket`. This packet type allows BSNs to report
+slashing evidence for finality providers.
 
 ```protobuf
 // InboundPacket represents packets received by Babylon from other chains
@@ -479,16 +483,9 @@ events.
 
 ### IBC Communication Protocol
 
-| Configuration Type | Value |
-|-------------------|--------|
-| Port | `zoneconcierge` |
-| Ordering | `ORDERED` |
-| Version | `zoneconcierge-1` |
-
-| Packet Direction | Types |
-|-----------------|-------|
-| Outbound | `BTCHeaders`, `BTCTimestamp`, `BTCStakingConsumerEvent` |
-| Inbound | `BSNSlashingIBCPacket` |
+Please refer to
+[docs/ibc-zoneconcierge-setup.md](../../docs/ibc-zoneconcierge-setup.md) for the
+setup of Zone Concierge IBC channel.
 
 ### Relaying BTC Headers
 


### PR DESCRIPTION
Resolves https://github.com/babylonlabs-io/pm/issues/459

This PR provides doc for setting up a Zone Concierge IBC channel. 

As a first version, the doc is kept minimal, in the sense that it focuses on unique characteristics of zone concierge IBC channel, and refers to external docs for Zone Concierge module, BTC staking, IBC relayer operation guides, etc..