### PR TITLE
fix: remove duplicate COMMIT variable definition in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ help:
 
 PACKAGES_NOSIMULATION=$(shell go list ./... | grep -v '/simulation')
 PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
-COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
 BINDIR ?= $(GOPATH)/bin
 PROJECT_NAME ?= babylon


### PR DESCRIPTION
Remove duplicate COMMIT variable assignment that was defined twice in the Makefile (lines 32 and 42). Keep the definition that is logically grouped with the BRANCH variable for better organization.

This cleanup improves maintainability and follows make best practices by avoiding variable redefinition.