### PR TITLE
add limit for ibc packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,8 @@ adjustment
 covenant signature to the events
 - [#1447](https://github.com/babylonlabs-io/babylon/pull/1447) Add multi-staking allow-list data for e2e tests
 - [#1453](https://github.com/babylonlabs-io/babylon/pull/1453) fix: inactive FP event on full unbonding
+- [#1476](https://github.com/babylonlabs-io/babylon/pull/1476) fix: Add limit for
+IBC packet size
 
 ## v2.2.0
 

--- a/test/e2e/configurer/current.go
+++ b/test/e2e/configurer/current.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/babylonlabs-io/babylon/v3/app"
 	"github.com/babylonlabs-io/babylon/v3/test/e2e/configurer/chain"
 	"github.com/babylonlabs-io/babylon/v3/test/e2e/containers"
 	"github.com/babylonlabs-io/babylon/v3/test/e2e/initialization"
@@ -53,6 +54,8 @@ func (cb *CurrentBranchConfigurer) ConfigureChain(chainConfig *chain.Config) err
 		time.Duration(chainConfig.ExpeditedVotingPeriod*1000000000),
 		0,
 		chainConfig.BTCHeaders,
+		app.DefaultGasLimit,
+		nil,
 	)
 	if err != nil {
 		return err

--- a/test/e2e/initialization/chain/main.go
+++ b/test/e2e/initialization/chain/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/babylonlabs-io/babylon/v3/app"
 	"github.com/babylonlabs-io/babylon/v3/test/e2e/initialization"
 	btclighttypes "github.com/babylonlabs-io/babylon/v3/x/btclightclient/types"
 )
@@ -54,7 +55,17 @@ func main() {
 	}
 
 	btcHeaders := btcHeaderFromFlag(btcHeadersBytesHexStr)
-	createdChain, err := initialization.InitChain(chainId, dataDir, valConfig, votingPeriod, expeditedVotingPeriod, forkHeight, btcHeaders)
+	createdChain, err := initialization.InitChain(
+		chainId,
+		dataDir,
+		valConfig,
+		votingPeriod,
+		expeditedVotingPeriod,
+		forkHeight,
+		btcHeaders,
+		app.DefaultGasLimit,
+		nil,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/test/e2e/initialization/config.go
+++ b/test/e2e/initialization/config.go
@@ -276,7 +276,7 @@ func initGenesis(
 		return fmt.Errorf("failed to update tokenfactory genesis state: %w", err)
 	}
 
-	err = updateModuleGenesis(appGenState, btcstktypes.ModuleName, &btcstktypes.GenesisState{}, updupdateBtcStakingGenesisFn(startingBtcStakingParams))
+	err = updateModuleGenesis(appGenState, btcstktypes.ModuleName, &btcstktypes.GenesisState{}, updateBtcStakingGenesisFn(startingBtcStakingParams))
 	if err != nil {
 		return fmt.Errorf("failed to update rate limiter genesis state: %w", err)
 	}
@@ -372,12 +372,7 @@ func updateFinalityGenesis(finalityGenState *finalitytypes.GenesisState) {
 	finalityGenState.Params.SignedBlocksWindow = 300
 }
 
-func updateBtcStakingGenesis(btcStakingGenState *btcstktypes.GenesisState) {
-	// bump max finality providers to 5 in e2e and replay tests
-	btcStakingGenState.Params[0].MaxFinalityProviders = 5
-}
-
-func updupdateBtcStakingGenesisFn(p *StartingBtcStakingParams) func(*btcstktypes.GenesisState) {
+func updateBtcStakingGenesisFn(p *StartingBtcStakingParams) func(*btcstktypes.GenesisState) {
 	return func(gen *btcstktypes.GenesisState) {
 		gen.Params[0].MaxFinalityProviders = 5
 

--- a/test/e2e/initialization/init.go
+++ b/test/e2e/initialization/init.go
@@ -14,18 +14,20 @@ func InitChain(
 	votingPeriod, expeditedVotingPeriod time.Duration,
 	forkHeight int,
 	btcHeaders []*btclighttypes.BTCHeaderInfo,
+	gasLimit int64,
+	startingBtcStakingParams *StartingBtcStakingParams,
 ) (*Chain, error) {
 	chain := new(id, dataDir)
 
 	for _, nodeConfig := range nodeConfigs {
-		newNode, err := newNode(chain, nodeConfig)
+		newNode, err := newNode(chain, nodeConfig, gasLimit)
 		if err != nil {
 			return nil, err
 		}
 		chain.nodes = append(chain.nodes, newNode)
 	}
 
-	if err := initGenesis(chain, votingPeriod, expeditedVotingPeriod, forkHeight, btcHeaders); err != nil {
+	if err := initGenesis(chain, votingPeriod, expeditedVotingPeriod, forkHeight, btcHeaders, startingBtcStakingParams); err != nil {
 		return nil, err
 	}
 

--- a/test/e2e/initialization/init_test.go
+++ b/test/e2e/initialization/init_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/babylonlabs-io/babylon/v3/app"
 	"github.com/babylonlabs-io/babylon/v3/test/e2e/initialization"
 )
 
@@ -50,7 +51,8 @@ func TestChainInit(t *testing.T) {
 		dataDir, err = os.MkdirTemp("", "bbn-e2e-testnet-test")
 	)
 
-	chain, err := initialization.InitChain(id, dataDir, nodeConfigs, time.Second*3, time.Second, forkHeight, nil)
+	chain, err := initialization.InitChain(
+		id, dataDir, nodeConfigs, time.Second*3, time.Second, forkHeight, nil, app.DefaultGasLimit, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, chain.ChainMeta.DataDir, dataDir)

--- a/test/e2e/initialization/node.go
+++ b/test/e2e/initialization/node.go
@@ -54,7 +54,7 @@ type internalNode struct {
 	isValidator  bool
 }
 
-func newNode(chain *internalChain, nodeConfig *NodeConfig) (*internalNode, error) {
+func newNode(chain *internalChain, nodeConfig *NodeConfig, gasLimit int64) (*internalNode, error) {
 	node := &internalNode{
 		chain:       chain,
 		moniker:     fmt.Sprintf("%s-node-%s", chain.chainMeta.Id, nodeConfig.Name),
@@ -68,7 +68,7 @@ func newNode(chain *internalChain, nodeConfig *NodeConfig) (*internalNode, error
 		return nil, err
 	}
 	// generate genesis files
-	if err := node.init(); err != nil {
+	if err := node.init(gasLimit); err != nil {
 		return nil, err
 	}
 	if err := node.createNodeKey(); err != nil {
@@ -302,7 +302,7 @@ func (n *internalNode) getAppGenesis() (*genutiltypes.AppGenesis, error) {
 	return appGenesis, nil
 }
 
-func (n *internalNode) init() error {
+func (n *internalNode) init(gasLimit int64) error {
 	if err := n.createConfig(); err != nil {
 		return err
 	}
@@ -330,7 +330,7 @@ func (n *internalNode) init() error {
 	appGenesis.Consensus = &genutiltypes.ConsensusGenesis{
 		Params: cmttypes.DefaultConsensusParams(),
 	}
-	appGenesis.Consensus.Params.Block.MaxGas = babylonApp.DefaultGasLimit
+	appGenesis.Consensus.Params.Block.MaxGas = gasLimit
 	appGenesis.Consensus.Params.ABCI.VoteExtensionsEnableHeight = babylonApp.DefaultVoteExtensionsEnableHeight
 
 	if err = genutil.ExportGenesisFile(appGenesis, config.GenesisFile()); err != nil {

--- a/test/replay/driver.go
+++ b/test/replay/driver.go
@@ -78,16 +78,16 @@ var validatorConfig = &initialization.NodeConfig{
 const (
 	chainID         = initialization.ChainAID
 	testPartSize    = 65536
-	defaultGasLimit = 750000
+	defaultGasLimit = 1000000
 	defaultFee      = 500000
 	epochLength     = 10
 	blkTime         = time.Second * 5
 )
 
 var (
-	defaultFeeCoin                 = sdk.NewCoin("ubbn", sdkmath.NewInt(defaultFee))
-	BtcParams                      = &chaincfg.SimNetParams
-	covenantSKs, _, CovenantQuorum = bstypes.DefaultCovenantCommittee()
+	defaultFeeCoin                   = sdk.NewCoin("ubbn", sdkmath.NewInt(defaultFee))
+	BtcParams                        = &chaincfg.SimNetParams
+	covenantSKs, pks, CovenantQuorum = bstypes.LargeDefaultCovenantCommittee()
 )
 
 func getGenDoc(
@@ -172,6 +172,12 @@ func NewBabylonAppDriver(
 		expeditedVotingPeriod,   // expedited
 		1,
 		[]*btclighttypes.BTCHeaderInfo{},
+		// 300M is gas limit set for testnet and mainnet
+		300_000_000,
+		&initialization.StartingBtcStakingParams{
+			CovenantCommittee: bbn.NewBIP340PKsFromBTCPKs(pks),
+			CovenantQuorum:    CovenantQuorum,
+		},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, chain)

--- a/test/replay/driver.go
+++ b/test/replay/driver.go
@@ -610,6 +610,11 @@ func (d *BabylonAppDriver) GenerateBlocksUntilHeight(untilBlock uint64) {
 	}
 }
 
+func (d *BabylonAppDriver) GenerateNewBlockReturnResults() []*abci.ExecTxResult {
+	response := d.GenerateNewBlock()
+	return response.TxResults
+}
+
 func (d *BabylonAppDriver) GenerateNewBlockAssertExecutionSuccessWithResults() []*abci.ExecTxResult {
 	response := d.GenerateNewBlock()
 

--- a/test/replay/multistaking_test.go
+++ b/test/replay/multistaking_test.go
@@ -6,10 +6,13 @@ import (
 	"testing"
 	"time"
 
-	bstypes "github.com/babylonlabs-io/babylon/v3/x/btcstaking/types"
-	ibctmtypes "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
-
 	bbn "github.com/babylonlabs-io/babylon/v3/types"
+	bstypes "github.com/babylonlabs-io/babylon/v3/x/btcstaking/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	connectiontypes "github.com/cosmos/ibc-go/v10/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	ibctmtypes "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
 	"github.com/stretchr/testify/require"
 )
 
@@ -203,4 +206,146 @@ func TestAdditionalGasCostForMultiStakedDelegation(t *testing.T) {
 	// We cannot use equal as multistaked delegations use more gas by default, though
 	// the difference is small enough so that `minimalGasDifference` is much larger than it
 	require.GreaterOrEqual(t, txResults2[0].GasUsed-txResults1[0].GasUsed, int64(minimalGasDifference))
+}
+
+func (d *BabylonAppDriver) packVerifiedDelegations() []*abci.ExecTxResult {
+	block := d.IncludeVerifiedStakingTxInBTC(0)
+	acitvationMsgs := blockWithProofsToActivationMessages(block, d.GetDriverAccountAddress())
+
+	for i, msg := range acitvationMsgs {
+		var gaslimit uint64
+
+		if i < 5 {
+			gaslimit = 1_100_000
+		} else if i < 10 {
+			gaslimit = 2_000_000
+		} else if i < 15 {
+			gaslimit = 2_700_000
+		} else if i < 20 {
+			gaslimit = 3_500_000
+		} else if i < 25 {
+			gaslimit = 4_400_000
+		} else if i < 30 {
+			gaslimit = 5_100_000
+		} else if i < 35 {
+			gaslimit = 6_000_000
+		} else if i < 40 {
+			gaslimit = 7_000_000
+		} else if i < 45 {
+			gaslimit = 7_500_000
+		} else if i < 50 {
+			gaslimit = 8_500_000
+		} else {
+			gaslimit = 10_000_000
+		}
+
+		d.SendTxWithMessagesSuccess(d.t, d.SenderInfo, gaslimit, defaultFeeCoin, msg)
+		d.IncSeq()
+	}
+
+	return d.GenerateNewBlockAssertExecutionSuccessWithResults()
+}
+
+func (driver *BabylonAppDriver) InitCosmosConsumer(ctx sdk.Context, consumerID string) {
+	driver.App.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID, &ibctmtypes.ClientState{})
+
+	driver.App.IBCKeeper.ConnectionKeeper.SetConnection(
+		ctx, consumerID, connectiontypes.ConnectionEnd{
+			ClientId: consumerID,
+		},
+	)
+
+	driver.App.IBCKeeper.ChannelKeeper.SetChannel(
+		ctx, "zoneconcierge", consumerID, channeltypes.Channel{
+			State:          channeltypes.OPEN,
+			ConnectionHops: []string{consumerID},
+		},
+	)
+
+}
+
+func TestCheckGasMulitstaking2FpsFailedPacket(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	driverTempDir := t.TempDir()
+	replayerTempDir := t.TempDir()
+	driver := NewBabylonAppDriver(r, t, driverTempDir, replayerTempDir)
+
+	const consumerID1 = "consumer1"
+	const consumerID2 = "consumer2"
+	const consumerID3 = "consumer3"
+
+	// 1. Set up mock IBC clients for each consumer before registering consumers
+	ctx := driver.App.BaseApp.NewContext(false)
+	driver.InitCosmosConsumer(ctx, consumerID1)
+	driver.InitCosmosConsumer(ctx, consumerID2)
+	driver.InitCosmosConsumer(ctx, consumerID3)
+
+	driver.GenerateNewBlock()
+
+	covSender := driver.CreateCovenantSender()
+
+	// 2. Register consumers
+	consumer1 := driver.RegisterConsumer(r, consumerID1)
+	consumer2 := driver.RegisterConsumer(r, consumerID2)
+	consumer3 := driver.RegisterConsumer(r, consumerID3)
+	// Create a Babylon FP (registered without consumer ID)
+	babylonFp := driver.CreateNFinalityProviderAccounts(1)[0]
+	babylonFp.RegisterFinalityProvider("")
+
+	babylonFp1 := driver.CreateNFinalityProviderAccounts(1)[0]
+	babylonFp1.RegisterFinalityProvider("")
+	driver.GenerateNewBlockAssertExecutionSuccess()
+
+	// 3. Create finality providers for each consumer
+	fp1s := []*FinalityProvider{
+		// Create 2 FPs for consumer1
+		driver.CreateFinalityProviderForConsumer(consumer1),
+		driver.CreateFinalityProviderForConsumer(consumer1),
+	}
+	require.NotEmpty(t, fp1s)
+	fp2 := driver.CreateFinalityProviderForConsumer(consumer2)
+	fp3 := driver.CreateFinalityProviderForConsumer(consumer3)
+	require.NotNil(t, fp3)
+	// Generate blocks to process registrations
+	driver.GenerateNewBlockAssertExecutionSuccess()
+	staker := driver.CreateNStakerAccounts(1)[0]
+
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+	driver.SendAndVerifyNDelegations(t, staker, covSender, []*bbn.BIP340PubKey{babylonFp1.BTCPublicKey(), fp2.BTCPublicKey()}, 5)
+
+	results := driver.packVerifiedDelegations()
+	require.NotEmpty(t, results)
+
+}
+
+func (driver *BabylonAppDriver) SendAndVerifyNDelegations(
+	t *testing.T,
+	staker *Staker,
+	covSender *CovenantSender,
+	keys []*bbn.BIP340PubKey,
+	n int,
+) {
+
+	for i := 0; i < n; i++ {
+		staker.CreatePreApprovalDelegation(
+			keys,
+			1000,
+			100000000,
+		)
+	}
+
+	driver.GenerateNewBlockAssertExecutionSuccess()
+	covSender.SendCovenantSignatures()
+	driver.GenerateNewBlockAssertExecutionSuccess()
 }

--- a/test/replay/multistaking_test.go
+++ b/test/replay/multistaking_test.go
@@ -220,27 +220,28 @@ func (d *BabylonAppDriver) packVerifiedDelegations() []*abci.ExecTxResult {
 	for i, msg := range acitvationMsgs {
 		var gaslimit uint64
 
-		if i < 5 {
+		switch {
+		case i < 5:
 			gaslimit = 1_100_000
-		} else if i < 10 {
+		case i < 10:
 			gaslimit = 2_000_000
-		} else if i < 15 {
+		case i < 15:
 			gaslimit = 2_700_000
-		} else if i < 20 {
+		case i < 20:
 			gaslimit = 3_500_000
-		} else if i < 25 {
+		case i < 25:
 			gaslimit = 4_400_000
-		} else if i < 30 {
+		case i < 30:
 			gaslimit = 5_100_000
-		} else if i < 35 {
+		case i < 35:
 			gaslimit = 6_000_000
-		} else if i < 40 {
+		case i < 40:
 			gaslimit = 7_000_000
-		} else if i < 45 {
+		case i < 45:
 			gaslimit = 7_500_000
-		} else if i < 50 {
+		case i < 50:
 			gaslimit = 8_500_000
-		} else {
+		default:
 			gaslimit = 10_000_000
 		}
 
@@ -266,10 +267,9 @@ func (driver *BabylonAppDriver) InitCosmosConsumer(ctx sdk.Context, consumerID s
 			ConnectionHops: []string{consumerID},
 		},
 	)
-
 }
 
-func TestTooBigMulistakingPacket(t *testing.T) {
+func TestTooBigMultistakingPacket(t *testing.T) {
 	t.Parallel()
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	driverTempDir := t.TempDir()
@@ -350,7 +350,6 @@ func (driver *BabylonAppDriver) SendAndVerifyNDelegations(
 	keys []*bbn.BIP340PubKey,
 	n int,
 ) {
-
 	for i := 0; i < n; i++ {
 		staker.CreatePreApprovalDelegation(
 			keys,

--- a/test/replay/replayer.go
+++ b/test/replay/replayer.go
@@ -1,8 +1,9 @@
 package replay
 
 import (
-	appparams "github.com/babylonlabs-io/babylon/v3/app/params"
 	"testing"
+
+	appparams "github.com/babylonlabs-io/babylon/v3/app/params"
 
 	"cosmossdk.io/log"
 	babylonApp "github.com/babylonlabs-io/babylon/v3/app"

--- a/x/btcstaking/keeper/btc_delegations.go
+++ b/x/btcstaking/keeper/btc_delegations.go
@@ -218,7 +218,7 @@ func (k Keeper) addCovenantSigsToBTCDelegation(
 	parsedUnbondingSlashingAdaptorSignatures []asig.AdaptorSignature,
 	stakeExpansionTxSig *bbn.BIP340Signature,
 	btcTipHeight uint32,
-) {
+) error {
 	btcDel := delInfo.Delegation
 	var quorumPreviousStk uint32
 	if btcDel.IsStakeExpansion() {
@@ -273,7 +273,9 @@ func (k Keeper) addCovenantSigsToBTCDelegation(
 			k.addPowerDistUpdateEvent(ctx, btcTipHeight, activeEvent)
 
 			// notify consumer chains about the active BTC delegation
-			k.notifyConsumersOnActiveBTCDel(ctx, btcDel)
+			if err := k.notifyConsumersOnActiveBTCDel(ctx, btcDel); err != nil {
+				return err
+			}
 		} else {
 			quorumReachedEvent := types.NewCovenantQuorumReachedEvent(
 				btcDel,
@@ -285,9 +287,11 @@ func (k Keeper) addCovenantSigsToBTCDelegation(
 			}
 		}
 	}
+
+	return nil
 }
 
-func (k Keeper) notifyConsumersOnActiveBTCDel(ctx context.Context, btcDel *types.BTCDelegation) {
+func (k Keeper) notifyConsumersOnActiveBTCDel(ctx context.Context, btcDel *types.BTCDelegation) error {
 	// get consumer ids of only non-Babylon finality providers
 	multiStakedFPConsumerIDs, err := k.multiStakedFPConsumerIDs(ctx, btcDel.FpBtcPkList)
 	if err != nil {
@@ -299,9 +303,11 @@ func (k Keeper) notifyConsumersOnActiveBTCDel(ctx context.Context, btcDel *types
 	}
 	for _, consumerID := range multiStakedFPConsumerIDs {
 		if err := k.AddBTCStakingConsumerEvent(ctx, consumerID, consumerEvent); err != nil {
-			panic(fmt.Errorf("failed to add active BTC delegation event: %w", err))
+			return fmt.Errorf("failed to add active BTC delegation event: %w", err)
 		}
 	}
+
+	return nil
 }
 
 // btcUndelegate adds the signature of the unbonding tx signed by the staker
@@ -312,12 +318,12 @@ func (k Keeper) btcUndelegate(
 	u *types.DelegatorUnbondingInfo,
 	stakeSpendingTx []byte,
 	proof *types.InclusionProof,
-) {
+) error {
 	btcDel.BtcUndelegation.DelegatorUnbondingInfo = u
 	k.setBTCDelegation(ctx, btcDel)
 
 	if !btcDel.HasInclusionProof() {
-		return
+		return nil
 	}
 
 	// notify subscriber about this unbonded BTC delegation
@@ -343,9 +349,10 @@ func (k Keeper) btcUndelegate(
 	}
 	for _, consumerID := range multiStakedFPConsumerIDs {
 		if err = k.AddBTCStakingConsumerEvent(ctx, consumerID, consumerEvent); err != nil {
-			panic(fmt.Errorf("failed to add active BTC delegation event: %w", err))
+			return fmt.Errorf("failed to add unbonded BTC delegation event: %w", err)
 		}
 	}
+	return nil
 }
 
 // isAllowListEnabled checks if the allow list is enabled at the given height

--- a/x/btcstaking/keeper/btc_staking_consumer_events.go
+++ b/x/btcstaking/keeper/btc_staking_consumer_events.go
@@ -57,7 +57,7 @@ func (k Keeper) AddBTCStakingConsumerEvents(ctx context.Context, consumerID stri
 
 	eventsBytes := k.cdc.MustMarshal(&packet)
 
-	if len(eventsBytes) >= types.MaxBtcStakingPacketSize {
+	if len(eventsBytes) > types.MaxBtcStakingPacketSize {
 		return fmt.Errorf("IBC packet size is too large %d bytes. Cannot create more staking events in the block", len(eventsBytes))
 	}
 

--- a/x/btcstaking/keeper/btc_staking_consumer_events.go
+++ b/x/btcstaking/keeper/btc_staking_consumer_events.go
@@ -56,6 +56,11 @@ func (k Keeper) AddBTCStakingConsumerEvents(ctx context.Context, consumerID stri
 	}
 
 	eventsBytes := k.cdc.MustMarshal(&packet)
+
+	if len(eventsBytes) >= types.MaxBtcStakingPacketSize {
+		return fmt.Errorf("IBC packet size is too large %d bytes. Cannot create more staking events in the block", len(eventsBytes))
+	}
+
 	store.Set(storeKey, eventsBytes)
 
 	return nil

--- a/x/btcstaking/keeper/inclusion_proof.go
+++ b/x/btcstaking/keeper/inclusion_proof.go
@@ -192,7 +192,9 @@ func (k Keeper) AddBTCDelegationInclusionProof(
 	)
 
 	// notify consumer chains about the active BTC delegation
-	k.notifyConsumersOnActiveBTCDel(ctx, btcDel)
+	if err := k.notifyConsumersOnActiveBTCDel(ctx, btcDel); err != nil {
+		return err
+	}
 
 	k.addPowerDistUpdateEvent(ctx, timeInfo.TipHeight, activeEvent)
 

--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -371,7 +371,7 @@ func (ms msgServer) AddCovenantSigs(goCtx context.Context, req *types.MsgAddCove
 
 	// All is fine add received signatures to the BTC delegation and BtcUndelegation
 	// and emit corresponding events
-	ms.addCovenantSigsToBTCDelegation(
+	if err := ms.addCovenantSigsToBTCDelegation(
 		ctx,
 		delInfo,
 		req.Pk,
@@ -380,7 +380,9 @@ func (ms msgServer) AddCovenantSigs(goCtx context.Context, req *types.MsgAddCove
 		parsedUnbondingSlashingAdaptorSignatures,
 		req.StakeExpansionTxSig,
 		btcTip.Height,
-	)
+	); err != nil {
+		return nil, err
+	}
 
 	// at this point, the covenant signatures are verified and are not duplicated.
 	// Thus, we can safely consider this message as refundable
@@ -648,7 +650,9 @@ func (ms msgServer) BTCUndelegate(goCtx context.Context, req *types.MsgBTCUndele
 
 	// all good, add the signature to BTC delegation's undelegation
 	// and set back
-	ms.btcUndelegate(ctx, btcDel, delegatorUnbondingInfo, req.StakeSpendingTx, req.StakeSpendingTxInclusionProof)
+	if err := ms.btcUndelegate(ctx, btcDel, delegatorUnbondingInfo, req.StakeSpendingTx, req.StakeSpendingTxInclusionProof); err != nil {
+		return nil, err
+	}
 
 	// At this point, the unbonding signature is verified.
 	// Thus, we can safely consider this message as refundable

--- a/x/btcstaking/types/params.go
+++ b/x/btcstaking/types/params.go
@@ -7,6 +7,8 @@ import (
 
 	"cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
+	"github.com/babylonlabs-io/babylon/v3/btcstaking"
+	bbn "github.com/babylonlabs-io/babylon/v3/types"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -15,10 +17,8 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
 	"gopkg.in/yaml.v2"
-
-	"github.com/babylonlabs-io/babylon/v3/btcstaking"
-	bbn "github.com/babylonlabs-io/babylon/v3/types"
 )
 
 const (
@@ -30,6 +30,10 @@ const (
 	// because every covenant committee member must create separate Adaptor Signature
 	// for each FP in the multi-staked delegation.
 	GasCostPerMultiStakedFP = 7000
+
+	// MaxBtcStakingPacketSize is the maximum size of the BTC staking packet
+	// 144 bytes is a buffer for OutboundPacket packet wrapper
+	MaxBtcStakingPacketSize = channeltypes.MaximumPayloadsSize - 144
 )
 
 var _ paramtypes.ParamSet = (*Params)(nil)

--- a/x/btcstaking/types/params.go
+++ b/x/btcstaking/types/params.go
@@ -47,6 +47,19 @@ func DefaultCovenantCommittee() ([]*btcec.PrivateKey, []*btcec.PublicKey, uint32
 	return sks, pks, 3
 }
 
+// LargeDefaultCovenantCommittee deterministically generates a covenant committee
+// with 9 members and quorum size of 6
+func LargeDefaultCovenantCommittee() ([]*btcec.PrivateKey, []*btcec.PublicKey, uint32) {
+	sks, pks := []*btcec.PrivateKey{}, []*btcec.PublicKey{}
+	for i := uint8(0); i < 9; i++ {
+		skBytes := tmhash.Sum([]byte{i})
+		sk, pk := btcec.PrivKeyFromBytes(skBytes)
+		sks = append(sks, sk)
+		pks = append(pks, pk)
+	}
+	return sks, pks, 6
+}
+
 func defaultSlashingPkScript() []byte {
 	// 20 bytes
 	pkHash := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}


### PR DESCRIPTION
Currently in case of IBC packet being to large, Babylon waould just fail to send it and later delete it:
- [error](https://github.com/babylonlabs-io/babylon/blob/v3.0.0-snapshot.250731/x/zoneconcierge/keeper/ibc_packet.go#L80)
- [deletion](https://github.com/babylonlabs-io/babylon/blob/v3.0.0-snapshot.250731/x/zoneconcierge/keeper/ibc_packet_btc_staking_consumer_event.go#L94)

This behaviour would lead to incorrect accounting of voting power on consumer chain.

Given that creating such packet requires tightly packing delegation activations in one Babylon block, it could on exploited by malicious validator and has low chance of being triggered in normal operations.

This PR:
- adds test showing that it is in fact possible to create invalid too big packet
- adds fail safe limit making it impossible to produce such packet

