### PR TITLE
fix awk version extractor

### DIFF
--- a/scripts/makefile/release.mk
+++ b/scripts/makefile/release.mk
@@ -15,7 +15,7 @@ release-help:
 	@echo ""
 
 # The below is adapted from https://github.com/osmosis-labs/osmosis/blob/main/Makefile
-GO_VERSION := $(shell grep -E '^go [0-9]+\.[0-9]+' go.mod | awk '{split($2, v, "."); print v[1]"."v[2]}')
+GO_VERSION := $(shell grep -E '^go [0-9]+\.[0-9]+' go.mod | awk '{split($$2, v, "."); print v[1]"."v[2]}')
 GORELEASER_IMAGE := ghcr.io/goreleaser/goreleaser-cross:v$(GO_VERSION)
 COSMWASM_VERSION := $(shell go list -m github.com/CosmWasm/wasmvm/v2 | sed 's/.* //')
 


### PR DESCRIPTION
Fixes awk version extractor.

The problem was that in Makefiles, when using awk within a shell command, we need to escape the $ character by doubling it ($$) when we want to reference awk variables. This is because Make itself uses $ for its own variable interpolation.

Without the fix every command in makefile shows:
```
awk: syntax error at source line 1
 context is
         >>> {split(, <<<
awk: illegal statement at source line 1
awk: illegal statement at source line 
```
error