### PR TITLE
fix(zoneconcierge): refactor for optimize ibc channel, client related io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ to allow empty coins in fp current rewards.
 - [#1485](https://github.com/babylonlabs-io/babylon/pull/1485) Add channel check on consumer FP creation
 - [#1516](https://github.com/babylonlabs-io/babylon/pull/1516) Remove `zoneconcierge` port ID from state
 - [#1492](https://github.com/babylonlabs-io/babylon/pull/1492) Bump cosmos evm to v0.3.1
+- [#1536](https://github.com/babylonlabs-io/babylon/pull/1536) Refactor `zoneconcierge` for optimize ibc channel, client io
 
 ### State Machine Breaking
 

--- a/test/replay/bsn_incentive_test.go
+++ b/test/replay/bsn_incentive_test.go
@@ -6,14 +6,15 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
 	"github.com/babylonlabs-io/babylon/v3/app/params"
 	"github.com/babylonlabs-io/babylon/v3/testutil/datagen"
 	bbn "github.com/babylonlabs-io/babylon/v3/types"
 	"github.com/babylonlabs-io/babylon/v3/x/btcstaking/types"
 	ictvtypes "github.com/babylonlabs-io/babylon/v3/x/incentive/types"
 	minttypes "github.com/babylonlabs-io/babylon/v3/x/mint/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestConsumerBsnRewardDistribution(t *testing.T) {
@@ -30,7 +31,7 @@ func TestConsumerBsnRewardDistribution(t *testing.T) {
 	OpenChannelForConsumer(d.Ctx(), d.App, consumerID)
 	d.GenerateNewBlock()
 
-	consumer0 := d.RegisterConsumer(r, consumerID)
+	consumer0 := d.RegisterConsumer(r, d.Ctx(), d.App, consumerID)
 	d.GenerateNewBlockAssertExecutionSuccess()
 
 	babylonFp := d.CreateNFinalityProviderAccounts(1)[0]

--- a/test/replay/btcstaking_test.go
+++ b/test/replay/btcstaking_test.go
@@ -802,8 +802,8 @@ func TestSlashingFpWithManyMulistakedDelegations(t *testing.T) {
 	OpenChannelForConsumer(ctx, d.App, consumerID2)
 
 	// 2. Register consumers
-	consumer1 := d.RegisterConsumer(r, consumerID1)
-	consumer2 := d.RegisterConsumer(r, consumerID2)
+	consumer1 := d.RegisterConsumer(r, ctx, d.App, consumerID1)
+	consumer2 := d.RegisterConsumer(r, ctx, d.App, consumerID2)
 	require.NotNil(t, consumer1, consumer2)
 
 	// 3. Create finality providers for each consumer

--- a/test/replay/driver.go
+++ b/test/replay/driver.go
@@ -6,17 +6,17 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-
-	appparams "github.com/babylonlabs-io/babylon/v3/app/params"
-	"github.com/babylonlabs-io/babylon/v3/app/signingcontext"
-
 	"math/rand"
 	"path/filepath"
 	"testing"
 	"time"
 
+	appparams "github.com/babylonlabs-io/babylon/v3/app/params"
+	"github.com/babylonlabs-io/babylon/v3/app/signingcontext"
+
 	"cosmossdk.io/math"
 	sdkmath "cosmossdk.io/math"
+
 	"github.com/babylonlabs-io/babylon/v3/btctxformatter"
 	bbn "github.com/babylonlabs-io/babylon/v3/types"
 	btckckpttypes "github.com/babylonlabs-io/babylon/v3/x/btccheckpoint/types"
@@ -1091,7 +1091,7 @@ type Consumer struct {
 }
 
 // RegisterConsumer registers a new consumer
-func (d *BabylonAppDriver) RegisterConsumer(r *rand.Rand, consumerID string, rollupContractAddr ...string) *Consumer {
+func (d *BabylonAppDriver) RegisterConsumer(r *rand.Rand, ctx sdk.Context, app *babylonApp.BabylonApp, consumerID string, rollupContractAddr ...string) *Consumer {
 	commission := datagen.GenBabylonRewardsCommission(r)
 	msg := &btcstkconsumertypes.MsgRegisterConsumer{
 		Signer:                   d.GetDriverAccountAddress().String(),
@@ -1107,6 +1107,18 @@ func (d *BabylonAppDriver) RegisterConsumer(r *rand.Rand, consumerID string, rol
 	}
 
 	d.SendTxWithMsgsFromDriverAccount(d.t, msg)
+
+	// Set channel id on consumer's metadata
+	// To minimize mocking complexity, perform the channel ID setup manually without a transaction
+	consumerRegister, err := app.BTCStkConsumerKeeper.GetConsumerRegister(ctx, consumerID)
+	require.NoError(d.t, err)
+	cosmosMetadata := consumerRegister.GetCosmosConsumerMetadata()
+	cosmosMetadata.ChannelId = fmt.Sprintf("channel-%s", consumerID)
+	consumerRegister.ConsumerMetadata = &btcstkconsumertypes.ConsumerRegister_CosmosConsumerMetadata{
+		CosmosConsumerMetadata: cosmosMetadata,
+	}
+	err = app.BTCStkConsumerKeeper.UpdateConsumer(ctx, consumerRegister)
+	require.NoError(d.t, err)
 
 	return &Consumer{
 		ID:                consumerID,

--- a/test/replay/finality_test.go
+++ b/test/replay/finality_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 	"time"
 
-	appparams "github.com/babylonlabs-io/babylon/v3/app/params"
-	"github.com/babylonlabs-io/babylon/v3/testutil/datagen"
-	ftypes "github.com/babylonlabs-io/babylon/v3/x/finality/types"
 	ibctmtypes "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	appparams "github.com/babylonlabs-io/babylon/v3/app/params"
+	"github.com/babylonlabs-io/babylon/v3/testutil/datagen"
+	ftypes "github.com/babylonlabs-io/babylon/v3/x/finality/types"
 )
 
 func FuzzJailing(f *testing.F) {
@@ -334,7 +335,7 @@ func TestOnlyBabylonFpCanCommitRandomness(t *testing.T) {
 	driver.GenerateNewBlock()
 
 	// 2. Register consumers
-	consumer1 := driver.RegisterConsumer(r, consumerID1)
+	consumer1 := driver.RegisterConsumer(r, ctx, driver.App, consumerID1)
 	require.NotNil(t, consumer1)
 
 	// Create a Babylon FP (registered without consumer ID)

--- a/test/replay/incentive_test.go
+++ b/test/replay/incentive_test.go
@@ -6,11 +6,12 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	"github.com/stretchr/testify/require"
+
 	"github.com/babylonlabs-io/babylon/v3/testutil/datagen"
 	bbn "github.com/babylonlabs-io/babylon/v3/types"
 	"github.com/babylonlabs-io/babylon/v3/x/btcstaking/types"
 	minttypes "github.com/babylonlabs-io/babylon/v3/x/mint/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBtcRewardTrackerAtRewardedBabylonBlockAndNotLatestState(t *testing.T) {
@@ -96,7 +97,7 @@ func TestAddBsnRewardsMathOverflow(t *testing.T) {
 	OpenChannelForConsumer(d.Ctx(), d.App, consumerID)
 	d.GenerateNewBlock()
 
-	consumer0 := d.RegisterConsumer(r, consumerID)
+	consumer0 := d.RegisterConsumer(r, d.Ctx(), d.App, consumerID)
 	d.GenerateNewBlockAssertExecutionSuccess()
 
 	babylonFp := d.CreateNFinalityProviderAccounts(1)[0]

--- a/test/replay/replayer.go
+++ b/test/replay/replayer.go
@@ -3,11 +3,11 @@ package replay
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	appparams "github.com/babylonlabs-io/babylon/v3/app/params"
 
 	"cosmossdk.io/log"
-	babylonApp "github.com/babylonlabs-io/babylon/v3/app"
-	appsigner "github.com/babylonlabs-io/babylon/v3/app/signer"
 	dbmc "github.com/cometbft/cometbft-db"
 	cs "github.com/cometbft/cometbft/consensus"
 	cometlog "github.com/cometbft/cometbft/libs/log"
@@ -18,12 +18,16 @@ import (
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/stretchr/testify/require"
+
+	babylonApp "github.com/babylonlabs-io/babylon/v3/app"
+	appsigner "github.com/babylonlabs-io/babylon/v3/app/signer"
 )
 
 type BlockReplayer struct {
 	BlockExec *sm.BlockExecutor
 	LastState sm.State
 	App       *babylonApp.BabylonApp
+	Ctx       sdk.Context
 }
 
 func NewBlockReplayer(t *testing.T, nodeDir string) *BlockReplayer {
@@ -114,5 +118,6 @@ func (r *BlockReplayer) ReplayBlocks(t *testing.T, blocks []FinalizedBlock) {
 		require.NoError(t, err)
 		require.NotNil(t, state)
 		r.LastState = state.Copy()
+		r.Ctx = r.App.NewUncachedContext(false, *block.Block.Header.ToProto())
 	}
 }

--- a/testutil/btcstaking-helper/keeper.go
+++ b/testutil/btcstaking-helper/keeper.go
@@ -450,7 +450,7 @@ func (h *Helper) CreateConsumerFinalityProvider(r *rand.Rand, consumerID string)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	h.ChannelKeeper.EXPECT().ConsumerHasIBCChannelOpen(h.Ctx, consumerID).Return(true).AnyTimes()
+	h.ChannelKeeper.EXPECT().ConsumerHasIBCChannelOpen(h.Ctx, consumerID, gomock.Any()).Return(true).AnyTimes()
 	msgNewFp := types.MsgCreateFinalityProvider{
 		Addr:        fp.Addr,
 		Description: fp.Description,

--- a/testutil/datagen/btcstkconsumer.go
+++ b/testutil/datagen/btcstkconsumer.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 
 	sdkmath "cosmossdk.io/math"
+
 	bsctypes "github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
 )
 

--- a/testutil/datagen/btcstkconsumer.go
+++ b/testutil/datagen/btcstkconsumer.go
@@ -15,6 +15,20 @@ func GenRandomCosmosConsumerRegister(r *rand.Rand) *bsctypes.ConsumerRegister {
 		ConsumerName:        GenRandomHexStr(r, 5),
 		ConsumerDescription: "Chain description: " + GenRandomHexStr(r, 15),
 		ConsumerMetadata: &bsctypes.ConsumerRegister_CosmosConsumerMetadata{
+			CosmosConsumerMetadata: &bsctypes.CosmosConsumerMetadata{
+				ChannelId: "channel-" + GenRandomHexStr(r, 3), // Generate random channel ID
+			},
+		},
+		BabylonRewardsCommission: GenBabylonRewardsCommission(r),
+	}
+}
+func GenRandomCosmosConsumerRegisterWithoutChannelSet(r *rand.Rand) *bsctypes.ConsumerRegister {
+	clientID := "test-" + GenRandomHexStr(r, 10)
+	return &bsctypes.ConsumerRegister{
+		ConsumerId:          clientID,
+		ConsumerName:        GenRandomHexStr(r, 5),
+		ConsumerDescription: "Chain description: " + GenRandomHexStr(r, 15),
+		ConsumerMetadata: &bsctypes.ConsumerRegister_CosmosConsumerMetadata{
 			CosmosConsumerMetadata: &bsctypes.CosmosConsumerMetadata{},
 		},
 		BabylonRewardsCommission: GenBabylonRewardsCommission(r),

--- a/testutil/mocks/zc_chan_keeper.go
+++ b/testutil/mocks/zc_chan_keeper.go
@@ -34,17 +34,17 @@ func (m *MockZoneConciergeChannelKeeper) EXPECT() *MockZoneConciergeChannelKeepe
 }
 
 // ConsumerHasIBCChannelOpen mocks base method.
-func (m *MockZoneConciergeChannelKeeper) ConsumerHasIBCChannelOpen(ctx context.Context, consumerID string) bool {
+func (m *MockZoneConciergeChannelKeeper) ConsumerHasIBCChannelOpen(ctx context.Context, consumerID, channelID string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConsumerHasIBCChannelOpen", ctx, consumerID)
+	ret := m.ctrl.Call(m, "ConsumerHasIBCChannelOpen", ctx, consumerID, channelID)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // ConsumerHasIBCChannelOpen indicates an expected call of ConsumerHasIBCChannelOpen.
-func (mr *MockZoneConciergeChannelKeeperMockRecorder) ConsumerHasIBCChannelOpen(ctx, consumerID interface{}) *gomock.Call {
+func (mr *MockZoneConciergeChannelKeeperMockRecorder) ConsumerHasIBCChannelOpen(ctx, consumerID, channelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumerHasIBCChannelOpen", reflect.TypeOf((*MockZoneConciergeChannelKeeper)(nil).ConsumerHasIBCChannelOpen), ctx, consumerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumerHasIBCChannelOpen", reflect.TypeOf((*MockZoneConciergeChannelKeeper)(nil).ConsumerHasIBCChannelOpen), ctx, consumerID, channelID)
 }
 
 // GetChannelClientState mocks base method.

--- a/x/btcstaking/keeper/finality_provider_consumer_validation_test.go
+++ b/x/btcstaking/keeper/finality_provider_consumer_validation_test.go
@@ -1,0 +1,262 @@
+package keeper_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"cosmossdk.io/math"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	testutil "github.com/babylonlabs-io/babylon/v3/testutil/btcstaking-helper"
+	"github.com/babylonlabs-io/babylon/v3/testutil/datagen"
+	"github.com/babylonlabs-io/babylon/v3/testutil/mocks"
+	"github.com/babylonlabs-io/babylon/v3/x/btcstaking/types"
+	btcstkconsumertypes "github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
+)
+
+// TestAddFinalityProvider_ConsumerValidation tests the consumer validation logic
+// in the AddFinalityProvider function
+func TestAddFinalityProvider_ConsumerValidation(t *testing.T) {
+	r := rand.New(rand.NewSource(12345))
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Setup mocks
+	btclcKeeper := types.NewMockBTCLightClientKeeper(ctrl)
+	btccKeeper := types.NewMockBtcCheckpointKeeper(ctrl)
+	bankKeeper := types.NewMockBankKeeper(ctrl)
+	chanKeeper := mocks.NewMockZoneConciergeChannelKeeper(ctrl)
+	ictvKeeper := testutil.NewMockIctvKeeperK(ctrl)
+
+	// Allow any calls to the incentive keeper methods
+	ictvKeeper.MockIncentiveKeeper.EXPECT().IndexRefundableMsg(gomock.Any(), gomock.Any()).AnyTimes()
+
+	h := testutil.NewHelperWithBankMock(t, btclcKeeper, btccKeeper, bankKeeper, chanKeeper, ictvKeeper, nil)
+	h.GenAndApplyParams(r)
+
+	babylonChainID := h.Ctx.ChainID()
+	unregisteredConsumerID := "unregistered-consumer"
+	registeredCosmosConsumerID := "registered-cosmos-consumer"
+	registeredRollupConsumerID := "registered-rollup-consumer"
+
+	t.Run("babylon_chain_skips_consumer_validation", func(t *testing.T) {
+		// Create finality provider for Babylon chain (empty BSN ID defaults to Babylon chain ID)
+		fp, err := datagen.GenRandomFinalityProvider(r, h.FpPopContext(), "")
+		require.NoError(t, err)
+
+		msg := &types.MsgCreateFinalityProvider{
+			Addr:        fp.Addr,
+			Description: fp.Description,
+			Commission: types.NewCommissionRates(
+				*fp.Commission,
+				fp.CommissionInfo.MaxRate,
+				fp.CommissionInfo.MaxChangeRate,
+			),
+			BtcPk: fp.BtcPk,
+			Pop:   fp.Pop,
+			BsnId: "", // Empty BSN ID should default to Babylon chain ID
+		}
+
+		// No mock expectations needed as consumer validation should be skipped
+
+		_, err = h.MsgServer.CreateFinalityProvider(h.Ctx, msg)
+		require.NoError(t, err)
+
+		// Verify FP was created successfully
+		storedFp, err := h.BTCStakingKeeper.GetFinalityProvider(h.Ctx, fp.BtcPk.MustMarshal())
+		require.NoError(t, err)
+		require.Equal(t, babylonChainID, storedFp.BsnId)
+	})
+
+	t.Run("consumer_not_registered_returns_ErrFpBSNIdNotRegistered", func(t *testing.T) {
+		// Create finality provider for unregistered consumer
+		fp, err := datagen.GenRandomFinalityProvider(r, h.FpPopContext(), unregisteredConsumerID)
+		require.NoError(t, err)
+
+		msg := &types.MsgCreateFinalityProvider{
+			Addr:        fp.Addr,
+			Description: fp.Description,
+			Commission: types.NewCommissionRates(
+				*fp.Commission,
+				fp.CommissionInfo.MaxRate,
+				fp.CommissionInfo.MaxChangeRate,
+			),
+			BtcPk: fp.BtcPk,
+			Pop:   fp.Pop,
+			BsnId: unregisteredConsumerID,
+		}
+
+		// Consumer is not registered, so GetConsumerRegister will fail
+		_, err = h.MsgServer.CreateFinalityProvider(h.Ctx, msg)
+		require.ErrorIs(t, err, types.ErrFpBSNIdNotRegistered)
+	})
+
+	t.Run("cosmos_consumer_without_channel_id_returns_ErrFpConsumerNoIBCChannelOpen", func(t *testing.T) {
+		// Create finality provider for registered Cosmos consumer
+		fp, err := datagen.GenRandomFinalityProvider(r, h.FpPopContext(), registeredCosmosConsumerID)
+		require.NoError(t, err)
+
+		msg := &types.MsgCreateFinalityProvider{
+			Addr:        fp.Addr,
+			Description: fp.Description,
+			Commission: types.NewCommissionRates(
+				*fp.Commission,
+				fp.CommissionInfo.MaxRate,
+				fp.CommissionInfo.MaxChangeRate,
+			),
+			BtcPk: fp.BtcPk,
+			Pop:   fp.Pop,
+			BsnId: registeredCosmosConsumerID,
+		}
+
+		// Create cosmos consumer register without channel ID
+		cosmosConsumerRegister := btcstkconsumertypes.NewCosmosConsumerRegister(
+			registeredCosmosConsumerID,
+			"Test Cosmos Consumer",
+			"Test Description",
+			math.LegacyNewDecWithPrec(5, 2), // 0.05
+		)
+		// Case for channel ID is empty
+
+		// Register the consumer
+		err = h.BTCStkConsumerKeeper.RegisterConsumer(h.Ctx, cosmosConsumerRegister)
+		require.NoError(t, err)
+
+		_, err = h.MsgServer.CreateFinalityProvider(h.Ctx, msg)
+		require.ErrorIs(t, err, types.ErrFpConsumerNoIBCChannelOpen)
+	})
+
+	t.Run("cosmos_consumer_with_closed_ibc_channel_returns_ErrFpConsumerNoIBCChannelOpen", func(t *testing.T) {
+		consumerIDWithClosedChannel := registeredCosmosConsumerID + "-closed"
+
+		// Create finality provider for registered Cosmos consumer
+		fp, err := datagen.GenRandomFinalityProvider(r, h.FpPopContext(), consumerIDWithClosedChannel)
+		require.NoError(t, err)
+
+		msg := &types.MsgCreateFinalityProvider{
+			Addr:        fp.Addr,
+			Description: fp.Description,
+			Commission: types.NewCommissionRates(
+				*fp.Commission,
+				fp.CommissionInfo.MaxRate,
+				fp.CommissionInfo.MaxChangeRate,
+			),
+			BtcPk: fp.BtcPk,
+			Pop:   fp.Pop,
+			BsnId: consumerIDWithClosedChannel,
+		}
+
+		// Create cosmos consumer register with channel ID
+		cosmosConsumerRegister := btcstkconsumertypes.NewCosmosConsumerRegister(
+			consumerIDWithClosedChannel,
+			"Test Cosmos Consumer with Closed Channel",
+			"Test Description",
+			math.LegacyNewDecWithPrec(5, 2), // 0.05
+		)
+		cosmosConsumerRegister.GetCosmosConsumerMetadata().ChannelId = "channel-123"
+
+		// Register the consumer
+		err = h.BTCStkConsumerKeeper.RegisterConsumer(h.Ctx, cosmosConsumerRegister)
+		require.NoError(t, err)
+
+		// Mock: ConsumerHasIBCChannelOpen returns false (channel is closed)
+		chanKeeper.EXPECT().
+			ConsumerHasIBCChannelOpen(gomock.Any(), consumerIDWithClosedChannel, "channel-123").
+			Return(false).
+			Times(1)
+
+		_, err = h.MsgServer.CreateFinalityProvider(h.Ctx, msg)
+		require.ErrorIs(t, err, types.ErrFpConsumerNoIBCChannelOpen)
+	})
+
+	t.Run("cosmos_consumer_with_open_ibc_channel_succeeds", func(t *testing.T) {
+		consumerIDWithOpenChannel := registeredCosmosConsumerID + "-open"
+
+		// Create finality provider for registered Cosmos consumer
+		fp, err := datagen.GenRandomFinalityProvider(r, h.FpPopContext(), consumerIDWithOpenChannel)
+		require.NoError(t, err)
+
+		msg := &types.MsgCreateFinalityProvider{
+			Addr:        fp.Addr,
+			Description: fp.Description,
+			Commission: types.NewCommissionRates(
+				*fp.Commission,
+				fp.CommissionInfo.MaxRate,
+				fp.CommissionInfo.MaxChangeRate,
+			),
+			BtcPk: fp.BtcPk,
+			Pop:   fp.Pop,
+			BsnId: consumerIDWithOpenChannel,
+		}
+
+		// Create cosmos consumer register with channel ID
+		cosmosConsumerRegister := btcstkconsumertypes.NewCosmosConsumerRegister(
+			consumerIDWithOpenChannel,
+			"Test Cosmos Consumer with Open Channel",
+			"Test Description",
+			math.LegacyNewDecWithPrec(5, 2), // 0.05
+		)
+		cosmosConsumerRegister.GetCosmosConsumerMetadata().ChannelId = "channel-456"
+
+		// Register the consumer
+		err = h.BTCStkConsumerKeeper.RegisterConsumer(h.Ctx, cosmosConsumerRegister)
+		require.NoError(t, err)
+
+		// Mock: ConsumerHasIBCChannelOpen returns true (channel is open)
+		chanKeeper.EXPECT().
+			ConsumerHasIBCChannelOpen(gomock.Any(), consumerIDWithOpenChannel, "channel-456").
+			Return(true).
+			Times(1)
+
+		_, err = h.MsgServer.CreateFinalityProvider(h.Ctx, msg)
+		require.NoError(t, err)
+
+		// Verify FP was created successfully
+		storedFp, err := h.BTCStakingKeeper.GetFinalityProvider(h.Ctx, fp.BtcPk.MustMarshal())
+		require.NoError(t, err)
+		require.Equal(t, consumerIDWithOpenChannel, storedFp.BsnId)
+	})
+
+	t.Run("rollup_consumer_skips_ibc_channel_validation", func(t *testing.T) {
+		// Create finality provider for registered rollup consumer
+		fp, err := datagen.GenRandomFinalityProvider(r, h.FpPopContext(), registeredRollupConsumerID)
+		require.NoError(t, err)
+
+		msg := &types.MsgCreateFinalityProvider{
+			Addr:        fp.Addr,
+			Description: fp.Description,
+			Commission: types.NewCommissionRates(
+				*fp.Commission,
+				fp.CommissionInfo.MaxRate,
+				fp.CommissionInfo.MaxChangeRate,
+			),
+			BtcPk: fp.BtcPk,
+			Pop:   fp.Pop,
+			BsnId: registeredRollupConsumerID,
+		}
+
+		// Create rollup consumer register
+		rollupConsumerRegister := btcstkconsumertypes.NewRollupConsumerRegister(
+			registeredRollupConsumerID,
+			"Test Rollup Consumer",
+			"Test Description",
+			"0x1234567890abcdef",
+			math.LegacyNewDecWithPrec(5, 2), // 0.05
+		)
+
+		// Register the consumer
+		err = h.BTCStkConsumerKeeper.RegisterConsumer(h.Ctx, rollupConsumerRegister)
+		require.NoError(t, err)
+
+		// No ConsumerHasIBCChannelOpen expectation - should be skipped for rollup consumers
+
+		_, err = h.MsgServer.CreateFinalityProvider(h.Ctx, msg)
+		require.NoError(t, err)
+
+		// Verify FP was created successfully
+		storedFp, err := h.BTCStakingKeeper.GetFinalityProvider(h.Ctx, fp.BtcPk.MustMarshal())
+		require.NoError(t, err)
+		require.Equal(t, registeredRollupConsumerID, storedFp.BsnId)
+	})
+}

--- a/x/btcstaking/keeper/finality_providers.go
+++ b/x/btcstaking/keeper/finality_providers.go
@@ -56,9 +56,8 @@ func (k Keeper) AddFinalityProvider(goCtx context.Context, msg *types.MsgCreateF
 		}
 		// Ensure there's an IBC channel open if it is a Cosmos BSN
 		ccm := cr.GetCosmosConsumerMetadata()
-		if ccm != nil && ccm.ChannelId != "" {
-			hasChannel := k.BscKeeper.ConsumerHasIBCChannelOpen(ctx, bsnID, ccm.ChannelId)
-			if !hasChannel {
+		if ccm != nil {
+			if ccm.ChannelId == "" || !k.BscKeeper.ConsumerHasIBCChannelOpen(ctx, bsnID, ccm.ChannelId) {
 				return types.ErrFpConsumerNoIBCChannelOpen
 			}
 		}

--- a/x/btcstaking/keeper/finality_providers.go
+++ b/x/btcstaking/keeper/finality_providers.go
@@ -55,8 +55,9 @@ func (k Keeper) AddFinalityProvider(goCtx context.Context, msg *types.MsgCreateF
 			return types.ErrFpBSNIdNotRegistered
 		}
 		// Ensure there's an IBC channel open if it is a Cosmos BSN
-		if cr.GetCosmosConsumerMetadata() != nil {
-			hasChannel := k.BscKeeper.ConsumerHasIBCChannelOpen(ctx, bsnID, cr.GetCosmosConsumerMetadata().ChannelId)
+		ccm := cr.GetCosmosConsumerMetadata()
+		if ccm != nil && ccm.ChannelId != "" {
+			hasChannel := k.BscKeeper.ConsumerHasIBCChannelOpen(ctx, bsnID, ccm.ChannelId)
 			if !hasChannel {
 				return types.ErrFpConsumerNoIBCChannelOpen
 			}

--- a/x/btcstaking/keeper/finality_providers.go
+++ b/x/btcstaking/keeper/finality_providers.go
@@ -56,7 +56,7 @@ func (k Keeper) AddFinalityProvider(goCtx context.Context, msg *types.MsgCreateF
 		}
 		// Ensure there's an IBC channel open if it is a Cosmos BSN
 		if cr.GetCosmosConsumerMetadata() != nil {
-			hasChannel := k.BscKeeper.ConsumerHasIBCChannelOpen(ctx, bsnID)
+			hasChannel := k.BscKeeper.ConsumerHasIBCChannelOpen(ctx, bsnID, cr.GetCosmosConsumerMetadata().ChannelId)
 			if !hasChannel {
 				return types.ErrFpConsumerNoIBCChannelOpen
 			}

--- a/x/btcstaking/keeper/grpc_query_test.go
+++ b/x/btcstaking/keeper/grpc_query_test.go
@@ -66,7 +66,7 @@ func FuzzFinalityProviders(f *testing.F) {
 		numTotalFPs := int(datagen.RandomInt(r, 20) + 1) // 1 to 20 FPs total
 
 		// If it's a registered consumer, we need to ensure the channel is open to be able to create a consumer FP
-		h.ChannelKeeper.EXPECT().ConsumerHasIBCChannelOpen(h.Ctx, registeredBsnId).Return(true).AnyTimes()
+		h.ChannelKeeper.EXPECT().ConsumerHasIBCChannelOpen(h.Ctx, registeredBsnId, consumerRegister.GetCosmosConsumerMetadata().ChannelId).Return(true).AnyTimes()
 
 		for i := 0; i < numTotalFPs; i++ {
 			fpSK, _, err := datagen.GenRandomBTCKeyPair(r)

--- a/x/btcstaking/keeper/msg_server_test.go
+++ b/x/btcstaking/keeper/msg_server_test.go
@@ -138,7 +138,7 @@ func FuzzMsgCreateFinalityProvider(f *testing.F) {
 		require.Error(t, err)
 
 		// Try to create a FP for a registered BSN but without an IBC channel
-		h.ChannelKeeper.EXPECT().ConsumerHasIBCChannelOpen(h.Ctx, registeredBsnId).Return(false).Times(1)
+		h.ChannelKeeper.EXPECT().ConsumerHasIBCChannelOpen(h.Ctx, registeredBsnId, consumerRegister.GetCosmosConsumerMetadata().ChannelId).Return(false).Times(1)
 		fpRegisteredBsn, err := datagen.GenRandomFinalityProvider(r, h.FpPopContext(), registeredBsnId)
 		require.NoError(t, err)
 		msgRegisteredBsn := &types.MsgCreateFinalityProvider{
@@ -158,7 +158,7 @@ func FuzzMsgCreateFinalityProvider(f *testing.F) {
 		require.ErrorIs(t, err, types.ErrFpConsumerNoIBCChannelOpen)
 
 		// If it's a registered consumer, we need to ensure the channel is open to be able to create a consumer FP
-		h.ChannelKeeper.EXPECT().ConsumerHasIBCChannelOpen(h.Ctx, registeredBsnId).Return(true).AnyTimes()
+		h.ChannelKeeper.EXPECT().ConsumerHasIBCChannelOpen(h.Ctx, registeredBsnId, consumerRegister.GetCosmosConsumerMetadata().ChannelId).Return(true).AnyTimes()
 
 		fps := []*types.FinalityProvider{}
 		for i := 0; i < int(datagen.RandomInt(r, 20)); i++ {

--- a/x/btcstaking/types/expected_keepers.go
+++ b/x/btcstaking/types/expected_keepers.go
@@ -3,11 +3,12 @@ package types
 import (
 	"context"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	bbn "github.com/babylonlabs-io/babylon/v3/types"
 	btcctypes "github.com/babylonlabs-io/babylon/v3/x/btccheckpoint/types"
 	btclctypes "github.com/babylonlabs-io/babylon/v3/x/btclightclient/types"
 	btcstkconsumertypes "github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type BTCLightClientKeeper interface {
@@ -29,7 +30,7 @@ type BTCStkConsumerKeeper interface {
 	IsCosmosConsumer(ctx context.Context, consumerID string) (bool, error)
 	GetConsumerRegister(ctx context.Context, consumerID string) (*btcstkconsumertypes.ConsumerRegister, error)
 	GetConsumerID(ctx sdk.Context, portID, channelID string) (consumerID string, err error)
-	ConsumerHasIBCChannelOpen(ctx context.Context, consumerID string) bool
+	ConsumerHasIBCChannelOpen(ctx context.Context, consumerID, channelID string) bool
 }
 
 type IncentiveKeeper interface {

--- a/x/btcstaking/types/mocked_keepers.go
+++ b/x/btcstaking/types/mocked_keepers.go
@@ -180,17 +180,17 @@ func (m *MockBTCStkConsumerKeeper) EXPECT() *MockBTCStkConsumerKeeperMockRecorde
 }
 
 // ConsumerHasIBCChannelOpen mocks base method.
-func (m *MockBTCStkConsumerKeeper) ConsumerHasIBCChannelOpen(ctx context.Context, consumerID string) bool {
+func (m *MockBTCStkConsumerKeeper) ConsumerHasIBCChannelOpen(ctx context.Context, consumerID, channelID string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConsumerHasIBCChannelOpen", ctx, consumerID)
+	ret := m.ctrl.Call(m, "ConsumerHasIBCChannelOpen", ctx, consumerID, channelID)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // ConsumerHasIBCChannelOpen indicates an expected call of ConsumerHasIBCChannelOpen.
-func (mr *MockBTCStkConsumerKeeperMockRecorder) ConsumerHasIBCChannelOpen(ctx, consumerID interface{}) *gomock.Call {
+func (mr *MockBTCStkConsumerKeeperMockRecorder) ConsumerHasIBCChannelOpen(ctx, consumerID, channelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumerHasIBCChannelOpen", reflect.TypeOf((*MockBTCStkConsumerKeeper)(nil).ConsumerHasIBCChannelOpen), ctx, consumerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumerHasIBCChannelOpen", reflect.TypeOf((*MockBTCStkConsumerKeeper)(nil).ConsumerHasIBCChannelOpen), ctx, consumerID, channelID)
 }
 
 // GetConsumerID mocks base method.

--- a/x/btcstkconsumer/keeper/consumer_registry.go
+++ b/x/btcstkconsumer/keeper/consumer_registry.go
@@ -55,17 +55,19 @@ func (k Keeper) IsCosmosConsumer(ctx context.Context, consumerID string) (bool, 
 	return consumerRegister.GetCosmosConsumerMetadata() != nil, nil
 }
 
-// GetAllRegisteredConsumerIDs gets all consumer IDs that registered to Babylon
-func (k Keeper) GetAllRegisteredConsumerIDs(ctx context.Context) []string {
-	var consumerIDs []string
-	err := k.ConsumerRegistry.Walk(ctx, nil, func(consumerID string, _ types.ConsumerRegister) (bool, error) {
-		consumerIDs = append(consumerIDs, consumerID)
+// GetAllRegisteredCosmosConsumers gets all cosmos consumers that registered to Babylon
+func (k Keeper) GetAllRegisteredCosmosConsumers(ctx context.Context) []*types.ConsumerRegister {
+	var consumers []*types.ConsumerRegister
+	err := k.ConsumerRegistry.Walk(ctx, nil, func(consumerID string, consumerRegister types.ConsumerRegister) (bool, error) {
+		if consumerRegister.GetCosmosConsumerMetadata() != nil {
+			consumers = append(consumers, &consumerRegister)
+		}
 		return false, nil
 	})
 	if err != nil {
 		panic(err)
 	}
-	return consumerIDs
+	return consumers
 }
 
 // GetConsumerID returns the consumer ID based on the channel and port ID
@@ -83,6 +85,6 @@ func (k Keeper) GetConsumerID(ctx sdk.Context, portID, channelID string) (consum
 	return cons.ConsumerId, nil
 }
 
-func (k Keeper) ConsumerHasIBCChannelOpen(ctx context.Context, consumerID string) bool {
-	return k.channelKeeper.ConsumerHasIBCChannelOpen(ctx, consumerID)
+func (k Keeper) ConsumerHasIBCChannelOpen(ctx context.Context, consumerID, channelID string) bool {
+	return k.channelKeeper.ConsumerHasIBCChannelOpen(ctx, consumerID, channelID)
 }

--- a/x/btcstkconsumer/keeper/consumer_registry.go
+++ b/x/btcstkconsumer/keeper/consumer_registry.go
@@ -55,11 +55,13 @@ func (k Keeper) IsCosmosConsumer(ctx context.Context, consumerID string) (bool, 
 	return consumerRegister.GetCosmosConsumerMetadata() != nil, nil
 }
 
-// GetAllRegisteredCosmosConsumers gets all cosmos consumers that registered to Babylon
+// GetAllRegisteredCosmosConsumers gets all cosmos consumers that registered and IBC init complete with channel ID set
 func (k Keeper) GetAllRegisteredCosmosConsumers(ctx context.Context) []*types.ConsumerRegister {
 	var consumers []*types.ConsumerRegister
 	err := k.ConsumerRegistry.Walk(ctx, nil, func(consumerID string, consumerRegister types.ConsumerRegister) (bool, error) {
-		if consumerRegister.GetCosmosConsumerMetadata() != nil {
+		// Select consumers registered as Cosmos consumer with metadata, IBC init complete with channel ID set
+		metadata := consumerRegister.GetCosmosConsumerMetadata()
+		if metadata != nil && metadata.ChannelId != "" {
 			consumers = append(consumers, &consumerRegister)
 		}
 		return false, nil

--- a/x/btcstkconsumer/keeper/consumer_registry.go
+++ b/x/btcstkconsumer/keeper/consumer_registry.go
@@ -56,6 +56,7 @@ func (k Keeper) IsCosmosConsumer(ctx context.Context, consumerID string) (bool, 
 }
 
 // GetAllRegisteredCosmosConsumers gets all cosmos consumers that registered and IBC init complete with channel ID set
+// Note: # Since the introduction of map in #1540, it is not currently used, but kept for potential future use.
 func (k Keeper) GetAllRegisteredCosmosConsumers(ctx context.Context) []*types.ConsumerRegister {
 	var consumers []*types.ConsumerRegister
 	err := k.ConsumerRegistry.Walk(ctx, nil, func(consumerID string, consumerRegister types.ConsumerRegister) (bool, error) {

--- a/x/btcstkconsumer/keeper/consumer_registry_test.go
+++ b/x/btcstkconsumer/keeper/consumer_registry_test.go
@@ -4,9 +4,12 @@ import (
 	"math/rand"
 	"testing"
 
+	"cosmossdk.io/math"
+	"github.com/stretchr/testify/require"
+
 	"github.com/babylonlabs-io/babylon/v3/app"
 	"github.com/babylonlabs-io/babylon/v3/testutil/datagen"
-	"github.com/stretchr/testify/require"
+	"github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
 )
 
 func FuzzConsumerRegistry(f *testing.F) {
@@ -40,5 +43,165 @@ func FuzzConsumerRegistry(f *testing.F) {
 		require.Equal(t, consumerRegister.ConsumerId, consumerRegister2.ConsumerId)
 		require.Equal(t, consumerRegister.ConsumerName, consumerRegister2.ConsumerName)
 		require.Equal(t, consumerRegister.ConsumerDescription, consumerRegister2.ConsumerDescription)
+	})
+}
+
+func TestCosmosConsumerMetadataValidation(t *testing.T) {
+	babylonApp := app.Setup(t, false)
+	bscKeeper := babylonApp.BTCStkConsumerKeeper
+	ctx := babylonApp.NewContext(false)
+
+	// Test NewCosmosConsumerRegister creates consumer with non-nil metadata
+	t.Run("NewCosmosConsumerRegister_creates_non_nil_metadata", func(t *testing.T) {
+		consumerRegister := types.NewCosmosConsumerRegister(
+			"test-consumer-1",
+			"Test Consumer",
+			"Test Description",
+			math.LegacyNewDecWithPrec(5, 2), // 0.05
+		)
+
+		// Verify metadata is not nil
+		require.NotNil(t, consumerRegister.GetCosmosConsumerMetadata())
+
+		// Verify the consumer is considered a cosmos consumer
+		require.True(t, consumerRegister.GetCosmosConsumerMetadata() != nil)
+	})
+
+	// Test consumer without channel_id is still included in GetAllRegisteredCosmosConsumers
+	t.Run("consumer_without_channel_id_included_in_GetAllRegisteredCosmosConsumers", func(t *testing.T) {
+		// Create consumer with empty channel_id
+		consumerRegister := types.NewCosmosConsumerRegister(
+			"test-consumer-2",
+			"Test Consumer 2",
+			"Test Description 2",
+			math.LegacyNewDecWithPrec(10, 2), // 0.10
+		)
+
+		// Register the consumer
+		err := bscKeeper.RegisterConsumer(ctx, consumerRegister)
+		require.NoError(t, err)
+
+		// Get all registered cosmos consumers
+		cosmosConsumers := bscKeeper.GetAllRegisteredCosmosConsumers(ctx)
+
+		// Verify the consumer is included even without channel_id
+		found := false
+		for _, consumer := range cosmosConsumers {
+			if consumer.ConsumerId == "test-consumer-2" {
+				found = true
+				break
+			}
+		}
+		require.False(t, found, "Consumer should not be found in GetAllRegisteredCosmosConsumers when without channel_id")
+	})
+
+	// Test consumer with channel_id is included in GetAllRegisteredCosmosConsumers
+	t.Run("consumer_with_channel_id_included_in_GetAllRegisteredCosmosConsumers", func(t *testing.T) {
+		// Create consumer with channel_id set
+		consumerRegister := types.NewCosmosConsumerRegister(
+			"test-consumer-3",
+			"Test Consumer 3",
+			"Test Description 3",
+			math.LegacyNewDecWithPrec(15, 2), // 0.15
+		)
+		consumerRegister.GetCosmosConsumerMetadata().ChannelId = "channel-123"
+
+		// Register the consumer
+		err := bscKeeper.RegisterConsumer(ctx, consumerRegister)
+		require.NoError(t, err)
+
+		// Get all registered cosmos consumers
+		cosmosConsumers := bscKeeper.GetAllRegisteredCosmosConsumers(ctx)
+
+		// Verify the consumer is included with channel_id
+		found := false
+		for _, consumer := range cosmosConsumers {
+			if consumer.ConsumerId == "test-consumer-3" {
+				found = true
+				// Verify metadata exists and channel_id is set
+				require.NotNil(t, consumer.GetCosmosConsumerMetadata())
+				require.Equal(t, "channel-123", consumer.GetCosmosConsumerMetadata().ChannelId)
+				break
+			}
+		}
+		require.True(t, found, "Consumer should be found in GetAllRegisteredCosmosConsumers with channel_id")
+	})
+
+	// Test rollup consumer is NOT included in GetAllRegisteredCosmosConsumers
+	t.Run("rollup_consumer_not_included_in_GetAllRegisteredCosmosConsumers", func(t *testing.T) {
+		// Create rollup consumer
+		rollupRegister := types.NewRollupConsumerRegister(
+			"test-rollup-1",
+			"Test Rollup",
+			"Test Rollup Description",
+			"0x1234567890abcdef",
+			math.LegacyNewDecWithPrec(20, 2), // 0.20
+		)
+
+		// Register the rollup consumer
+		err := bscKeeper.RegisterConsumer(ctx, rollupRegister)
+		require.NoError(t, err)
+
+		// Get all registered cosmos consumers
+		cosmosConsumers := bscKeeper.GetAllRegisteredCosmosConsumers(ctx)
+
+		// Verify the rollup consumer is NOT included
+		found := false
+		for _, consumer := range cosmosConsumers {
+			if consumer.ConsumerId == "test-rollup-1" {
+				found = true
+				break
+			}
+		}
+		require.False(t, found, "Rollup consumer should NOT be found in GetAllRegisteredCosmosConsumers")
+
+		// Verify rollup consumer has nil cosmos metadata
+		require.Nil(t, rollupRegister.GetCosmosConsumerMetadata())
+	})
+}
+
+func TestCosmosConsumerIdentificationStrategies(t *testing.T) {
+	// This test demonstrates different strategies for identifying cosmos consumers
+	// and whether metadata != nil check is sufficient vs requiring channel_id validation
+
+	t.Run("metadata_nil_check_vs_channel_id_validation", func(t *testing.T) {
+		// Strategy 1: Check metadata != nil (current approach)
+		cosmosConsumerWithoutChannel := types.NewCosmosConsumerRegister(
+			"cosmos-no-channel", "Cosmos No Channel", "Description", math.LegacyNewDecWithPrec(5, 2))
+		cosmosConsumerWithChannel := types.NewCosmosConsumerRegister(
+			"cosmos-with-channel", "Cosmos With Channel", "Description", math.LegacyNewDecWithPrec(10, 2))
+		cosmosConsumerWithChannel.GetCosmosConsumerMetadata().ChannelId = "channel-456"
+
+		rollupConsumer := types.NewRollupConsumerRegister(
+			"rollup-consumer", "Rollup Consumer", "Description", "0xabcdef", math.LegacyNewDecWithPrec(15, 2))
+
+		// Test: metadata != nil
+		t.Run("current_strategy_metadata_not_nil", func(t *testing.T) {
+			// Both cosmos consumers should be identified as cosmos consumers
+			require.True(t, cosmosConsumerWithoutChannel.GetCosmosConsumerMetadata() != nil,
+				"Cosmos consumer without channel should be identified by metadata != nil")
+			require.True(t, cosmosConsumerWithChannel.GetCosmosConsumerMetadata() != nil,
+				"Cosmos consumer with channel should be identified by metadata != nil")
+
+			// Rollup consumer should NOT be identified as cosmos consumer
+			require.False(t, rollupConsumer.GetCosmosConsumerMetadata() != nil,
+				"Rollup consumer should NOT be identified as cosmos consumer")
+		})
+
+		// Test: require channel_id
+		t.Run("alternative_strategy_require_channel_id", func(t *testing.T) {
+			// Only cosmos consumer with channel_id would be identified
+			hasChannelId := func(cr *types.ConsumerRegister) bool {
+				metadata := cr.GetCosmosConsumerMetadata()
+				return metadata != nil && metadata.ChannelId != ""
+			}
+
+			require.False(t, hasChannelId(cosmosConsumerWithoutChannel),
+				"Cosmos consumer without channel would be excluded with channel_id requirement")
+			require.True(t, hasChannelId(cosmosConsumerWithChannel),
+				"Cosmos consumer with channel would be included with channel_id requirement")
+			require.False(t, hasChannelId(rollupConsumer),
+				"Rollup consumer would be excluded with channel_id requirement")
+		})
 	})
 }

--- a/x/btcstkconsumer/keeper/consumer_registry_test.go
+++ b/x/btcstkconsumer/keeper/consumer_registry_test.go
@@ -67,6 +67,13 @@ func TestCosmosConsumerMetadataValidation(t *testing.T) {
 		require.True(t, consumerRegister.GetCosmosConsumerMetadata() != nil)
 	})
 
+	// Test empty case - no consumers registered
+	t.Run("empty_registry", func(t *testing.T) {
+		cosmosConsumers := bscKeeper.GetAllRegisteredCosmosConsumers(ctx)
+		require.Empty(t, cosmosConsumers, "Should return empty slice when no consumers are registered")
+		require.Len(t, cosmosConsumers, 0, "Should return a slice of length 0 when no consumers are registered")
+	})
+
 	// Test consumer without channel_id is still included in GetAllRegisteredCosmosConsumers
 	t.Run("consumer_without_channel_id_included_in_GetAllRegisteredCosmosConsumers", func(t *testing.T) {
 		// Create consumer with empty channel_id
@@ -157,6 +164,57 @@ func TestCosmosConsumerMetadataValidation(t *testing.T) {
 
 		// Verify rollup consumer has nil cosmos metadata
 		require.Nil(t, rollupRegister.GetCosmosConsumerMetadata())
+	})
+
+	// Test multiple mixed consumer types
+	t.Run("multiple_mixed_consumers", func(t *testing.T) {
+		babylonApp = app.Setup(t, false)
+		bscKeeper = babylonApp.BTCStkConsumerKeeper
+		ctx = babylonApp.NewContext(false)
+
+		// Create multiple cosmos consumers with channel IDs
+		cosmos1 := types.NewCosmosConsumerRegister(
+			"cosmos-1", "Cosmos 1", "Description 1", math.LegacyNewDecWithPrec(5, 2))
+		cosmos1.GetCosmosConsumerMetadata().ChannelId = "channel-cosmos-1"
+
+		cosmos2 := types.NewCosmosConsumerRegister(
+			"cosmos-2", "Cosmos 2", "Description 2", math.LegacyNewDecWithPrec(10, 2))
+		cosmos2.GetCosmosConsumerMetadata().ChannelId = "channel-cosmos-2"
+
+		// Create cosmos consumer without channel ID
+		cosmos3 := types.NewCosmosConsumerRegister(
+			"cosmos-3", "Cosmos 3", "Description 3", math.LegacyNewDecWithPrec(15, 2))
+		// cosmos3 has empty channel ID
+
+		// Create rollup consumer
+		rollup1 := types.NewRollupConsumerRegister(
+			"rollup-1", "Rollup 1", "Description 4", "0xabcdef", math.LegacyNewDecWithPrec(20, 2))
+
+		// Register all consumers
+		err := bscKeeper.RegisterConsumer(ctx, cosmos1)
+		require.NoError(t, err)
+		err = bscKeeper.RegisterConsumer(ctx, cosmos2)
+		require.NoError(t, err)
+		err = bscKeeper.RegisterConsumer(ctx, cosmos3)
+		require.NoError(t, err)
+		err = bscKeeper.RegisterConsumer(ctx, rollup1)
+		require.NoError(t, err)
+
+		cosmosConsumers := bscKeeper.GetAllRegisteredCosmosConsumers(ctx)
+		require.Len(t, cosmosConsumers, 2, "Should return only cosmos consumers with channel IDs")
+
+		// Check that returned consumers are correct
+		consumerIDs := make(map[string]bool)
+		for _, consumer := range cosmosConsumers {
+			consumerIDs[consumer.ConsumerId] = true
+			require.NotNil(t, consumer.GetCosmosConsumerMetadata(), "All returned consumers should have cosmos metadata")
+			require.NotEmpty(t, consumer.GetCosmosConsumerMetadata().ChannelId, "All returned consumers should have non-empty channel ID")
+		}
+
+		require.True(t, consumerIDs["cosmos-1"], "Should include cosmos-1")
+		require.True(t, consumerIDs["cosmos-2"], "Should include cosmos-2")
+		require.False(t, consumerIDs["cosmos-3"], "Should exclude cosmos-3 (no channel ID)")
+		require.False(t, consumerIDs["rollup-1"], "Should exclude rollup-1")
 	})
 }
 

--- a/x/btcstkconsumer/keeper/msg_server_test.go
+++ b/x/btcstkconsumer/keeper/msg_server_test.go
@@ -8,15 +8,16 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	ibctmtypes "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
+
 	"github.com/babylonlabs-io/babylon/v3/app"
 	"github.com/babylonlabs-io/babylon/v3/testutil/datagen"
 	keepertest "github.com/babylonlabs-io/babylon/v3/testutil/keeper"
 	wasmtest "github.com/babylonlabs-io/babylon/v3/wasmbinding/test"
 	"github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/keeper"
 	"github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	ibctmtypes "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
 )
 
 func setupMsgServer(t testing.TB) (keeper.Keeper, types.MsgServer, context.Context) {
@@ -43,7 +44,7 @@ func TestRejectConsumerIdSameAsChainId(t *testing.T) {
 		Test registering Cosmos consumer
 	*/
 	// generate a random consumer register
-	consumerRegister := datagen.GenRandomCosmosConsumerRegister(r)
+	consumerRegister := datagen.GenRandomCosmosConsumerRegisterWithoutChannelSet(r)
 	// mock IBC light client
 	babylonApp.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerRegister.ConsumerId, &ibctmtypes.ClientState{})
 	// Register the consumer
@@ -76,7 +77,7 @@ func FuzzRegisterConsumer(f *testing.F) {
 		})
 		require.NoError(t, err)
 		// generate a random consumer register
-		consumerRegister := datagen.GenRandomCosmosConsumerRegister(r)
+		consumerRegister := datagen.GenRandomCosmosConsumerRegisterWithoutChannelSet(r)
 		// Register the consumer
 		_, err = msgServer.RegisterConsumer(ctx, &types.MsgRegisterConsumer{
 			ConsumerId:               consumerRegister.ConsumerId,
@@ -96,7 +97,7 @@ func FuzzRegisterConsumer(f *testing.F) {
 			Test registering Cosmos consumer
 		*/
 		// generate a random consumer register
-		consumerRegister = datagen.GenRandomCosmosConsumerRegister(r)
+		consumerRegister = datagen.GenRandomCosmosConsumerRegisterWithoutChannelSet(r)
 		// mock IBC light client
 		babylonApp.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerRegister.ConsumerId, &ibctmtypes.ClientState{})
 		// Register the consumer

--- a/x/btcstkconsumer/types/expected_keepers.go
+++ b/x/btcstkconsumer/types/expected_keepers.go
@@ -15,7 +15,7 @@ type ClientKeeper interface {
 
 type ChannelKeeper interface {
 	GetChannelClientState(ctx sdk.Context, portID, channelID string) (clientID string, state ibcexported.ClientState, err error)
-	ConsumerHasIBCChannelOpen(ctx context.Context, consumerID string) bool
+	ConsumerHasIBCChannelOpen(ctx context.Context, consumerID, channelID string) bool
 }
 
 type WasmKeeper interface {

--- a/x/zoneconcierge/genesis_test.go
+++ b/x/zoneconcierge/genesis_test.go
@@ -3,12 +3,14 @@ package zoneconcierge_test
 import (
 	"testing"
 
-	keepertest "github.com/babylonlabs-io/babylon/v3/testutil/keeper"
-	"github.com/babylonlabs-io/babylon/v3/testutil/nullify"
-	"github.com/babylonlabs-io/babylon/v3/x/zoneconcierge"
-	"github.com/babylonlabs-io/babylon/v3/x/zoneconcierge/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/babylonlabs-io/babylon/v3/testutil/keeper"
+	"github.com/babylonlabs-io/babylon/v3/testutil/nullify"
+	btcstkconsumertypes "github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
+	"github.com/babylonlabs-io/babylon/v3/x/zoneconcierge"
+	"github.com/babylonlabs-io/babylon/v3/x/zoneconcierge/types"
 )
 
 func TestGenesis(t *testing.T) {
@@ -21,7 +23,7 @@ func TestGenesis(t *testing.T) {
 
 	// mock btcstkconsumer keeper
 	btcStkConsumerKeeper := types.NewMockBTCStkConsumerKeeper(ctrl)
-	btcStkConsumerKeeper.EXPECT().GetAllRegisteredConsumerIDs(gomock.Any()).Return([]string{}).AnyTimes()
+	btcStkConsumerKeeper.EXPECT().GetAllRegisteredCosmosConsumers(gomock.Any()).Return([]*btcstkconsumertypes.ConsumerRegister{}).AnyTimes()
 
 	k, ctx := keepertest.ZoneConciergeKeeper(t, nil, nil, nil, nil, nil, nil, btcStkConsumerKeeper)
 	zoneconcierge.InitGenesis(ctx, *k, genesisState)

--- a/x/zoneconcierge/keeper/channel_keeper.go
+++ b/x/zoneconcierge/keeper/channel_keeper.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"cosmossdk.io/log"
-	"github.com/babylonlabs-io/babylon/v3/x/zoneconcierge/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
+
+	"github.com/babylonlabs-io/babylon/v3/x/zoneconcierge/types"
 )
 
 // ChannelKeeper is a wrapper around the IBC channel keeper
@@ -29,20 +30,13 @@ func (k ChannelKeeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", "x/"+ibcexported.ModuleName+"-"+types.ModuleName+"-channel")
 }
 
-func (k ChannelKeeper) GetAllChannels(ctx context.Context) []channeltypes.IdentifiedChannel {
-	return k.channelKeeper.GetAllChannels(sdk.UnwrapSDKContext(ctx))
-}
-
 // GetAllOpenZCChannels returns all open channels that are connected to ZoneConcierge's port
 func (k ChannelKeeper) GetAllOpenZCChannels(ctx context.Context) []channeltypes.IdentifiedChannel {
-	channels := k.GetAllChannels(ctx)
+	zcChannels := k.channelKeeper.GetAllChannelsWithPortPrefix(sdk.UnwrapSDKContext(ctx), types.PortID)
 
 	openZCChannels := []channeltypes.IdentifiedChannel{}
-	for _, channel := range channels {
+	for _, channel := range zcChannels {
 		if channel.State != channeltypes.OPEN {
-			continue
-		}
-		if channel.PortId != types.PortID {
 			continue
 		}
 		openZCChannels = append(openZCChannels, channel)
@@ -51,8 +45,8 @@ func (k ChannelKeeper) GetAllOpenZCChannels(ctx context.Context) []channeltypes.
 	return openZCChannels
 }
 
-func (k ChannelKeeper) ConsumerHasIBCChannelOpen(ctx context.Context, consumerID string) bool {
-	_, found := k.GetChannelForConsumer(ctx, consumerID)
+func (k ChannelKeeper) ConsumerHasIBCChannelOpen(ctx context.Context, consumerID, channelID string) bool {
+	_, found := k.GetChannelForConsumer(ctx, consumerID, channelID)
 	return found
 }
 
@@ -68,20 +62,21 @@ func (k ChannelKeeper) GetClientID(ctx context.Context, channel channeltypes.Ide
 	return clientID, nil
 }
 
-// getChannelForConsumer finds an open channel for a given consumer ID
-func (k ChannelKeeper) GetChannelForConsumer(ctx context.Context, consumerID string) (channeltypes.IdentifiedChannel, bool) {
-	openChannels := k.GetAllOpenZCChannels(ctx)
-
-	for _, channel := range openChannels {
-		clientID, err := k.GetClientID(ctx, channel)
-		if err != nil {
-			continue
-		}
-		if clientID == consumerID {
-			return channel, true
-		}
+// GetChannelForConsumer finds an open channel for a given consumer ID and channel ID
+func (k ChannelKeeper) GetChannelForConsumer(ctx context.Context, consumerID, channelID string) (channeltypes.IdentifiedChannel, bool) {
+	channel, found := k.channelKeeper.GetChannel(sdk.UnwrapSDKContext(ctx), types.PortID, channelID)
+	if !found || channel.State != channeltypes.OPEN {
+		return channeltypes.IdentifiedChannel{}, false
 	}
+	identifiedChannel := channeltypes.NewIdentifiedChannel(types.PortID, channelID, channel)
 
+	clientID, _, err := k.channelKeeper.GetChannelClientState(sdk.UnwrapSDKContext(ctx), identifiedChannel.PortId, identifiedChannel.ChannelId)
+	if err != nil {
+		return channeltypes.IdentifiedChannel{}, false
+	}
+	if clientID == consumerID {
+		return identifiedChannel, true
+	}
 	return channeltypes.IdentifiedChannel{}, false
 }
 

--- a/x/zoneconcierge/keeper/channel_keeper_test.go
+++ b/x/zoneconcierge/keeper/channel_keeper_test.go
@@ -1,0 +1,580 @@
+package keeper_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	connectiontypes "github.com/cosmos/ibc-go/v10/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	ibctmtypes "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
+	"github.com/stretchr/testify/require"
+
+	"github.com/babylonlabs-io/babylon/v3/app"
+	zckeeper "github.com/babylonlabs-io/babylon/v3/x/zoneconcierge/keeper"
+	zctypes "github.com/babylonlabs-io/babylon/v3/x/zoneconcierge/types"
+)
+
+func setupChannelKeeperTest(t *testing.T) (*app.BabylonApp, sdk.Context, *zckeeper.ChannelKeeper) {
+	babylonApp := app.Setup(t, false)
+	ctx := babylonApp.NewContext(false)
+	channelKeeper := zckeeper.NewChannelKeeper(babylonApp.IBCKeeper.ChannelKeeper)
+	return babylonApp, ctx, channelKeeper
+}
+
+// Helper function to setup IBC infrastructure for consumer
+func setupConsumerChannel(app *app.BabylonApp, ctx sdk.Context, consumerID, channelID string, state channeltypes.State) {
+	// Set client state
+	app.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID, &ibctmtypes.ClientState{})
+
+	// Set connection
+	app.IBCKeeper.ConnectionKeeper.SetConnection(
+		ctx, consumerID, connectiontypes.ConnectionEnd{
+			ClientId: consumerID,
+		},
+	)
+
+	// Set channel with the specified state
+	app.IBCKeeper.ChannelKeeper.SetChannel(
+		ctx, zctypes.PortID, channelID, channeltypes.Channel{
+			State:          state,
+			ConnectionHops: []string{consumerID},
+		},
+	)
+}
+
+func TestGetChannelForConsumer(t *testing.T) {
+	// Test case: Channel not found
+	t.Run("channel_not_found", func(t *testing.T) {
+		_, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-1"
+		channelID := "channel-1"
+
+		channel, found := channelKeeper.GetChannelForConsumer(ctx, consumerID, channelID)
+		require.False(t, found, "Should not find non-existent channel")
+		require.Equal(t, channeltypes.IdentifiedChannel{}, channel, "Should return empty IdentifiedChannel")
+	})
+
+	// Test case: Channel exists but not open (INIT state)
+	t.Run("channel_not_open_init", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-2"
+		channelID := "channel-2"
+
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.INIT)
+
+		channel, found := channelKeeper.GetChannelForConsumer(ctx, consumerID, channelID)
+		require.False(t, found, "Should not find channel in INIT state")
+		require.Equal(t, channeltypes.IdentifiedChannel{}, channel, "Should return empty IdentifiedChannel")
+	})
+
+	// Test case: Channel exists but not open (TRYOPEN state)
+	t.Run("channel_not_open_tryopen", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-3"
+		channelID := "channel-3"
+
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.TRYOPEN)
+
+		channel, found := channelKeeper.GetChannelForConsumer(ctx, consumerID, channelID)
+		require.False(t, found, "Should not find channel in TRYOPEN state")
+		require.Equal(t, channeltypes.IdentifiedChannel{}, channel, "Should return empty IdentifiedChannel")
+	})
+
+	// Test case: Channel exists but closed
+	t.Run("channel_closed", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-4"
+		channelID := "channel-4"
+
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.CLOSED)
+
+		channel, found := channelKeeper.GetChannelForConsumer(ctx, consumerID, channelID)
+		require.False(t, found, "Should not find closed channel")
+		require.Equal(t, channeltypes.IdentifiedChannel{}, channel, "Should return empty IdentifiedChannel")
+	})
+
+	// Test case: Channel is open but client ID doesn't match consumer ID
+	t.Run("client_id_mismatch", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-5"
+		channelID := "channel-5"
+		differentClientID := "different-client-id"
+
+		// Setup with different client ID
+		babylonApp.IBCKeeper.ClientKeeper.SetClientState(ctx, differentClientID, &ibctmtypes.ClientState{})
+		babylonApp.IBCKeeper.ConnectionKeeper.SetConnection(
+			ctx, differentClientID, connectiontypes.ConnectionEnd{
+				ClientId: differentClientID,
+			},
+		)
+		babylonApp.IBCKeeper.ChannelKeeper.SetChannel(
+			ctx, zctypes.PortID, channelID, channeltypes.Channel{
+				State:          channeltypes.OPEN,
+				ConnectionHops: []string{differentClientID},
+			},
+		)
+
+		channel, found := channelKeeper.GetChannelForConsumer(ctx, consumerID, channelID)
+		require.False(t, found, "Should not find channel with mismatched client ID")
+		require.Equal(t, channeltypes.IdentifiedChannel{}, channel, "Should return empty IdentifiedChannel")
+	})
+
+	// Test case: Valid open channel with matching client ID
+	t.Run("valid_open_channel", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-6"
+		channelID := "channel-6"
+
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.OPEN)
+
+		channel, found := channelKeeper.GetChannelForConsumer(ctx, consumerID, channelID)
+		require.True(t, found, "Should find valid open channel")
+		require.NotEqual(t, channeltypes.IdentifiedChannel{}, channel, "Should return non-empty IdentifiedChannel")
+
+		// Verify channel details
+		require.Equal(t, zctypes.PortID, channel.PortId, "Should have correct port ID")
+		require.Equal(t, channelID, channel.ChannelId, "Should have correct channel ID")
+		require.Equal(t, channeltypes.OPEN, channel.State, "Should be in OPEN state")
+		require.Equal(t, []string{consumerID}, channel.ConnectionHops, "Should have correct connection hops")
+	})
+
+	// Test case: Multiple consumers, ensure correct matching
+	t.Run("multiple_consumers_correct_matching", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumer1ID := "consumer-7"
+		channel1ID := "channel-7"
+		consumer2ID := "consumer-8"
+		channel2ID := "channel-8"
+
+		// Setup two different consumers
+		setupConsumerChannel(babylonApp, ctx, consumer1ID, channel1ID, channeltypes.OPEN)
+		setupConsumerChannel(babylonApp, ctx, consumer2ID, channel2ID, channeltypes.OPEN)
+
+		// Test first consumer
+		channel1, found1 := channelKeeper.GetChannelForConsumer(ctx, consumer1ID, channel1ID)
+		require.True(t, found1, "Should find first consumer's channel")
+		require.Equal(t, channel1ID, channel1.ChannelId, "Should return correct channel ID for first consumer")
+		require.Equal(t, []string{consumer1ID}, channel1.ConnectionHops, "Should have correct connection for first consumer")
+
+		// Test second consumer
+		channel2, found2 := channelKeeper.GetChannelForConsumer(ctx, consumer2ID, channel2ID)
+		require.True(t, found2, "Should find second consumer's channel")
+		require.Equal(t, channel2ID, channel2.ChannelId, "Should return correct channel ID for second consumer")
+		require.Equal(t, []string{consumer2ID}, channel2.ConnectionHops, "Should have correct connection for second consumer")
+
+		// Test cross-consumer lookup (should fail)
+		_, found_cross := channelKeeper.GetChannelForConsumer(ctx, consumer1ID, channel2ID)
+		require.False(t, found_cross, "Should not find channel with mismatched consumer/channel combination")
+	})
+
+	// Test case: Same consumer ID, different channel IDs
+	t.Run("same_consumer_multiple_channels", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-9"
+		channel1ID := "channel-9-1"
+		channel2ID := "channel-9-2"
+
+		// Setup same consumer with multiple channels
+		setupConsumerChannel(babylonApp, ctx, consumerID, channel1ID, channeltypes.OPEN)
+		setupConsumerChannel(babylonApp, ctx, consumerID, channel2ID, channeltypes.OPEN)
+
+		// Test both channels
+		channel1, found1 := channelKeeper.GetChannelForConsumer(ctx, consumerID, channel1ID)
+		require.True(t, found1, "Should find first channel")
+		require.Equal(t, channel1ID, channel1.ChannelId, "Should return correct first channel ID")
+
+		channel2, found2 := channelKeeper.GetChannelForConsumer(ctx, consumerID, channel2ID)
+		require.True(t, found2, "Should find second channel")
+		require.Equal(t, channel2ID, channel2.ChannelId, "Should return correct second channel ID")
+	})
+
+	// Test case: Test with context cancellation scenarios
+	t.Run("context_handling", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-12"
+		channelID := "channel-12"
+
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.OPEN)
+
+		// Test with a fresh context
+		freshCtx := babylonApp.NewContext(false)
+		channel, found := channelKeeper.GetChannelForConsumer(freshCtx, consumerID, channelID)
+		require.True(t, found, "Should find channel with fresh context")
+		require.Equal(t, channelID, channel.ChannelId, "Should return correct channel ID with fresh context")
+	})
+}
+
+func TestConsumerHasIBCChannelOpen(t *testing.T) {
+	// Test case: Channel not found
+	t.Run("channel_not_found", func(t *testing.T) {
+		_, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-not-exist"
+		channelID := "channel-not-exist"
+
+		hasOpen := channelKeeper.ConsumerHasIBCChannelOpen(ctx, consumerID, channelID)
+		require.False(t, hasOpen, "Should return false for non-existent channel")
+	})
+
+	// Test case: Channel exists but not open
+	t.Run("channel_exists_not_open", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-not-open-2"
+		channelID := "channel-not-open-2"
+
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.INIT)
+
+		hasOpen := channelKeeper.ConsumerHasIBCChannelOpen(ctx, consumerID, channelID)
+		require.False(t, hasOpen, "Should return false for channel in INIT state")
+	})
+
+	// Test case: Valid open channel
+	t.Run("valid_open_channel", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-hasopen"
+		channelID := "channel-hasopen"
+
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.OPEN)
+
+		hasOpen := channelKeeper.ConsumerHasIBCChannelOpen(ctx, consumerID, channelID)
+		require.True(t, hasOpen, "Should return true for valid open channel")
+	})
+
+	// Test case: Client ID mismatch
+	t.Run("client_id_mismatch", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-mismatch"
+		channelID := "channel-hasopen-2"
+		differentClientID := "different-client-hasopen-4"
+
+		// Setup with different client ID
+		babylonApp.IBCKeeper.ClientKeeper.SetClientState(ctx, differentClientID, &ibctmtypes.ClientState{})
+		babylonApp.IBCKeeper.ConnectionKeeper.SetConnection(
+			ctx, differentClientID, connectiontypes.ConnectionEnd{
+				ClientId: differentClientID,
+			},
+		)
+		babylonApp.IBCKeeper.ChannelKeeper.SetChannel(
+			ctx, zctypes.PortID, channelID, channeltypes.Channel{
+				State:          channeltypes.OPEN,
+				ConnectionHops: []string{differentClientID},
+			},
+		)
+
+		hasOpen := channelKeeper.ConsumerHasIBCChannelOpen(ctx, consumerID, channelID)
+		require.False(t, hasOpen, "Should return false for mismatched client ID")
+	})
+}
+
+func TestGetChannelForConsumer_IdentifiedChannelStructure(t *testing.T) {
+	babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+
+	consumerID := "consumer-structure-test"
+	channelID := "channel-structure-test"
+
+	setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.OPEN)
+
+	channel, found := channelKeeper.GetChannelForConsumer(ctx, consumerID, channelID)
+	require.True(t, found, "Should find the channel")
+
+	// Test the structure of IdentifiedChannel
+	t.Run("identified_channel_structure", func(t *testing.T) {
+		require.IsType(t, channeltypes.IdentifiedChannel{}, channel, "Should return IdentifiedChannel type")
+		require.NotEmpty(t, channel.PortId, "Port ID should not be empty")
+		require.NotEmpty(t, channel.ChannelId, "Channel ID should not be empty")
+		require.Equal(t, zctypes.PortID, channel.PortId, "Should use zoneconcierge port ID")
+		require.Equal(t, channelID, channel.ChannelId, "Should return the correct channel ID")
+	})
+
+	// Test the Channel field within IdentifiedChannel
+	t.Run("channel_field_structure", func(t *testing.T) {
+		require.Equal(t, channeltypes.OPEN, channel.State, "Channel should be in OPEN state")
+		require.NotEmpty(t, channel.ConnectionHops, "Connection hops should not be empty")
+		require.Contains(t, channel.ConnectionHops, consumerID, "Connection hops should contain consumer ID")
+		require.Len(t, channel.ConnectionHops, 1, "Should have exactly one connection hop")
+	})
+}
+
+func TestGetChannelForConsumer_AdditionalEdgeCases(t *testing.T) {
+	babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+
+	// Test with different channel states
+	t.Run("all_channel_states", func(t *testing.T) {
+		consumerID := "consumer-states"
+
+		// Test all possible channel states
+		states := []struct {
+			state    channeltypes.State
+			expected bool
+			name     string
+		}{
+			{channeltypes.UNINITIALIZED, false, "UNINITIALIZED"},
+			{channeltypes.INIT, false, "INIT"},
+			{channeltypes.TRYOPEN, false, "TRYOPEN"},
+			{channeltypes.OPEN, true, "OPEN"},
+			{channeltypes.CLOSED, false, "CLOSED"},
+		}
+
+		for i, test := range states {
+			channelID := fmt.Sprintf("channel-state-%d", i)
+			setupConsumerChannel(babylonApp, ctx, consumerID, channelID, test.state)
+
+			_, found := channelKeeper.GetChannelForConsumer(ctx, consumerID, channelID)
+			if test.expected {
+				require.True(t, found, "Should find channel in %s state", test.name)
+			} else {
+				require.False(t, found, "Should not find channel in %s state", test.name)
+			}
+		}
+	})
+
+	// Test multiple sequential calls for consistency
+	t.Run("consistency_check", func(t *testing.T) {
+		consumerID := "consumer-consistency"
+		channelID := "channel-consistency"
+
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.OPEN)
+
+		// Call multiple times to ensure consistency
+		for i := 0; i < 5; i++ {
+			channel, found := channelKeeper.GetChannelForConsumer(ctx, consumerID, channelID)
+			require.True(t, found, "Call %d should succeed", i)
+			require.Equal(t, channelID, channel.ChannelId, "Channel ID should be consistent on call %d", i)
+			require.Equal(t, channeltypes.OPEN, channel.State, "Channel state should be consistent on call %d", i)
+		}
+	})
+}
+
+func TestGetAllOpenZCChannels(t *testing.T) {
+	babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+
+	// Test empty case - no channels exist
+	t.Run("no_channels_exist", func(t *testing.T) {
+		openChannels := channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Empty(t, openChannels, "Should return empty slice when no channels exist")
+		require.NotNil(t, openChannels, "Should return non-nil empty slice")
+	})
+
+	// Test single open channel
+	t.Run("single_open_channel", func(t *testing.T) {
+		// Create fresh context to avoid interference
+		ctx1 := babylonApp.NewContext(false)
+
+		consumerID := "consumer-single"
+		channelID := "channel-single"
+
+		setupConsumerChannel(babylonApp, ctx1, consumerID, channelID, channeltypes.OPEN)
+
+		openChannels := channelKeeper.GetAllOpenZCChannels(ctx1)
+		require.Len(t, openChannels, 1, "Should return exactly one open channel")
+		require.Equal(t, channelID, openChannels[0].ChannelId, "Should return the correct channel")
+		require.Equal(t, zctypes.PortID, openChannels[0].PortId, "Should use zoneconcierge port")
+		require.Equal(t, channeltypes.OPEN, openChannels[0].State, "Should be in OPEN state")
+	})
+
+	// Test channels in different states - only OPEN should be returned
+	t.Run("filter_by_open_state", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper = setupChannelKeeperTest(t)
+
+		// Setup channels in different states
+		states := []struct {
+			consumerID string
+			channelID  string
+			state      channeltypes.State
+			name       string
+		}{
+			{"consumer-uninit", "channel-uninit", channeltypes.UNINITIALIZED, "UNINITIALIZED"},
+			{"consumer-init", "channel-init", channeltypes.INIT, "INIT"},
+			{"consumer-tryopen", "channel-tryopen", channeltypes.TRYOPEN, "TRYOPEN"},
+			{"consumer-open1", "channel-open1", channeltypes.OPEN, "OPEN1"},
+			{"consumer-open2", "channel-open2", channeltypes.OPEN, "OPEN2"},
+			{"consumer-closed", "channel-closed", channeltypes.CLOSED, "CLOSED"},
+		}
+
+		for _, test := range states {
+			setupConsumerChannel(babylonApp, ctx, test.consumerID, test.channelID, test.state)
+		}
+
+		openChannels := channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Len(t, openChannels, 2, "Should return only OPEN channels")
+
+		// Verify all returned channels are OPEN
+		openChannelIDs := make(map[string]bool)
+		for _, channel := range openChannels {
+			require.Equal(t, channeltypes.OPEN, channel.State, "All returned channels should be OPEN")
+			require.Equal(t, zctypes.PortID, channel.PortId, "All channels should use zoneconcierge port")
+			openChannelIDs[channel.ChannelId] = true
+		}
+
+		// Verify correct channels are returned
+		require.True(t, openChannelIDs["channel-open1"], "Should include channel-open1")
+		require.True(t, openChannelIDs["channel-open2"], "Should include channel-open2")
+	})
+
+	// Test multiple open channels
+	t.Run("multiple_open_channels", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper = setupChannelKeeperTest(t)
+
+		expectedChannels := []struct {
+			consumerID string
+			channelID  string
+		}{
+			{"consumer-multi-1", "channel-multi-1"},
+			{"consumer-multi-2", "channel-multi-2"},
+			{"consumer-multi-3", "channel-multi-3"},
+			{"consumer-multi-4", "channel-multi-4"},
+			{"consumer-multi-5", "channel-multi-5"},
+		}
+
+		// Setup multiple open channels
+		for _, expected := range expectedChannels {
+			setupConsumerChannel(babylonApp, ctx, expected.consumerID, expected.channelID, channeltypes.OPEN)
+		}
+
+		openChannels := channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Len(t, openChannels, len(expectedChannels), "Should return all open channels")
+
+		// Verify all channels are returned and have correct properties
+		channelIDs := make(map[string]bool)
+		for _, channel := range openChannels {
+			require.Equal(t, channeltypes.OPEN, channel.State, "Channel %s should be OPEN", channel.ChannelId)
+			require.Equal(t, zctypes.PortID, channel.PortId, "Channel %s should use zoneconcierge port", channel.ChannelId)
+			channelIDs[channel.ChannelId] = true
+		}
+
+		// Verify all expected channels are present
+		for _, expected := range expectedChannels {
+			require.True(t, channelIDs[expected.channelID], "Should include %s", expected.channelID)
+		}
+	})
+
+	// Test that non-zoneconcierge port channels are filtered out
+	t.Run("filter_by_port_prefix", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper = setupChannelKeeperTest(t)
+
+		// Setup zoneconcierge channel (should be included)
+		consumerID1 := "consumer-zc"
+		channelID1 := "channel-zc"
+		setupConsumerChannel(babylonApp, ctx, consumerID1, channelID1, channeltypes.OPEN)
+
+		// Setup channel with different port (should be filtered out)
+		consumerID2 := "consumer-other"
+		channelID2 := "channel-other"
+		babylonApp.IBCKeeper.ClientKeeper.SetClientState(ctx, consumerID2, &ibctmtypes.ClientState{})
+		babylonApp.IBCKeeper.ConnectionKeeper.SetConnection(
+			ctx, consumerID2, connectiontypes.ConnectionEnd{
+				ClientId: consumerID2,
+			},
+		)
+		// Set with different port ID (not zoneconcierge)
+		babylonApp.IBCKeeper.ChannelKeeper.SetChannel(
+			ctx, "different-port", channelID2, channeltypes.Channel{
+				State:          channeltypes.OPEN,
+				ConnectionHops: []string{consumerID2},
+			},
+		)
+
+		openChannels := channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Len(t, openChannels, 1, "Should only return zoneconcierge port channels")
+		require.Equal(t, channelID1, openChannels[0].ChannelId, "Should return the zoneconcierge channel")
+		require.Equal(t, zctypes.PortID, openChannels[0].PortId, "Should use zoneconcierge port")
+	})
+
+	// Test return value consistency
+	t.Run("return_value_consistency", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper = setupChannelKeeperTest(t)
+
+		consumerID := "consumer-consistency"
+		channelID := "channel-consistency"
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.OPEN)
+
+		// Call multiple times and verify consistency
+		for i := 0; i < 5; i++ {
+			openChannels := channelKeeper.GetAllOpenZCChannels(ctx)
+			require.Len(t, openChannels, 1, "Should consistently return 1 channel on call %d", i)
+			require.Equal(t, channelID, openChannels[0].ChannelId, "Channel ID should be consistent on call %d", i)
+			require.Equal(t, channeltypes.OPEN, openChannels[0].State, "Channel state should be consistent on call %d", i)
+		}
+	})
+
+	// Test slice behavior and immutability
+	t.Run("slice_behavior", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper = setupChannelKeeperTest(t)
+
+		consumerID := "consumer-slice"
+		channelID := "channel-slice"
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.OPEN)
+
+		// Get first slice
+		openChannels1 := channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Len(t, openChannels1, 1)
+
+		// Get second slice
+		openChannels2 := channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Len(t, openChannels2, 1)
+
+		// Verify they contain the same data but are different slice instances
+		require.Equal(t, openChannels1[0].ChannelId, openChannels2[0].ChannelId, "Channel IDs should match")
+		require.Equal(t, openChannels1[0].State, openChannels2[0].State, "Channel states should match")
+
+		// Modifying one slice should not affect the other (different instances)
+		if len(openChannels1) > 0 {
+			originalChannelID := openChannels1[0].ChannelId
+			// This modification shouldn't affect the stored data or other calls
+			openChannels1[0].ChannelId = "modified-channel"
+
+			// Get fresh slice and verify original data is unchanged
+			openChannels3 := channelKeeper.GetAllOpenZCChannels(ctx)
+			require.Equal(t, originalChannelID, openChannels3[0].ChannelId, "Original data should be unchanged")
+		}
+	})
+}
+
+func TestGetAllOpenZCChannels_StateTransitions(t *testing.T) {
+	// Test state transitions and their effect on GetAllOpenZCChannels
+	t.Run("state_transitions", func(t *testing.T) {
+		babylonApp, ctx, channelKeeper := setupChannelKeeperTest(t)
+		consumerID := "consumer-transition"
+		channelID := "channel-transition"
+
+		// Initially no channels
+		openChannels := channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Empty(t, openChannels, "Should start with no channels")
+
+		// Create channel in INIT state
+		setupConsumerChannel(babylonApp, ctx, consumerID, channelID, channeltypes.INIT)
+		openChannels = channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Empty(t, openChannels, "Should not include INIT channels")
+
+		// Transition to TRYOPEN
+		babylonApp.IBCKeeper.ChannelKeeper.SetChannel(
+			ctx, zctypes.PortID, channelID, channeltypes.Channel{
+				State:          channeltypes.TRYOPEN,
+				ConnectionHops: []string{consumerID},
+			},
+		)
+		openChannels = channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Empty(t, openChannels, "Should not include TRYOPEN channels")
+
+		// Transition to OPEN
+		babylonApp.IBCKeeper.ChannelKeeper.SetChannel(
+			ctx, zctypes.PortID, channelID, channeltypes.Channel{
+				State:          channeltypes.OPEN,
+				ConnectionHops: []string{consumerID},
+			},
+		)
+		openChannels = channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Len(t, openChannels, 1, "Should include OPEN channels")
+		require.Equal(t, channelID, openChannels[0].ChannelId, "Should return the opened channel")
+
+		// Transition to CLOSED
+		babylonApp.IBCKeeper.ChannelKeeper.SetChannel(
+			ctx, zctypes.PortID, channelID, channeltypes.Channel{
+				State:          channeltypes.CLOSED,
+				ConnectionHops: []string{consumerID},
+			},
+		)
+		openChannels = channelKeeper.GetAllOpenZCChannels(ctx)
+		require.Empty(t, openChannels, "Should not include CLOSED channels")
+	})
+}

--- a/x/zoneconcierge/keeper/consumer_registry.go
+++ b/x/zoneconcierge/keeper/consumer_registry.go
@@ -17,21 +17,3 @@ func (k Keeper) HasConsumer(ctx context.Context, consumerID string) bool {
 
 	return isCosmosConsumer
 }
-
-// GetAllConsumerIDs returns all registered Cosmos consumer IDs
-func (k Keeper) GetAllConsumerIDs(ctx context.Context) []string {
-	allConsumerIDs := k.btcStkKeeper.GetAllRegisteredConsumerIDs(ctx)
-
-	var cosmosConsumerIDs []string
-	for _, consumerID := range allConsumerIDs {
-		isCosmosConsumer, err := k.btcStkKeeper.IsCosmosConsumer(ctx, consumerID)
-		if err != nil {
-			continue
-		}
-		if isCosmosConsumer {
-			cosmosConsumerIDs = append(cosmosConsumerIDs, consumerID)
-		}
-	}
-
-	return cosmosConsumerIDs
-}

--- a/x/zoneconcierge/keeper/genesis_test.go
+++ b/x/zoneconcierge/keeper/genesis_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/babylonlabs-io/babylon/v3/testutil/datagen"
 	keepertest "github.com/babylonlabs-io/babylon/v3/testutil/keeper"
+	btcstkconsumertypes "github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
 	"github.com/babylonlabs-io/babylon/v3/x/zoneconcierge/types"
 
 	"github.com/golang/mock/gomock"
@@ -27,7 +28,7 @@ func FuzzTestExportGenesis(f *testing.F) {
 
 		// mock btcstkconsumer keeper
 		btcStkConsumerKeeper := types.NewMockBTCStkConsumerKeeper(ctrl)
-		btcStkConsumerKeeper.EXPECT().GetAllRegisteredConsumerIDs(gomock.Any()).Return([]string{}).AnyTimes()
+		btcStkConsumerKeeper.EXPECT().GetAllRegisteredCosmosConsumers(gomock.Any()).Return([]*btcstkconsumertypes.ConsumerRegister{}).AnyTimes()
 		btcStkConsumerKeeper.EXPECT().IsCosmosConsumer(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 
 		k, ctx := keepertest.ZoneConciergeKeeper(t, nil, nil, nil, nil, nil, nil, btcStkConsumerKeeper)
@@ -58,7 +59,7 @@ func FuzzTestInitGenesis(f *testing.F) {
 
 		// mock btcstkconsumer keeper
 		btcStkConsumerKeeper := types.NewMockBTCStkConsumerKeeper(ctrl)
-		btcStkConsumerKeeper.EXPECT().GetAllRegisteredConsumerIDs(gomock.Any()).Return([]string{}).AnyTimes()
+		btcStkConsumerKeeper.EXPECT().GetAllRegisteredCosmosConsumers(gomock.Any()).Return([]*btcstkconsumertypes.ConsumerRegister{}).AnyTimes()
 		btcStkConsumerKeeper.EXPECT().IsCosmosConsumer(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 
 		k, ctx := keepertest.ZoneConciergeKeeper(t, nil, nil, nil, nil, nil, nil, btcStkConsumerKeeper)

--- a/x/zoneconcierge/keeper/grpc_query_test.go
+++ b/x/zoneconcierge/keeper/grpc_query_test.go
@@ -5,10 +5,11 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/babylonlabs-io/babylon/v3/app"
-	btclightclienttypes "github.com/babylonlabs-io/babylon/v3/x/btclightclient/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/babylonlabs-io/babylon/v3/app"
+	btclightclienttypes "github.com/babylonlabs-io/babylon/v3/x/btclightclient/types"
 
 	"github.com/babylonlabs-io/babylon/v3/testutil/datagen"
 	testkeeper "github.com/babylonlabs-io/babylon/v3/testutil/keeper"
@@ -143,7 +144,7 @@ func FuzzFinalizedChainInfo(f *testing.F) {
 		)
 
 		// Set up the mock to return the consumerIDs slice
-		btcStkConsumerKeeper.EXPECT().GetAllRegisteredConsumerIDs(gomock.Any()).DoAndReturn(func(ctx context.Context) []string {
+		btcStkConsumerKeeper.EXPECT().GetAllRegisteredCosmosConsumers(gomock.Any()).DoAndReturn(func(ctx context.Context) []string {
 			return consumerIDs
 		}).AnyTimes()
 		numChains := datagen.RandomInt(r, 100) + 1

--- a/x/zoneconcierge/types/expected_keepers.go
+++ b/x/zoneconcierge/types/expected_keepers.go
@@ -3,6 +3,12 @@ package types
 import (
 	"context"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	clienttypes "github.com/cosmos/ibc-go/v10/modules/core/02-client/types" //nolint:staticcheck
+	connectiontypes "github.com/cosmos/ibc-go/v10/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
+
 	bbn "github.com/babylonlabs-io/babylon/v3/types"
 	btcctypes "github.com/babylonlabs-io/babylon/v3/x/btccheckpoint/types"
 	btclctypes "github.com/babylonlabs-io/babylon/v3/x/btclightclient/types"
@@ -10,11 +16,6 @@ import (
 	btcstkconsumertypes "github.com/babylonlabs-io/babylon/v3/x/btcstkconsumer/types"
 	checkpointingtypes "github.com/babylonlabs-io/babylon/v3/x/checkpointing/types"
 	epochingtypes "github.com/babylonlabs-io/babylon/v3/x/epoching/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	clienttypes "github.com/cosmos/ibc-go/v10/modules/core/02-client/types" //nolint:staticcheck
-	connectiontypes "github.com/cosmos/ibc-go/v10/modules/core/03-connection/types"
-	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
-	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
 )
 
 // AccountKeeper defines the contract required for account APIs.
@@ -50,13 +51,14 @@ type ChannelKeeper interface {
 	GetChannel(ctx sdk.Context, srcPort, srcChan string) (channel channeltypes.Channel, found bool)
 	GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool)
 	GetAllChannels(ctx sdk.Context) (channels []channeltypes.IdentifiedChannel)
+	GetAllChannelsWithPortPrefix(ctx sdk.Context, portPrefix string) []channeltypes.IdentifiedChannel
 	GetChannelClientState(ctx sdk.Context, portID, channelID string) (string, ibcexported.ClientState, error)
 }
 
 // ZoneConciergeChannelKeeper defines the expected zoneconcierge IBC channel keeper
 type ZoneConciergeChannelKeeper interface {
 	GetChannelClientState(ctx sdk.Context, portID, channelID string) (string, ibcexported.ClientState, error)
-	GetChannelForConsumer(ctx context.Context, consumerID string) (channeltypes.IdentifiedChannel, bool)
+	GetChannelForConsumer(ctx context.Context, consumerID, channelID string) (channeltypes.IdentifiedChannel, bool)
 	GetAllOpenZCChannels(ctx context.Context) []channeltypes.IdentifiedChannel
 	GetClientID(ctx context.Context, channel channeltypes.IdentifiedChannel) (string, error)
 	IsChannelUninitialized(ctx context.Context, channel channeltypes.IdentifiedChannel) bool
@@ -111,6 +113,6 @@ type BTCStkConsumerKeeper interface {
 	UpdateConsumer(ctx context.Context, consumerRegister *btcstkconsumertypes.ConsumerRegister) error
 	GetConsumerRegister(ctx context.Context, consumerID string) (*btcstkconsumertypes.ConsumerRegister, error)
 	IsConsumerRegistered(ctx context.Context, consumerID string) bool
-	GetAllRegisteredConsumerIDs(ctx context.Context) []string
+	GetAllRegisteredCosmosConsumers(ctx context.Context) []*btcstkconsumertypes.ConsumerRegister
 	IsCosmosConsumer(ctx context.Context, consumerID string) (bool, error)
 }

--- a/x/zoneconcierge/types/mocked_keepers.go
+++ b/x/zoneconcierge/types/mocked_keepers.go
@@ -256,6 +256,20 @@ func (mr *MockChannelKeeperMockRecorder) GetAllChannels(ctx interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllChannels", reflect.TypeOf((*MockChannelKeeper)(nil).GetAllChannels), ctx)
 }
 
+// GetAllChannelsWithPortPrefix mocks base method.
+func (m *MockChannelKeeper) GetAllChannelsWithPortPrefix(ctx types6.Context, portPrefix string) []types9.IdentifiedChannel {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllChannelsWithPortPrefix", ctx, portPrefix)
+	ret0, _ := ret[0].([]types9.IdentifiedChannel)
+	return ret0
+}
+
+// GetAllChannelsWithPortPrefix indicates an expected call of GetAllChannelsWithPortPrefix.
+func (mr *MockChannelKeeperMockRecorder) GetAllChannelsWithPortPrefix(ctx, portPrefix interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllChannelsWithPortPrefix", reflect.TypeOf((*MockChannelKeeper)(nil).GetAllChannelsWithPortPrefix), ctx, portPrefix)
+}
+
 // GetChannel mocks base method.
 func (m *MockChannelKeeper) GetChannel(ctx types6.Context, srcPort, srcChan string) (types9.Channel, bool) {
 	m.ctrl.T.Helper()
@@ -356,18 +370,18 @@ func (mr *MockZoneConciergeChannelKeeperMockRecorder) GetChannelClientState(ctx,
 }
 
 // GetChannelForConsumer mocks base method.
-func (m *MockZoneConciergeChannelKeeper) GetChannelForConsumer(ctx context.Context, consumerID string) (types9.IdentifiedChannel, bool) {
+func (m *MockZoneConciergeChannelKeeper) GetChannelForConsumer(ctx context.Context, consumerID, channelID string) (types9.IdentifiedChannel, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChannelForConsumer", ctx, consumerID)
+	ret := m.ctrl.Call(m, "GetChannelForConsumer", ctx, consumerID, channelID)
 	ret0, _ := ret[0].(types9.IdentifiedChannel)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // GetChannelForConsumer indicates an expected call of GetChannelForConsumer.
-func (mr *MockZoneConciergeChannelKeeperMockRecorder) GetChannelForConsumer(ctx, consumerID interface{}) *gomock.Call {
+func (mr *MockZoneConciergeChannelKeeperMockRecorder) GetChannelForConsumer(ctx, consumerID, channelID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelForConsumer", reflect.TypeOf((*MockZoneConciergeChannelKeeper)(nil).GetChannelForConsumer), ctx, consumerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelForConsumer", reflect.TypeOf((*MockZoneConciergeChannelKeeper)(nil).GetChannelForConsumer), ctx, consumerID, channelID)
 }
 
 // GetClientID mocks base method.
@@ -882,18 +896,18 @@ func (m *MockBTCStkConsumerKeeper) EXPECT() *MockBTCStkConsumerKeeperMockRecorde
 	return m.recorder
 }
 
-// GetAllRegisteredConsumerIDs mocks base method.
-func (m *MockBTCStkConsumerKeeper) GetAllRegisteredConsumerIDs(ctx context.Context) []string {
+// GetAllRegisteredCosmosConsumers mocks base method.
+func (m *MockBTCStkConsumerKeeper) GetAllRegisteredCosmosConsumers(ctx context.Context) []*types3.ConsumerRegister {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllRegisteredConsumerIDs", ctx)
-	ret0, _ := ret[0].([]string)
+	ret := m.ctrl.Call(m, "GetAllRegisteredCosmosConsumers", ctx)
+	ret0, _ := ret[0].([]*types3.ConsumerRegister)
 	return ret0
 }
 
-// GetAllRegisteredConsumerIDs indicates an expected call of GetAllRegisteredConsumerIDs.
-func (mr *MockBTCStkConsumerKeeperMockRecorder) GetAllRegisteredConsumerIDs(ctx interface{}) *gomock.Call {
+// GetAllRegisteredCosmosConsumers indicates an expected call of GetAllRegisteredCosmosConsumers.
+func (mr *MockBTCStkConsumerKeeperMockRecorder) GetAllRegisteredCosmosConsumers(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllRegisteredConsumerIDs", reflect.TypeOf((*MockBTCStkConsumerKeeper)(nil).GetAllRegisteredConsumerIDs), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllRegisteredCosmosConsumers", reflect.TypeOf((*MockBTCStkConsumerKeeper)(nil).GetAllRegisteredCosmosConsumers), ctx)
 }
 
 // GetConsumerRegister mocks base method.


### PR DESCRIPTION
Refactor in zoneconcierge to address inefficiencies and ambiguities in the logic for retrieving IBC channels and clients 

### 1. GetAllOpenZCChannels

- Currently, it retrieves all channels, but by using `GetAllChannelsWithPortPrefix`, we can explicitly fetch only the channels for the zoneconcierge port. This makes it more efficient and ensures that channels from other ports are never fetched.

### 2. GetChannelForConsumer

- Currently written to iterate over all channels to obtain the channel ID, but since RegisteredConsumer.metadata already contains the channel ID explicitly, we can use that directly for a more efficient and explicit retrieval.

### 3. GetAllConsumerIDs -> GetAllRegisteredCosmosConsumers
- At present, GetAllConsumerIDs is used to retrieve consumerIDs for packet broadcasting, but to enable explicit channel ID access and more efficient iteration, I’m adding `GetAllRegisteredCosmosConsumers`.
- But since the introduction of map in #1540, it is not currently used, but kept for potential future use.