### PR TITLE
fix(make): align PHONY targets with existing rules in gosec, linting, and protobuf makefiles

### DIFF
--- a/scripts/makefile/gosec.mk
+++ b/scripts/makefile/gosec.mk
@@ -19,4 +19,4 @@ gosec-docker:
 gosec-local:
 	gosec -exclude-generated -exclude-dir=$(CURDIR)/testutil -exclude-dir=$(CURDIR)/test -conf $(CURDIR)/gosec.json $(CURDIR)/...
 
-.PHONY: gosec-menu gosec-docker gosec-local
+.PHONY: gosec gosec-docker gosec-local

--- a/scripts/makefile/linting.mk
+++ b/scripts/makefile/linting.mk
@@ -50,7 +50,7 @@ lint-all-fix:
 	@codespell -w
 	@$(golangci_lint_cmd) run --out-format=tab --fix
 
-.PHONY: lint-go lint-go-fix lint-markdown lint-markdown-fix lint  lint-typo lint-typo-fix lint-all-fix
+.PHONY: lint-go lint-go-fix lint-markdown lint-markdown-fix lint-typo lint-typo-fix lint-all-fix
 
 format: ## Run code formatter
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' | xargs gofmt -w -s

--- a/scripts/makefile/protobuf.mk
+++ b/scripts/makefile/protobuf.mk
@@ -41,4 +41,4 @@ proto-format:
 proto-lint:
 	@$(bufImage) lint --error-format=json
 
-.PHONY: proto proto-gen proto-swagger-gen proto-format proto-lint proto-all
+.PHONY: proto-gen proto-swagger-gen proto-format proto-lint proto-all


### PR DESCRIPTION
 - scripts/makefile/gosec.mk: replace non-existent gosec-menu with gosec in .PHONY
- scripts/makefile/linting.mk: remove non-existent lint from .PHONY
- scripts/makefile/protobuf.mk: remove non-existent proto from .PHONY