### PR TITLE
fix: typos in documentation files

### DIFF
--- a/x/btccheckpoint/types/msgs.go
+++ b/x/btccheckpoint/types/msgs.go
@@ -73,7 +73,7 @@ func ParseTwoProofs(
 		checkpointData = append(checkpointData, data)
 	}
 
-	// at this point we know we have two correctly formated babylon op return transactions
+	// at this point we know we have two correctly formatted babylon op return transactions
 	// we need to check if parts match
 	rawCkptData, err := txformat.ConnectParts(txformat.CurrentVersion, checkpointData[0], checkpointData[1])
 

--- a/x/incentive/README.md
+++ b/x/incentive/README.md
@@ -234,7 +234,7 @@ is used to store this structure.
 message FinalityProviderHistoricalRewards {
   // The cumulative rewards of that finality provider per sat until that period
   // This coins will aways increase the value, never be reduced due to keep
-  // acumulation and when the cumulative rewards will be used to distribute
+  // accumulation and when the cumulative rewards will be used to distribute
   // rewards, 2 periods will be loaded, calculate the difference and multiplied
   // by the total sat amount delegated
   // https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47

--- a/x/incentive/keeper/reward_tracker_test.go
+++ b/x/incentive/keeper/reward_tracker_test.go
@@ -393,7 +393,7 @@ func FuzzCheckAddFinalityProviderRewardsForBtcDelegations(f *testing.F) {
 
 		coinsAdded := datagen.GenRandomCoins(r)
 		coinsAddedWithDecimals := coinsAdded.MulInt(types.DecimalRewards)
-		// add rewards without initiliaze should error out
+		// add rewards without initialize should error out
 		err := k.AddFinalityProviderRewardsForBtcDelegations(ctx, fp, coinsAdded)
 		require.EqualError(t, err, types.ErrFPCurrentRewardsNotFound.Error())
 


### PR DESCRIPTION
Corrected `formated` → `formatted`
Corrected `acumulation` → `accumulation`
Corrected `initiliaze` → `initialize`