### PR TITLE
Add expired status type to the query btc-delegations cli command help message

### DIFF
--- a/x/btcstaking/types/btc_delegation.go
+++ b/x/btcstaking/types/btc_delegation.go
@@ -39,7 +39,7 @@ func NewBTCDelegationStatusFromString(statusStr string) (BTCDelegationStatus, er
 	case "any":
 		return BTCDelegationStatus_ANY, nil
 	default:
-		return -1, fmt.Errorf("invalid status string; should be one of {pending, verified, active, unbonded, any}")
+		return -1, fmt.Errorf("invalid status string; should be one of {pending, verified, active, unbonded, expired, any}")
 	}
 }
 


### PR DESCRIPTION
Context:
```
> babylond q btcstaking btc-delegations --count-total expir
Error: invalid status string; should be one of {pending, verified, active, unbonded, any}
```

Error text is not showing the expired status as a possible value when querying `btc-delegations` on the `btcstaking` module.