### PR TITLE
fix: restore proofConsumerHeaderInEpoch allocation removed in PR #1387

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,7 @@ adjustment
 covenant signature to the events
 - [#1447](https://github.com/babylonlabs-io/babylon/pull/1447) Add multi-staking allow-list data for e2e tests
 - [#1453](https://github.com/babylonlabs-io/babylon/pull/1453) fix: inactive FP event on full unbonding
+- [#1491](https://github.com/babylonlabs-io/babylon/pull/1491) fix: restore `proofConsumerHeaderInEpoch` allocation removed
 
 ## v2.2.0
 

--- a/x/zoneconcierge/keeper/ibc_packet_btc_timestamp.go
+++ b/x/zoneconcierge/keeper/ibc_packet_btc_timestamp.go
@@ -127,7 +127,7 @@ func (k Keeper) createBTCTimestamp(
 		epochOfHeader := finalizedHeader.Header.BabylonEpoch
 		if epochOfHeader == epochNum {
 			btcTimestamp.Header = finalizedHeader.Header
-			// Note: proof is now included in the IndexedHeaderWithProof, not separately
+			btcTimestamp.Proof.ProofConsumerHeaderInEpoch = finalizedHeader.Proof
 		}
 	} else {
 		k.Logger(sdkCtx).Debug("no finalized header for consumer",


### PR DESCRIPTION
Closes: #1454

### Summary

Restore the assignment of `finalizedHeader.Proof` to `btcTimestamp.Proof.ProofConsumerHeaderInEpoch`, which was removed in PR [#1387](https://github.com/babylonlabs-io/babylon/pull/1387/files#diff-3fd29e097d45a0f042e4cf72768de74dc135d28987c48ec04133f761c88d2d16L131-R130) during recent refactoring.

This change addresses the issue where `proof_consumer_header_in_epoch` field in IBC packets is sometimes empty, as reported in #1454.


### Context & Root Cause
- While investigating issue #1454, it was suspected that the refactoring in PR [#1387](https://github.com/babylonlabs-io/babylon/pull/1387/files#diff-3fd29e097d45a0f042e4cf72768de74dc135d28987c48ec04133f761c88d2d16L131-R130) accidentally removed the assignment:
`btcTimestamp.Proof.ProofConsumerHeaderInEpoch = finalizedHeader.Proof`

https://github.com/babylonlabs-io/babylon/blob/4eae05aa7800b7ae99e42e79ee0b9806f6e14b98/x/zoneconcierge/keeper/ibc_packet_btc_timestamp.go#L114-L130


- The likely cause is a misunderstanding of the data structure:
- It seems that `FinalizedHeader(IndexedHeaderWithProof)` was mistakenly assumed to have a unified proof field in the header.
- However, `ProofConsumerHeaderInEpoch` still requires an explicit assignment of finalizedHeader.Proof to ensure inclusion proofs are correctly propagated.

c.c. @Vvaradinov If my assumption or fix is incorrect, please feel free to leave a comment and correct me


**Note:**
_Ideally, integration and e2e tests should be added together to verify this fix.
However, the e2e tests currently reside in the babylon-sdk, and the babylon repository does not have corresponding e2e or integration test setups.
Due to the current phase timeline, I’m prioritizing this urgent bugfix and deferring test additions for now._