### PR TITLE
fix: costaking find inactive returns slashed and jailed

### DIFF
--- a/test/replay/btcstaking_test.go
+++ b/test/replay/btcstaking_test.go
@@ -734,7 +734,7 @@ func TestAcceptSlashingTxAsUnbondingTx(t *testing.T) {
 		driver.App.BTCLightClientKeeper.GetBTCNet(),
 	)
 
-	blockWithProofs := driver.IncludeTxsInBTCAndConfirm([]*wire.MsgTx{slashingTxMsg})
+	blockWithProofs, _ := driver.IncludeTxsInBTCAndConfirm([]*wire.MsgTx{slashingTxMsg})
 	require.Len(t, blockWithProofs.Proofs, 2)
 
 	msg := &bstypes.MsgBTCUndelegate{

--- a/test/replay/multistaking_test.go
+++ b/test/replay/multistaking_test.go
@@ -264,10 +264,10 @@ func TestAdditionalGasCostForMultiStakedDelegation(t *testing.T) {
 // - Every tx is less than 10M gas
 // - Block will have less than 300M gas
 func (d *BabylonAppDriver) packVerifiedDelegations() []*abci.ExecTxResult {
-	block := d.IncludeVerifiedStakingTxInBTC(0)
-	acitvationMsgs := blockWithProofsToActivationMessages(block, d.GetDriverAccountAddress())
+	block, _ := d.IncludeVerifiedStakingTxInBTC(0)
+	activationMsgs := blockWithProofsToActivationMessages(block, d.GetDriverAccountAddress())
 
-	for i, msg := range acitvationMsgs {
+	for i, msg := range activationMsgs {
 		var gaslimit uint64
 
 		switch {

--- a/test/replay/stake_expansion_test.go
+++ b/test/replay/stake_expansion_test.go
@@ -82,7 +82,7 @@ func TestExpandBTCDelegation(t *testing.T) {
 			require.Len(t, verifiedDels, 1)
 			require.NotNil(t, verifiedDels[0].StkExp)
 
-			blockWithProofs := s.Driver.IncludeVerifiedStakingTxInBTC(1)
+			blockWithProofs, _ := s.Driver.IncludeVerifiedStakingTxInBTC(1)
 			require.Len(t, blockWithProofs.Proofs, 2)
 
 			spendingTx, err := bbn.NewBTCTxFromBytes(btcExpMsg.StakingTx)
@@ -308,7 +308,7 @@ func TestInvalidStakeExpansion(t *testing.T) {
 					s.Driver.App.BTCLightClientKeeper.GetBTCNet(),
 				)
 
-				blockWithProofs := s.Driver.IncludeTxsInBTCAndConfirm([]*wire.MsgTx{slashingTxMsg})
+				blockWithProofs, _ := s.Driver.IncludeTxsInBTCAndConfirm([]*wire.MsgTx{slashingTxMsg})
 				require.Len(t, blockWithProofs.Proofs, 2)
 
 				msg := &bstypes.MsgBTCUndelegate{
@@ -330,7 +330,7 @@ func TestInvalidStakeExpansion(t *testing.T) {
 				// staking output should be already spent by the unbonding tx
 				stkExpStakingTx, err := bbn.NewBTCTxFromBytes(stakeExpandMsg.StakingTx)
 				require.NoError(t, err)
-				blockWithProofs = s.Driver.IncludeVerifiedStakingTxInBTC(1)
+				blockWithProofs, _ = s.Driver.IncludeVerifiedStakingTxInBTC(1)
 				require.Len(t, blockWithProofs.Proofs, 2)
 
 				spendingTxWithWitnessBz, _ := datagen.AddWitnessToStakeExpTx(

--- a/test/replay/staker_sender.go
+++ b/test/replay/staker_sender.go
@@ -1,9 +1,10 @@
 package replay
 
 import (
-	"github.com/babylonlabs-io/babylon/v4/btcstaking"
 	"math/rand"
 	"testing"
+
+	"github.com/babylonlabs-io/babylon/v4/btcstaking"
 
 	"github.com/babylonlabs-io/babylon/v4/testutil/datagen"
 	bbn "github.com/babylonlabs-io/babylon/v4/types"
@@ -405,7 +406,7 @@ func (s *Staker) UnbondDelegation(
 	unbondingTxMsg := infos.UnbondingSlashingInfo.UnbondingTx
 	unbondingTxMsg.TxIn[0].Witness = witness
 
-	blockWithUnbondingTx := s.d.IncludeTxsInBTCAndConfirm([]*wire.MsgTx{unbondingTxMsg})
+	blockWithUnbondingTx, _ := s.d.IncludeTxsInBTCAndConfirm([]*wire.MsgTx{unbondingTxMsg})
 	require.Len(s.t, blockWithUnbondingTx.Proofs, 2)
 
 	stakingTxBz, err := bbn.SerializeBTCTx(stakingTx)

--- a/x/finality/types/power_table.go
+++ b/x/finality/types/power_table.go
@@ -135,7 +135,6 @@ func (dc *VotingPowerDistCache) GetActiveFinalityProviderSet() map[string]*Final
 
 // GetInactiveFinalityProviderSet returns a set of inactive finality providers
 // keyed by the hex string of the finality provider's BTC public key
-// i.e., not within top N of them in terms of voting power and not slashed or jailed
 func (dc *VotingPowerDistCache) GetInactiveFinalityProviderSet() map[string]*FinalityProviderDistInfo {
 	numActiveFPs := dc.NumActiveFps
 
@@ -146,9 +145,7 @@ func (dc *VotingPowerDistCache) GetInactiveFinalityProviderSet() map[string]*Fin
 	inactiveFps := make(map[string]*FinalityProviderDistInfo)
 
 	for _, fp := range dc.FinalityProviders[numActiveFPs:] {
-		if !fp.IsSlashed && !fp.IsJailed {
-			inactiveFps[fp.BtcPk.MarshalHex()] = fp
-		}
+		inactiveFps[fp.BtcPk.MarshalHex()] = fp
 	}
 
 	return inactiveFps

--- a/x/finality/types/power_table_test.go
+++ b/x/finality/types/power_table_test.go
@@ -123,7 +123,7 @@ func TestVotingPowerDistCache(t *testing.T) {
 			desc:             "one got jailed",
 			maxActiveFPs:     80,
 			numActiveFps:     1,
-			numInactiveFps:   0,
+			numInactiveFps:   1,
 			totalVotingPower: 1000,
 			prevDistCache:    types.NewVotingPowerDistCache(),
 			fps: []*types.FinalityProviderDistInfo{
@@ -144,7 +144,7 @@ func TestVotingPowerDistCache(t *testing.T) {
 			desc:             "one got slashed",
 			maxActiveFPs:     80,
 			numActiveFps:     1,
-			numInactiveFps:   0,
+			numInactiveFps:   1,
 			totalVotingPower: 1000,
 			prevDistCache:    types.NewVotingPowerDistCache(),
 			fps: []*types.FinalityProviderDistInfo{


### PR DESCRIPTION
Modified `GetInactiveFinalityProviderSet` to return jailed and slashed fp as well, check is now done at `HandleFPStateUpdates` after calling hooks but prior to emit block events