### PR TITLE
Add : Upgrade handler for epoching spam prevention (#1663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
-- [#1664] (https://github.com/babylonlabs-io/babylon/pull/1663) Add upgrade handler for spam prevention mechanisms to epoching
+- [#1703] (https://github.com/babylonlabs-io/babylon/pull/1703) Add upgrade handler for spam prevention mechanisms to epoching
 - [#1663] (https://github.com/babylonlabs-io/babylon/pull/1663) Add spam prevention mechanisms to epoching module with minimum amount validation and gas consumption limits for wrapped delegate operations.
 - [#1571](https://github.com/babylonlabs-io/babylon/pull/1571) Optimize `x/zoneconcierge` bottlenecks by caching redundant logics.
 - [#1584](https://github.com/babylonlabs-io/babylon/pull/1584) Add e2e test for wrapper feemarket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#1664] (https://github.com/babylonlabs-io/babylon/pull/1663) Add upgrade handler for spam prevention mechanisms to epoching
 - [#1663] (https://github.com/babylonlabs-io/babylon/pull/1663) Add spam prevention mechanisms to epoching module with minimum amount validation and gas consumption limits for wrapped delegate operations.
 - [#1571](https://github.com/babylonlabs-io/babylon/pull/1571) Optimize `x/zoneconcierge` bottlenecks by caching redundant logics.
 - [#1584](https://github.com/babylonlabs-io/babylon/pull/1584) Add e2e test for wrapper feemarket

--- a/app/include_upgrade_testnet.go
+++ b/app/include_upgrade_testnet.go
@@ -10,6 +10,7 @@ import (
 	v3 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v3"
 	v3rc2 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v3rc2/testnet"
 	v3rc3 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v3rc3"
+	v3rc4 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v3rc4/testnet"
 )
 
 // init is used to include v1 upgrade testnet data
@@ -22,5 +23,6 @@ func init() {
 		v2rc4.Upgrade,
 		v2.CreateUpgrade(true, map[string]struct{}{}),
 		v22.Upgrade,
+		v3rc4.Upgrade,
 	}
 }

--- a/app/include_upgrade_testnet.go
+++ b/app/include_upgrade_testnet.go
@@ -17,12 +17,12 @@ import (
 // it is also used for e2e testing
 func init() {
 	Upgrades = []upgrades.Upgrade{
+		v3rc4.Upgrade,
 		v3rc3.Upgrade, // same as v2_3 mainnet
 		v3rc2.Upgrade,
 		v3.CreateUpgrade(false, 10, 264773, 2419200), // TODO: to be updated
 		v2rc4.Upgrade,
 		v2.CreateUpgrade(true, map[string]struct{}{}),
 		v22.Upgrade,
-		v3rc4.Upgrade,
 	}
 }

--- a/app/upgrades/epoching/validation.go
+++ b/app/upgrades/epoching/validation.go
@@ -8,6 +8,7 @@ import (
 	epochingkeeper "github.com/babylonlabs-io/babylon/v4/x/epoching/keeper"
 	"github.com/babylonlabs-io/babylon/v4/x/epoching/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
@@ -19,6 +20,14 @@ func ValidateDelegatePoolModuleAccount(ctx context.Context, ak types.AccountKeep
 			types.DelegatePoolModuleName)
 	}
 
+	// Check if account exists and is not a module account
+	acc := ak.GetAccount(ctx, moduleAddr)
+	if acc != nil {
+		if _, ok := acc.(sdktypes.ModuleAccountI); !ok {
+			return fmt.Errorf("regular account exists at module address %s - should be removed and replaced by module account",
+				moduleAddr.String())
+		}
+	}
 	// Module account address exists, which means it's properly configured
 	// The actual account object will be created when first used by the module
 	sdkCtx := sdk.UnwrapSDKContext(ctx)

--- a/app/upgrades/epoching/validation.go
+++ b/app/upgrades/epoching/validation.go
@@ -1,0 +1,99 @@
+package epoching
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/babylonlabs-io/babylon/v4/app/keepers"
+	epochingkeeper "github.com/babylonlabs-io/babylon/v4/x/epoching/keeper"
+	"github.com/babylonlabs-io/babylon/v4/x/epoching/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// ValidateDelegatePoolModuleAccount validates that the delegation pool module account is properly configured
+func ValidateDelegatePoolModuleAccount(ctx context.Context, ak types.AccountKeeper) error {
+	moduleAddr := ak.GetModuleAddress(types.DelegatePoolModuleName)
+	if moduleAddr == nil {
+		return fmt.Errorf("module account %s has not been configured - ensure it's added to maccPerms in app.go",
+			types.DelegatePoolModuleName)
+	}
+
+	// Module account address exists, which means it's properly configured
+	// The actual account object will be created when first used by the module
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	sdkCtx.Logger().Info("delegation pool module account validated",
+		"module", types.DelegatePoolModuleName,
+		"address", moduleAddr.String())
+
+	return nil
+}
+
+// ValidateDelegatePoolEmpty validates that the delegation pool module account has no locked funds
+func ValidateDelegatePoolEmpty(ctx context.Context, ak types.AccountKeeper, bk types.BankKeeper) error {
+	moduleAddr := ak.GetModuleAddress(types.DelegatePoolModuleName)
+
+	balance := bk.SpendableCoins(ctx, moduleAddr)
+	if !balance.IsZero() {
+		return fmt.Errorf("delegation pool has locked funds (balance: %s)",
+			balance.String())
+	}
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	sdkCtx.Logger().Info("delegation pool validation successful",
+		"module", types.DelegatePoolModuleName,
+		"address", moduleAddr.String(),
+		"balance", balance.String())
+
+	return nil
+}
+
+// ValidateEpochBoundary validates that upgrade happens at epoch boundary using epoching keeper
+func ValidateEpochBoundary(ctx context.Context, epochingKeeper epochingkeeper.Keeper) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	currentHeight := uint64(sdkCtx.HeaderInfo().Height)
+
+	// Get current epoch information
+	currentEpoch := epochingKeeper.GetEpoch(ctx)
+
+	// Handle special case: height 1 is always valid as first possible upgrade height
+	if currentHeight == 1 {
+		sdkCtx.Logger().Info("epoch boundary validation successful - height 1",
+			"current_height", currentHeight,
+			"note", "height 1 is always valid epoch boundary")
+		return nil
+	}
+
+	if !currentEpoch.IsFirstBlockOfNextEpoch(ctx) {
+		// Calculate next epoch boundary for error message using current epoch interval
+		nextEpochHeight := currentEpoch.FirstBlockHeight + currentEpoch.CurrentEpochInterval
+
+		return fmt.Errorf("upgrade must happen at epoch boundary - current height %d is not first block of next epoch (next epoch boundary at height %d, current epoch interval: %d)",
+			currentHeight, nextEpochHeight, currentEpoch.CurrentEpochInterval)
+	}
+
+	sdkCtx.Logger().Info("epoch boundary validation successful",
+		"current_height", currentHeight,
+		"current_epoch", currentEpoch.EpochNumber,
+		"epoch_interval", currentEpoch.CurrentEpochInterval,
+		"is_epoch_boundary", true)
+
+	return nil
+}
+
+// ValidateMigrationResults validates the results of the migration using epoching keeper
+func ValidateMigrationResults(ctx context.Context, keepers *keepers.AppKeepers) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	// Validate epoching params after migration
+	epochingParams := keepers.EpochingKeeper.GetParams(sdkCtx)
+	if err := epochingParams.Validate(); err != nil {
+		return fmt.Errorf("migrated epoching params validation failed: %w", err)
+	}
+
+	sdkCtx.Logger().Info("migration validation successful",
+		"epoch_interval", epochingParams.EpochInterval,
+		"min_amount", epochingParams.MinAmount,
+		"delegate_gas", epochingParams.ExecuteGas.Delegate)
+
+	return nil
+}

--- a/app/upgrades/v3/upgrades.go
+++ b/app/upgrades/v3/upgrades.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"context"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -10,6 +11,7 @@ import (
 
 	"github.com/babylonlabs-io/babylon/v4/app/keepers"
 	"github.com/babylonlabs-io/babylon/v4/app/upgrades"
+	"github.com/babylonlabs-io/babylon/v4/app/upgrades/epoching"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
 	btcstkconsumertypes "github.com/babylonlabs-io/babylon/v4/x/btcstkconsumer/types"
@@ -52,12 +54,29 @@ func CreateUpgradeHandler(
 ) upgrades.UpgradeHandlerCreator {
 	return func(mm *module.Manager, configurator module.Configurator, keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
 		return func(goCtx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			// Validate epoch boundary using epoching keeper
+			ctx := sdk.UnwrapSDKContext(goCtx)
+			if err := epoching.ValidateEpochBoundary(goCtx, keepers.EpochingKeeper); err != nil {
+				return nil, fmt.Errorf("epoch boundary validation failed: %w", err)
+			}
+
+			// Validate delegation pool module account exists before running migrations
+			if err := epoching.ValidateDelegatePoolModuleAccount(goCtx, keepers.AccountKeeper); err != nil {
+				return nil, fmt.Errorf("spam prevention upgrade validation failed: %w", err)
+			}
+			// Validate that delegation pool has no locked funds
+			if err := epoching.ValidateDelegatePoolEmpty(goCtx, keepers.AccountKeeper, keepers.BankKeeper); err != nil {
+				ctx.Logger().Warn("delegate pool validation warning", "error", err.Error())
+			}
+
 			migrations, err := mm.RunMigrations(goCtx, configurator, fromVM)
 			if err != nil {
 				return nil, err
 			}
 
-			ctx := sdk.UnwrapSDKContext(goCtx)
+			if err := epoching.ValidateMigrationResults(goCtx, keepers); err != nil {
+				return nil, fmt.Errorf("migration validation failed: %w", err)
+			}
 
 			zoneConciergeParams := zoneconciergetypes.DefaultParams()
 			zoneConciergeParams.IbcPacketTimeoutSeconds = ibcPacketTimeoutSeconds

--- a/app/upgrades/v3/upgrades.go
+++ b/app/upgrades/v3/upgrades.go
@@ -66,7 +66,7 @@ func CreateUpgradeHandler(
 			}
 			// Validate that delegation pool has no locked funds
 			if err := epoching.ValidateDelegatePoolEmpty(goCtx, keepers.AccountKeeper, keepers.BankKeeper); err != nil {
-				ctx.Logger().Warn("delegate pool validation warning", "error", err.Error())
+				ctx.Logger().Warn("delegate pool had non-zero balance but failed to transfer funds to fee collector - upgrade proceeding", "error", err.Error())
 			}
 
 			migrations, err := mm.RunMigrations(goCtx, configurator, fromVM)

--- a/app/upgrades/v3rc4/testnet/upgrades.go
+++ b/app/upgrades/v3rc4/testnet/upgrades.go
@@ -1,0 +1,158 @@
+package testnet
+
+import (
+	"context"
+	"fmt"
+
+	store "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/babylonlabs-io/babylon/v4/app/keepers"
+	"github.com/babylonlabs-io/babylon/v4/app/upgrades"
+	epochingkeeper "github.com/babylonlabs-io/babylon/v4/x/epoching/keeper"
+	"github.com/babylonlabs-io/babylon/v4/x/epoching/types"
+)
+
+const UpgradeName = "v3rc4"
+const delegatePoolModuleName = "epoching_delegate_pool"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+	},
+}
+
+func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		currentHeight := uint64(sdkCtx.HeaderInfo().Height)
+
+		// Validate epoch boundary using epoching keeper
+		if err := validateEpochBoundary(ctx, keepers.EpochingKeeper); err != nil {
+			return nil, fmt.Errorf("epoch boundary validation failed: %w", err)
+		}
+
+		// Validate delegation pool module account exists before running migrations
+		if err := validateDelegatePoolModuleAccount(ctx, keepers.AccountKeeper); err != nil {
+			return nil, fmt.Errorf("spam prevention upgrade validation failed: %w", err)
+		}
+		// Validate that delegation pool has no locked funds
+		if err := validateDelegatePoolEmpty(ctx, keepers.AccountKeeper, keepers.BankKeeper); err != nil {
+			return nil, fmt.Errorf("delegate pool validation failed: %w", err)
+		}
+
+		// Run migrations (includes epoching v1->v2 migration)
+		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return nil, fmt.Errorf("failed to run migrations: %w", err)
+		}
+
+		if err := validateMigrationResults(ctx, keepers); err != nil {
+			return nil, fmt.Errorf("migration validation failed: %w", err)
+		}
+		// Log successful upgrade
+		sdkCtx.Logger().Info("spam prevention upgrade completed successfully",
+			"upgrade", UpgradeName,
+			"epoching_migration", "v3rc3->v3rc4",
+			"height", currentHeight,
+			"epoch_boundary", true,
+		)
+
+		return migrations, nil
+	}
+}
+
+// validateDelegatePoolModuleAccount validates that the delegation pool module account is properly configured
+func validateDelegatePoolModuleAccount(ctx context.Context, ak types.AccountKeeper) error {
+	// Use hardcoded module name to avoid dependency on upgraded types
+
+	moduleAddr := ak.GetModuleAddress(delegatePoolModuleName)
+	if moduleAddr == nil {
+		return fmt.Errorf("module account %s has not been configured - ensure it's added to maccPerms in app.go",
+			delegatePoolModuleName)
+	}
+
+	// Module account address exists, which means it's properly configured
+	// The actual account object will be created when first used by the module
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	sdkCtx.Logger().Info("delegation pool module account validated",
+		"module", delegatePoolModuleName,
+		"address", moduleAddr.String())
+
+	return nil
+}
+
+// validateDelegatePoolEmpty validates that the delegation pool module account has no locked funds
+func validateDelegatePoolEmpty(ctx context.Context, ak types.AccountKeeper, bk types.BankKeeper) error {
+	// Use hardcoded module name to avoid dependency on upgraded types
+	moduleAddr := ak.GetModuleAddress(delegatePoolModuleName)
+
+	balance := bk.SpendableCoins(ctx, moduleAddr)
+	if !balance.IsZero() {
+		return fmt.Errorf("upgrade cannot proceed with locked funds in delegation pool (balance: %s) - this indicates unprocessed queued messages with locked funds",
+			balance.String())
+	}
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	sdkCtx.Logger().Info("delegation pool validation successful",
+		"module", delegatePoolModuleName,
+		"address", moduleAddr.String(),
+		"balance", balance.String())
+
+	return nil
+}
+
+// validateEpochBoundary validates that upgrade happens at epoch boundary using epoching keeper
+func validateEpochBoundary(ctx context.Context, epochingKeeper epochingkeeper.Keeper) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	currentHeight := uint64(sdkCtx.HeaderInfo().Height)
+
+	// Get current epoch information
+	currentEpoch := epochingKeeper.GetEpoch(ctx)
+
+	// Handle special case: height 1 is always valid as first possible upgrade height
+	if currentHeight == 1 {
+		sdkCtx.Logger().Info("epoch boundary validation successful - height 1",
+			"current_height", currentHeight,
+			"note", "height 1 is always valid epoch boundary")
+		return nil
+	}
+
+	if !currentEpoch.IsFirstBlockOfNextEpoch(ctx) {
+		// Calculate next epoch boundary for error message using current epoch interval
+		nextEpochHeight := currentEpoch.FirstBlockHeight + currentEpoch.CurrentEpochInterval
+
+		return fmt.Errorf("upgrade must happen at epoch boundary - current height %d is not first block of next epoch (next epoch boundary at height %d, current epoch interval: %d)",
+			currentHeight, nextEpochHeight, currentEpoch.CurrentEpochInterval)
+	}
+
+	sdkCtx.Logger().Info("epoch boundary validation successful",
+		"current_height", currentHeight,
+		"current_epoch", currentEpoch.EpochNumber,
+		"epoch_interval", currentEpoch.CurrentEpochInterval,
+		"is_epoch_boundary", true)
+
+	return nil
+}
+
+func validateMigrationResults(ctx context.Context, keepers *keepers.AppKeepers) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	// Validate epoching params after migration
+	epochingParams := keepers.EpochingKeeper.GetParams(sdkCtx)
+	if err := epochingParams.Validate(); err != nil {
+		return fmt.Errorf("migrated epoching params validation failed: %w", err)
+	}
+
+	sdkCtx.Logger().Info("migration validation successful",
+		"epoch_interval", epochingParams.EpochInterval,
+		"min_amount", epochingParams.MinAmount,
+		"delegate_gas", epochingParams.ExecuteGas.Delegate)
+
+	return nil
+}

--- a/app/upgrades/v3rc4/testnet/upgrades.go
+++ b/app/upgrades/v3rc4/testnet/upgrades.go
@@ -42,7 +42,7 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, 
 		// Validate that delegation pool has no locked funds
 		if err := epoching.ValidateDelegatePoolEmpty(ctx, keepers.AccountKeeper, keepers.BankKeeper); err != nil {
 			// Log warning instead of failing upgrade
-			sdkCtx.Logger().Warn("delegate pool validation warning", "error", err.Error())
+			sdkCtx.Logger().Warn("delegate pool had non-zero balance but failed to transfer funds to fee collector - upgrade proceeding", "error", err.Error())
 		}
 
 		// Run migrations (includes epoching v1->v2 migration)

--- a/app/upgrades/v3rc4/testnet/upgrades.go
+++ b/app/upgrades/v3rc4/testnet/upgrades.go
@@ -11,12 +11,10 @@ import (
 
 	"github.com/babylonlabs-io/babylon/v4/app/keepers"
 	"github.com/babylonlabs-io/babylon/v4/app/upgrades"
-	epochingkeeper "github.com/babylonlabs-io/babylon/v4/x/epoching/keeper"
-	"github.com/babylonlabs-io/babylon/v4/x/epoching/types"
+	"github.com/babylonlabs-io/babylon/v4/app/upgrades/epoching"
 )
 
 const UpgradeName = "v3rc4"
-const delegatePoolModuleName = "epoching_delegate_pool"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
@@ -33,17 +31,18 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, 
 		currentHeight := uint64(sdkCtx.HeaderInfo().Height)
 
 		// Validate epoch boundary using epoching keeper
-		if err := validateEpochBoundary(ctx, keepers.EpochingKeeper); err != nil {
+		if err := epoching.ValidateEpochBoundary(ctx, keepers.EpochingKeeper); err != nil {
 			return nil, fmt.Errorf("epoch boundary validation failed: %w", err)
 		}
 
 		// Validate delegation pool module account exists before running migrations
-		if err := validateDelegatePoolModuleAccount(ctx, keepers.AccountKeeper); err != nil {
+		if err := epoching.ValidateDelegatePoolModuleAccount(ctx, keepers.AccountKeeper); err != nil {
 			return nil, fmt.Errorf("spam prevention upgrade validation failed: %w", err)
 		}
 		// Validate that delegation pool has no locked funds
-		if err := validateDelegatePoolEmpty(ctx, keepers.AccountKeeper, keepers.BankKeeper); err != nil {
-			return nil, fmt.Errorf("delegate pool validation failed: %w", err)
+		if err := epoching.ValidateDelegatePoolEmpty(ctx, keepers.AccountKeeper, keepers.BankKeeper); err != nil {
+			// Log warning instead of failing upgrade
+			sdkCtx.Logger().Warn("delegate pool validation warning", "error", err.Error())
 		}
 
 		// Run migrations (includes epoching v1->v2 migration)
@@ -52,7 +51,7 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, 
 			return nil, fmt.Errorf("failed to run migrations: %w", err)
 		}
 
-		if err := validateMigrationResults(ctx, keepers); err != nil {
+		if err := epoching.ValidateMigrationResults(ctx, keepers); err != nil {
 			return nil, fmt.Errorf("migration validation failed: %w", err)
 		}
 		// Log successful upgrade
@@ -65,94 +64,4 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, 
 
 		return migrations, nil
 	}
-}
-
-// validateDelegatePoolModuleAccount validates that the delegation pool module account is properly configured
-func validateDelegatePoolModuleAccount(ctx context.Context, ak types.AccountKeeper) error {
-	// Use hardcoded module name to avoid dependency on upgraded types
-
-	moduleAddr := ak.GetModuleAddress(delegatePoolModuleName)
-	if moduleAddr == nil {
-		return fmt.Errorf("module account %s has not been configured - ensure it's added to maccPerms in app.go",
-			delegatePoolModuleName)
-	}
-
-	// Module account address exists, which means it's properly configured
-	// The actual account object will be created when first used by the module
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.Logger().Info("delegation pool module account validated",
-		"module", delegatePoolModuleName,
-		"address", moduleAddr.String())
-
-	return nil
-}
-
-// validateDelegatePoolEmpty validates that the delegation pool module account has no locked funds
-func validateDelegatePoolEmpty(ctx context.Context, ak types.AccountKeeper, bk types.BankKeeper) error {
-	// Use hardcoded module name to avoid dependency on upgraded types
-	moduleAddr := ak.GetModuleAddress(delegatePoolModuleName)
-
-	balance := bk.SpendableCoins(ctx, moduleAddr)
-	if !balance.IsZero() {
-		return fmt.Errorf("upgrade cannot proceed with locked funds in delegation pool (balance: %s) - this indicates unprocessed queued messages with locked funds",
-			balance.String())
-	}
-
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.Logger().Info("delegation pool validation successful",
-		"module", delegatePoolModuleName,
-		"address", moduleAddr.String(),
-		"balance", balance.String())
-
-	return nil
-}
-
-// validateEpochBoundary validates that upgrade happens at epoch boundary using epoching keeper
-func validateEpochBoundary(ctx context.Context, epochingKeeper epochingkeeper.Keeper) error {
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	currentHeight := uint64(sdkCtx.HeaderInfo().Height)
-
-	// Get current epoch information
-	currentEpoch := epochingKeeper.GetEpoch(ctx)
-
-	// Handle special case: height 1 is always valid as first possible upgrade height
-	if currentHeight == 1 {
-		sdkCtx.Logger().Info("epoch boundary validation successful - height 1",
-			"current_height", currentHeight,
-			"note", "height 1 is always valid epoch boundary")
-		return nil
-	}
-
-	if !currentEpoch.IsFirstBlockOfNextEpoch(ctx) {
-		// Calculate next epoch boundary for error message using current epoch interval
-		nextEpochHeight := currentEpoch.FirstBlockHeight + currentEpoch.CurrentEpochInterval
-
-		return fmt.Errorf("upgrade must happen at epoch boundary - current height %d is not first block of next epoch (next epoch boundary at height %d, current epoch interval: %d)",
-			currentHeight, nextEpochHeight, currentEpoch.CurrentEpochInterval)
-	}
-
-	sdkCtx.Logger().Info("epoch boundary validation successful",
-		"current_height", currentHeight,
-		"current_epoch", currentEpoch.EpochNumber,
-		"epoch_interval", currentEpoch.CurrentEpochInterval,
-		"is_epoch_boundary", true)
-
-	return nil
-}
-
-func validateMigrationResults(ctx context.Context, keepers *keepers.AppKeepers) error {
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-
-	// Validate epoching params after migration
-	epochingParams := keepers.EpochingKeeper.GetParams(sdkCtx)
-	if err := epochingParams.Validate(); err != nil {
-		return fmt.Errorf("migrated epoching params validation failed: %w", err)
-	}
-
-	sdkCtx.Logger().Info("migration validation successful",
-		"epoch_interval", epochingParams.EpochInterval,
-		"min_amount", epochingParams.MinAmount,
-		"delegate_gas", epochingParams.ExecuteGas.Delegate)
-
-	return nil
 }

--- a/app/upgrades/v3rc4/testnet/upgrades_test.go
+++ b/app/upgrades/v3rc4/testnet/upgrades_test.go
@@ -1,0 +1,184 @@
+package testnet_test
+
+import (
+	"testing"
+	"time"
+
+	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/header"
+	"cosmossdk.io/math"
+	"cosmossdk.io/x/upgrade"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/babylonlabs-io/babylon/v4/app"
+	"github.com/babylonlabs-io/babylon/v4/app/upgrades"
+	v3rc4testnet "github.com/babylonlabs-io/babylon/v4/app/upgrades/v3rc4/testnet"
+	bbn "github.com/babylonlabs-io/babylon/v4/types"
+	"github.com/babylonlabs-io/babylon/v4/x/epoching"
+	epochingtypes "github.com/babylonlabs-io/babylon/v4/x/epoching/types"
+	minttypes "github.com/babylonlabs-io/babylon/v4/x/mint/types"
+)
+
+const (
+	DummyUpgradeHeight = 11 // Must be at epoch boundary for epochInterval=10
+)
+
+type UpgradeTestSuite struct {
+	suite.Suite
+
+	ctx       sdk.Context
+	app       *app.BabylonApp
+	preModule appmodule.HasPreBlocker
+}
+
+func TestUpgradeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeTestSuite))
+}
+
+func (s *UpgradeTestSuite) SetupTest() {
+	// Add the upgrade plan
+	app.Upgrades = []upgrades.Upgrade{v3rc4testnet.Upgrade}
+
+	// Set up app
+	s.app = app.SetupWithBitcoinConf(s.T(), false, bbn.BtcSignet)
+	s.ctx = s.app.BaseApp.NewContextLegacy(false, tmproto.Header{Height: 1, ChainID: "babylon-1", Time: time.Now().UTC()})
+	s.preModule = upgrade.NewAppModule(s.app.UpgradeKeeper, s.app.AccountKeeper.AddressCodec())
+}
+
+func (s *UpgradeTestSuite) TestUpgradeValidation() {
+	testCases := []struct {
+		name                  string
+		upgradeHeight         int64
+		expectSuccess         bool
+		expectedErrorContains string
+	}{
+		{
+			name:          "successful upgrade at epoch boundary",
+			upgradeHeight: 11, // First block of epoch 2 when epochInterval=10
+			expectSuccess: true,
+		},
+		{
+			name:                  "failed upgrade at non-epoch boundary",
+			upgradeHeight:         12, // Not first block of epoch
+			expectSuccess:         false,
+			expectedErrorContains: "epoch boundary validation failed",
+		},
+		{
+			name:          "successful upgrade at different epoch boundary",
+			upgradeHeight: 21, // First block of epoch 3 when epochInterval=10
+			expectSuccess: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest() // Reset for each test
+
+			if tc.expectSuccess {
+				s.executeSuccessfulUpgrade(tc.upgradeHeight)
+			} else {
+				s.executeFailedUpgrade(tc.upgradeHeight, tc.expectedErrorContains)
+			}
+		})
+	}
+}
+
+func (s *UpgradeTestSuite) TestUpgradeAtHeight1() {
+	s.SetupTest()
+
+	// Height 1 should always be valid (special case in validation)
+	s.executeSuccessfulUpgrade(1)
+}
+
+func (s *UpgradeTestSuite) TestUpgradeFailureScenarios() {
+	testCases := []struct {
+		name                  string
+		upgradeHeight         int64
+		setupFailureCondition func()
+		expectedErrorContains string
+	}{
+		{
+			name:          "upgrade fails with locked delegate pool funds",
+			upgradeHeight: DummyUpgradeHeight,
+			setupFailureCondition: func() {
+				// Simulate locked funds in delegate pool
+				coins := sdk.NewCoins(sdk.NewCoin("ubbn", math.NewInt(500000)))
+				s.Require().NoError(s.app.BankKeeper.MintCoins(s.ctx, minttypes.ModuleName, coins))
+				s.Require().NoError(s.app.BankKeeper.SendCoinsFromModuleToModule(s.ctx, minttypes.ModuleName, epochingtypes.DelegatePoolModuleName, coins))
+			},
+			expectedErrorContains: "delegate pool validation failed",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest() // Reset for each test
+
+			if tc.setupFailureCondition != nil {
+				tc.setupFailureCondition()
+			}
+
+			s.executeFailedUpgrade(tc.upgradeHeight, tc.expectedErrorContains)
+		})
+	}
+}
+
+// ========== HELPER FUNCTIONS ==========
+
+// advanceToEpochBoundary advances the context to the specified height by progressing through blocks
+func (s *UpgradeTestSuite) advanceToEpochBoundary(targetHeight int64) {
+	for currentHeight := s.ctx.BlockHeight(); currentHeight < targetHeight; currentHeight++ {
+		s.ctx = s.ctx.WithBlockHeight(currentHeight + 1).WithHeaderInfo(header.Info{
+			Height: currentHeight + 1,
+			Time:   s.ctx.BlockTime().Add(time.Second),
+		})
+
+		// Process epoch transitions
+		err := epoching.BeginBlocker(s.ctx, s.app.EpochingKeeper)
+		s.Require().NoError(err)
+	}
+}
+
+func (s *UpgradeTestSuite) executeUpgrade(upgradeHeight int64) error {
+	currentHeight := s.ctx.BlockHeight()
+
+	// Advance to target height if needed
+	if upgradeHeight > currentHeight+1 {
+		s.advanceToEpochBoundary(upgradeHeight - 1)
+	}
+
+	// Schedule upgrade
+	s.ctx = s.ctx.WithBlockHeight(upgradeHeight - 1)
+	plan := upgradetypes.Plan{Name: v3rc4testnet.UpgradeName, Height: upgradeHeight}
+	err := s.app.UpgradeKeeper.ScheduleUpgrade(s.ctx, plan)
+	s.Require().NoError(err)
+
+	// Verify upgrade plan exists
+	actualPlan, err := s.app.UpgradeKeeper.GetUpgradePlan(s.ctx)
+	s.Require().NoError(err)
+	s.Require().Equal(plan, actualPlan)
+
+	// Execute upgrade
+	s.ctx = s.ctx.WithHeaderInfo(header.Info{Height: upgradeHeight, Time: s.ctx.BlockTime().Add(time.Second)}).WithBlockHeight(upgradeHeight)
+
+	var upgradeErr error
+	s.NotPanics(func() {
+		_, upgradeErr = s.preModule.PreBlock(s.ctx)
+	})
+
+	return upgradeErr
+}
+
+func (s *UpgradeTestSuite) executeSuccessfulUpgrade(upgradeHeight int64) {
+	err := s.executeUpgrade(upgradeHeight)
+	s.Require().NoError(err)
+}
+
+func (s *UpgradeTestSuite) executeFailedUpgrade(upgradeHeight int64, expectedErrorContains string) {
+	err := s.executeUpgrade(upgradeHeight)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), expectedErrorContains)
+}

--- a/test/e2e/configurer/upgrade.go
+++ b/test/e2e/configurer/upgrade.go
@@ -206,19 +206,15 @@ func (uc *UpgradeConfigurer) runProposalUpgrade() error {
 			return err
 		}
 
-		chainConfig.UpgradePropHeight = currentHeight + int64(chainConfig.VotingPeriod) + int64(config.PropSubmitBlocks) + int64(config.PropBufferBlocks)
-		
-		// Adjust upgrade height to next epoch boundary (first block of next epoch)
-		// Epochs start at height 1, 11, 21, 31, ... (every 10 blocks)
-		// So epoch boundaries are at heights where (height - 1) % 10 == 0
-		epochInterval := int64(10)
-		if (chainConfig.UpgradePropHeight-1)%epochInterval != 0 {
-			// Calculate next epoch boundary
-			nextEpochBoundary := ((chainConfig.UpgradePropHeight-1)/epochInterval+1)*epochInterval + 1
-			uc.t.Logf("adjusting upgrade height from %d to epoch boundary %d", chainConfig.UpgradePropHeight, nextEpochBoundary)
-			chainConfig.UpgradePropHeight = nextEpochBoundary
+		upgradeMsg, err := uc.ParseGovPropFromFile()
+		if err != nil {
+			return err
 		}
-		
+		if upgradeMsg.Plan.Height <= currentHeight {
+			chainConfig.UpgradePropHeight = currentHeight + int64(chainConfig.VotingPeriod) + int64(config.PropSubmitBlocks) + int64(config.PropBufferBlocks)
+		} else {
+			chainConfig.UpgradePropHeight = upgradeMsg.Plan.Height
+		}
 		err = uc.SetGovPropUpgradeHeight(chainConfig.UpgradePropHeight)
 		if err != nil {
 			return err

--- a/test/e2e/govProps/v3.json
+++ b/test/e2e/govProps/v3.json
@@ -6,7 +6,7 @@
       "plan": {
         "name": "v3",
         "time": "0001-01-01T00:00:00Z",
-        "height": "183",
+        "height": "191",
         "info": "Upgrade to v3",
         "upgraded_client_state": null
       }

--- a/x/epoching/types/expected_keepers.go
+++ b/x/epoching/types/expected_keepers.go
@@ -26,6 +26,8 @@ type BankKeeper interface {
 	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	GetAllBalances(ctx context.Context, addr sdk.AccAddress) sdk.Coins
+	SendCoinsFromModuleToModule(ctx context.Context, senderModule string, recipientModule string, amt sdk.Coins) error
 	// Methods imported from bank should be defined here
 }
 


### PR DESCRIPTION
# Description

Closes: #1662 

Add upgrade handler logic to enable epoching spam prevention.

**Testnet:** upgrade handler applied in v3rc4

**Mainnet:** upgrade handler applied in v3

## Notes
**Upgrade must occur at the first block of the epoch; if the block number is incorrect, the upgrade fails.**

- Add v3rc4/upgrades.go: upgrade logic for testnet.
- Add v3rc4/upgrades_test.go: upgrade test code.
- Add validation.go: common validation logic for upgrade.
- Modify v3/upgrades.go: add validation logic for epoching spam prevention upgrade.
- Modify v3/upgrades_test.go: fix dummyUpgradeHeight to first block of epoch, add validation for epoching.
- Modify e2e/configurer/upgrade.go: fix ChainConfig.UpgradeHeight to first block of epoch.

## Progress check list

- [x] Implementation upgrade handler for v3rc4
- [x] Implementation upgrade handler for v3

