### PR TITLE
fix: `LargestBtcReorg` prefix to follow mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - [#1585](https://github.com/babylonlabs-io/babylon/pull/1585) Remove allow-lists logic and state in `x/btcstaking` module
 
+### Bug fixes
+
+- [#1608](https://github.com/babylonlabs-io/babylon/pull/1608) fix: `x/btcstaking` prefix of `LargestBtcReOrg` to match mainnet.
+
 ## v3.0.0-rc.2
 
 - [#1529](https://github.com/babylonlabs-io/babylon/pull/1529) Allow `FinalityProviderHistoricalRewards` to have empty coins

--- a/app/upgrades/delete_dup_fp.go
+++ b/app/upgrades/delete_dup_fp.go
@@ -6,10 +6,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	upgradetypes "cosmossdk.io/x/upgrade/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-
-	"github.com/babylonlabs-io/babylon/v4/app/keepers"
 	bbn "github.com/babylonlabs-io/babylon/v4/types"
 	btcstktypes "github.com/babylonlabs-io/babylon/v4/x/btcstaking/types"
 )
@@ -27,22 +23,6 @@ type (
 		FpTotalSatsStaked(ctx context.Context, fpBTCPK *bbn.BIP340PubKey) (uint64, error)
 	}
 )
-
-func CreateUpgradeHandlerFpSoftDeleteDupAddr(mm *module.Manager, configurator module.Configurator, keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
-	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
-		if err != nil {
-			return nil, err
-		}
-
-		err = FpSoftDeleteDupAddr(ctx, keepers.BTCStakingKeeper)
-		if err != nil {
-			return nil, err
-		}
-
-		return migrations, nil
-	}
-}
 
 // FpSoftDeleteDupAddr Iterates over all the finality providers and sets their fp bbn address
 // To block registration with the same address. It also soft deletes (unables the btc pk to

--- a/app/upgrades/v2_3/upgrades.go
+++ b/app/upgrades/v2_3/upgrades.go
@@ -1,8 +1,13 @@
 package v2_3
 
 import (
-	store "cosmossdk.io/store/types"
+	"context"
 
+	store "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/babylonlabs-io/babylon/v4/app/keepers"
 	"github.com/babylonlabs-io/babylon/v4/app/upgrades"
 )
 
@@ -11,9 +16,25 @@ const UpgradeName = "v2.3"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
-	CreateUpgradeHandler: upgrades.CreateUpgradeHandlerFpSoftDeleteDupAddr,
+	CreateUpgradeHandler: CreateUpgradeHandler,
 	StoreUpgrades: store.StoreUpgrades{
 		Added:   []string{},
 		Deleted: []string{},
 	},
+}
+
+func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return nil, err
+		}
+
+		err = upgrades.FpSoftDeleteDupAddr(ctx, keepers.BTCStakingKeeper)
+		if err != nil {
+			return nil, err
+		}
+
+		return migrations, nil
+	}
 }

--- a/app/upgrades/v3rc3/upgrades.go
+++ b/app/upgrades/v3rc3/upgrades.go
@@ -101,24 +101,24 @@ func UpdatePrefixLargestBtcReorgInBlocks(
 }
 
 func GetLargestBtcReorg(largestBtcReorg, oldLargestBtcReorg btcstktypes.LargestBtcReOrg, err, errOld error) *btcstktypes.LargestBtcReOrg {
-	if err == nil && errOld == nil {
-		// both prefixes have valid largest btc reorgs, get the largest diff than
-		if oldLargestBtcReorg.BlockDiff > largestBtcReorg.BlockDiff {
-			return &oldLargestBtcReorg
-		}
-		return &largestBtcReorg
-	}
-
-	// only the prefix 11 has a valid largest
-	if err == nil {
-		return &largestBtcReorg
+	if err != nil && errOld != nil {
+		// no valid largest btc reorg, should clean it all
+		return nil
 	}
 
 	// only the prefix 13 has a valid largest
-	if errOld == nil {
+	if err != nil {
 		return &oldLargestBtcReorg
 	}
 
-	// no valid largest btc reorg, should clean it all
-	return nil
+	// only the prefix 11 has a valid largest
+	if errOld != nil {
+		return &largestBtcReorg
+	}
+
+	// both prefixes have valid largest btc reorgs, get the largest diff than
+	if oldLargestBtcReorg.BlockDiff > largestBtcReorg.BlockDiff {
+		return &oldLargestBtcReorg
+	}
+	return &largestBtcReorg
 }

--- a/app/upgrades/v3rc3/upgrades.go
+++ b/app/upgrades/v3rc3/upgrades.go
@@ -1,19 +1,124 @@
 package v3rc3
 
 import (
-	store "cosmossdk.io/store/types"
+	"context"
+	"errors"
 
+	"cosmossdk.io/collections"
+	corestoretypes "cosmossdk.io/core/store"
+	store "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+
+	"github.com/babylonlabs-io/babylon/v4/app/keepers"
 	"github.com/babylonlabs-io/babylon/v4/app/upgrades"
+	btcstakingkeeper "github.com/babylonlabs-io/babylon/v4/x/btcstaking/keeper"
+	btcstktypes "github.com/babylonlabs-io/babylon/v4/x/btcstaking/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
 // UpgradeName defines the on-chain upgrade name for the Babylon v3rc3 upgrade
 const UpgradeName = "v3rc3"
 
-var Upgrade = upgrades.Upgrade{
-	UpgradeName:          UpgradeName,
-	CreateUpgradeHandler: upgrades.CreateUpgradeHandlerFpSoftDeleteDupAddr,
-	StoreUpgrades: store.StoreUpgrades{
-		Added:   []string{},
-		Deleted: []string{},
-	},
+var (
+	// Babylon Mainnet has the LargestBtcReorgInBlocks at prefix 11, at PR https://github.com/babylonlabs-io/babylon/pull/518
+	// it was modified to prefix 13 and only applied to testnet. This will be changed in this upgrade so that all branches
+	// and babylon chains will follow mainnet and have LargestBtcReorgInBlocks at prefix 11. Luckily the prefix 11 in testnet
+	// was being reserved by BTCCOnsumerDelegatorKey which was not being used and it can be revoked and cleaned.
+	oldTestnetLargestBtcReorgInBlocks = collections.NewPrefix(13)
+
+	// Upgrade for version v3rc3
+	Upgrade = upgrades.Upgrade{
+		UpgradeName:          UpgradeName,
+		CreateUpgradeHandler: CreateUpgradeHandler,
+		StoreUpgrades: store.StoreUpgrades{
+			Added:   []string{},
+			Deleted: []string{},
+		},
+	}
+)
+
+func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Run migrations before applying any other state changes.
+		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return nil, err
+		}
+
+		err = upgrades.FpSoftDeleteDupAddr(ctx, keepers.BTCStakingKeeper)
+		if err != nil {
+			return nil, err
+		}
+
+		btcStkStoreKey := keepers.GetKey(btcstktypes.StoreKey)
+		if btcStkStoreKey == nil {
+			return nil, errors.New("invalid btcstaking types store key")
+		}
+
+		btcStkStoreService := runtime.NewKVStoreService(btcStkStoreKey)
+		err = UpdatePrefixLargestBtcReorgInBlocks(ctx, keepers.EncCfg.Codec, btcStkStoreService, keepers.BTCStakingKeeper)
+		if err != nil {
+			return nil, err
+		}
+
+		return migrations, nil
+	}
+}
+
+func UpdatePrefixLargestBtcReorgInBlocks(
+	ctx context.Context,
+	cdc codec.BinaryCodec,
+	btcStkStoreService corestoretypes.KVStoreService,
+	btcStkK btcstakingkeeper.Keeper,
+) error {
+	sb := collections.NewSchemaBuilder(btcStkStoreService)
+	oldLargestBtcReorgItem := collections.NewItem(
+		sb,
+		oldTestnetLargestBtcReorgInBlocks,
+		"largest_btc_reorg",
+		codec.CollValue[btcstktypes.LargestBtcReOrg](cdc),
+	)
+
+	largestBtcReorg, err := btcStkK.LargestBtcReorg.Get(ctx)
+	oldLargestBtcReorg, errOld := oldLargestBtcReorgItem.Get(ctx)
+
+	btcReorgToSet := GetLargestBtcReorg(largestBtcReorg, oldLargestBtcReorg, err, errOld)
+	if btcReorgToSet == nil { // nothing to set, just clean...
+		if err := btcStkK.LargestBtcReorg.Remove(ctx); err != nil {
+			return err
+		}
+	} else {
+		// there is something to set
+		if err := btcStkK.SetLargestBtcReorg(ctx, *btcReorgToSet); err != nil {
+			return err
+		}
+	}
+
+	// last thing is to clean the prefix 13
+	return oldLargestBtcReorgItem.Remove(ctx)
+}
+
+func GetLargestBtcReorg(largestBtcReorg, oldLargestBtcReorg btcstktypes.LargestBtcReOrg, err, errOld error) *btcstktypes.LargestBtcReOrg {
+	if err == nil && errOld == nil {
+		// both prefixes have valid largest btc reorgs, get the largest diff than
+		if oldLargestBtcReorg.BlockDiff > largestBtcReorg.BlockDiff {
+			return &oldLargestBtcReorg
+		}
+		return &largestBtcReorg
+	}
+
+	// only the prefix 11 has a valid largest
+	if err == nil {
+		return &largestBtcReorg
+	}
+
+	// only the prefix 13 has a valid largest
+	if errOld == nil {
+		return &oldLargestBtcReorg
+	}
+
+	// no valid largest btc reorg, should clean it all
+	return nil
 }

--- a/app/upgrades/v3rc3/upgrades.go
+++ b/app/upgrades/v3rc3/upgrades.go
@@ -26,7 +26,7 @@ var (
 	// it was modified to prefix 13 and only applied to testnet. This will be changed in this upgrade so that all branches
 	// and babylon chains will follow mainnet and have LargestBtcReorgInBlocks at prefix 11. Luckily the prefix 11 in testnet
 	// was being reserved by BTCCOnsumerDelegatorKey which was not being used and it can be revoked and cleaned.
-	oldTestnetLargestBtcReorgInBlocks = collections.NewPrefix(13)
+	OldTestnetLargestBtcReorgInBlocks = collections.NewPrefix(13)
 
 	// Upgrade for version v3rc3
 	Upgrade = upgrades.Upgrade{
@@ -76,7 +76,7 @@ func UpdatePrefixLargestBtcReorgInBlocks(
 	sb := collections.NewSchemaBuilder(btcStkStoreService)
 	oldLargestBtcReorgItem := collections.NewItem(
 		sb,
-		oldTestnetLargestBtcReorgInBlocks,
+		OldTestnetLargestBtcReorgInBlocks,
 		"largest_btc_reorg",
 		codec.CollValue[btcstktypes.LargestBtcReOrg](cdc),
 	)

--- a/app/upgrades/v3rc3/upgrades_test.go
+++ b/app/upgrades/v3rc3/upgrades_test.go
@@ -39,7 +39,7 @@ func TestGetLargestBtcReorg(t *testing.T) {
 	headerInfo1.Height = 100
 
 	headerInfo2 := datagen.GenRandomBTCHeaderInfo(r)
-	headerInfo1.Height = 200
+	headerInfo2.Height = 200
 
 	tcs := []struct {
 		name               string

--- a/app/upgrades/v3rc3/upgrades_test.go
+++ b/app/upgrades/v3rc3/upgrades_test.go
@@ -174,7 +174,6 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 			s.Upgrade,
 			func() {
 				s.PostUpgrade()
-
 			},
 		},
 	}

--- a/app/upgrades/v3rc3/upgrades_test.go
+++ b/app/upgrades/v3rc3/upgrades_test.go
@@ -1,0 +1,227 @@
+package v3rc3_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"cosmossdk.io/collections"
+	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/header"
+	"cosmossdk.io/x/upgrade"
+	bbn "github.com/babylonlabs-io/babylon/v4/types"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/stretchr/testify/suite"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/babylonlabs-io/babylon/v4/app"
+	"github.com/babylonlabs-io/babylon/v4/app/upgrades"
+	v3rc3 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v3rc3"
+	"github.com/babylonlabs-io/babylon/v4/testutil/datagen"
+	btcstktypes "github.com/babylonlabs-io/babylon/v4/x/btcstaking/types"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	DummyUpgradeHeight = 5
+)
+
+func TestGetLargestBtcReorg(t *testing.T) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+
+	headerInfo1 := datagen.GenRandomBTCHeaderInfo(r)
+	headerInfo1.Height = 100
+
+	headerInfo2 := datagen.GenRandomBTCHeaderInfo(r)
+	headerInfo1.Height = 200
+
+	tcs := []struct {
+		name               string
+		largestBtcReorg    btcstktypes.LargestBtcReOrg
+		oldLargestBtcReorg btcstktypes.LargestBtcReOrg
+		err                error
+		errOld             error
+		expectedResult     *btcstktypes.LargestBtcReOrg
+	}{
+		{
+			name: "both valid - choose largest diff",
+			largestBtcReorg: btcstktypes.LargestBtcReOrg{
+				BlockDiff:    10,
+				RollbackFrom: headerInfo1,
+				RollbackTo:   headerInfo2,
+			},
+			oldLargestBtcReorg: btcstktypes.LargestBtcReOrg{
+				BlockDiff:    20,
+				RollbackFrom: headerInfo2,
+				RollbackTo:   headerInfo1,
+			},
+			err:    nil,
+			errOld: nil,
+			expectedResult: &btcstktypes.LargestBtcReOrg{
+				BlockDiff:    20,
+				RollbackFrom: headerInfo2,
+				RollbackTo:   headerInfo1,
+			},
+		},
+		{
+			name: "both valid - current is larger",
+			largestBtcReorg: btcstktypes.LargestBtcReOrg{
+				BlockDiff:    30,
+				RollbackFrom: headerInfo1,
+				RollbackTo:   headerInfo2,
+			},
+			oldLargestBtcReorg: btcstktypes.LargestBtcReOrg{
+				BlockDiff:    20,
+				RollbackFrom: headerInfo2,
+				RollbackTo:   headerInfo1,
+			},
+			err:    nil,
+			errOld: nil,
+			expectedResult: &btcstktypes.LargestBtcReOrg{
+				BlockDiff:    30,
+				RollbackFrom: headerInfo1,
+				RollbackTo:   headerInfo2,
+			},
+		},
+		{
+			name: "only current valid",
+			largestBtcReorg: btcstktypes.LargestBtcReOrg{
+				BlockDiff:    15,
+				RollbackFrom: headerInfo1,
+				RollbackTo:   headerInfo2,
+			},
+			oldLargestBtcReorg: btcstktypes.LargestBtcReOrg{},
+			err:                nil,
+			errOld:             collections.ErrNotFound,
+			expectedResult: &btcstktypes.LargestBtcReOrg{
+				BlockDiff:    15,
+				RollbackFrom: headerInfo1,
+				RollbackTo:   headerInfo2,
+			},
+		},
+		{
+			name:            "only old valid",
+			largestBtcReorg: btcstktypes.LargestBtcReOrg{},
+			oldLargestBtcReorg: btcstktypes.LargestBtcReOrg{
+				BlockDiff:    25,
+				RollbackFrom: headerInfo2,
+				RollbackTo:   headerInfo1,
+			},
+			err:    collections.ErrNotFound,
+			errOld: nil,
+			expectedResult: &btcstktypes.LargestBtcReOrg{
+				BlockDiff:    25,
+				RollbackFrom: headerInfo2,
+				RollbackTo:   headerInfo1,
+			},
+		},
+		{
+			name:               "neither valid",
+			largestBtcReorg:    btcstktypes.LargestBtcReOrg{},
+			oldLargestBtcReorg: btcstktypes.LargestBtcReOrg{},
+			err:                collections.ErrNotFound,
+			errOld:             collections.ErrNotFound,
+			expectedResult:     nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := v3rc3.GetLargestBtcReorg(tc.largestBtcReorg, tc.oldLargestBtcReorg, tc.err, tc.errOld)
+			if tc.expectedResult == nil {
+				require.Nil(t, actual)
+				return
+			}
+			require.NotNil(t, actual)
+			require.Equal(t, tc.expectedResult.BlockDiff, actual.BlockDiff)
+			require.Equal(t, tc.expectedResult.RollbackFrom, actual.RollbackFrom)
+			require.Equal(t, tc.expectedResult.RollbackTo, actual.RollbackTo)
+		})
+	}
+}
+
+type UpgradeTestSuite struct {
+	suite.Suite
+
+	ctx       sdk.Context
+	app       *app.BabylonApp
+	preModule appmodule.HasPreBlocker
+}
+
+func TestUpgradeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeTestSuite))
+}
+
+func (s *UpgradeTestSuite) TestUpgrade() {
+	tcs := []struct {
+		msg         string
+		preUpgrade  func()
+		upgrade     func()
+		postUpgrade func()
+	}{
+		{
+			"Test upgrade v3rc3 with duplicated fp addr and largest btc reorg in prefix 13",
+			s.PreUpgrade,
+			s.Upgrade,
+			s.PostUpgrade,
+		},
+		{
+			"Test upgrade v3rc3 witout duplicated fp addr and without largest btc reorg in any prefix",
+			s.PreUpgrade,
+			s.Upgrade,
+			func() {
+				s.PostUpgrade()
+
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		s.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			s.SetupTest() // reset
+
+			tc.preUpgrade()
+			tc.upgrade()
+			tc.postUpgrade()
+		})
+	}
+}
+
+func (s *UpgradeTestSuite) SetupTest() {
+	// add the upgrade plan
+	app.Upgrades = []upgrades.Upgrade{v3rc3.Upgrade}
+
+	// set up app
+	s.app = app.SetupWithBitcoinConf(s.T(), false, bbn.BtcSignet)
+	s.ctx = s.app.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: "babylon-1", Time: time.Now().UTC()})
+	s.preModule = upgrade.NewAppModule(s.app.UpgradeKeeper, s.app.AccountKeeper.AddressCodec())
+}
+
+func (s *UpgradeTestSuite) PreUpgrade() {}
+
+func (s *UpgradeTestSuite) Upgrade() {
+	// inject upgrade plan
+	s.ctx = s.ctx.WithBlockHeight(DummyUpgradeHeight - 1)
+	plan := upgradetypes.Plan{Name: v3rc3.UpgradeName, Height: DummyUpgradeHeight}
+	err := s.app.UpgradeKeeper.ScheduleUpgrade(s.ctx, plan)
+	s.NoError(err)
+
+	// ensure upgrade plan exists
+	actualPlan, err := s.app.UpgradeKeeper.GetUpgradePlan(s.ctx)
+	s.NoError(err)
+	s.Equal(plan, actualPlan)
+
+	// execute upgrade
+	s.ctx = s.ctx.WithHeaderInfo(header.Info{Height: DummyUpgradeHeight, Time: s.ctx.BlockTime().Add(time.Second)}).WithBlockHeight(DummyUpgradeHeight)
+	s.NotPanics(func() {
+		_, err := s.preModule.PreBlock(s.ctx)
+		s.Require().NoError(err)
+	})
+}
+
+func (s *UpgradeTestSuite) PostUpgrade() {
+
+}

--- a/x/btcstaking/types/keys.go
+++ b/x/btcstaking/types/keys.go
@@ -27,12 +27,12 @@ var (
 	// 0x05 was used for something else in the past
 	BTCHeightKey = []byte{0x06} // key prefix for the BTC heights
 	// 0x07 was used for something else in the past
-	PowerDistUpdateKey             = []byte{0x08}              // key prefix for power distribution update events
-	AllowedStakingTxHashesKey      = collections.NewPrefix(9)  // key prefix for allowed staking tx hashes
-	HeightToVersionMapKey          = []byte{0x10}              // key prefix for height to version map
-	BTCConsumerDelegatorKey        = []byte{0x11}              // key prefix for the Consumer BTC delegators
-	BTCStakingEventKey             = []byte{0x12}              // key prefix for the BTC staking events
-	LargestBtcReorgInBlocks        = collections.NewPrefix(13) // key prefix for the BTC block height difference of the largest reorg
+	PowerDistUpdateKey        = []byte{0x08}              // key prefix for power distribution update events
+	AllowedStakingTxHashesKey = collections.NewPrefix(9)  // key prefix for allowed staking tx hashes
+	HeightToVersionMapKey     = []byte{0x10}              // key prefix for height to version map
+	LargestBtcReorgInBlocks   = collections.NewPrefix(11) // key prefix for the BTC block height difference of the largest reorg
+	BTCStakingEventKey        = []byte{0x12}              // key prefix for the BTC staking events
+	// prefix {13} is cleaned in v3rc3 and can be reused after that upgrade is run on testnet
 	FinalityProviderBsnIndexKey    = []byte{0x14}              // key prefix for the finality provider BSN index
 	AllowedMultiStakingTxHashesKey = collections.NewPrefix(15) // key prefix for allowed multi-staking tx hashes
 	FpBbnAddrKey                   = collections.NewPrefix(16) // key prefix for index fpBbnAddr


### PR DESCRIPTION
- Update Testnet upgrade `v3rc3` to bring back `LargestBtcReorg` to prefix number 11 
