### PR TITLE
Docs: fix typos in BTC staking and incentive READMEs

### DIFF
--- a/x/btcstaking/README.md
+++ b/x/btcstaking/README.md
@@ -902,7 +902,7 @@ message EventBTCDelegationCreated {
 // EventCovenantSignatureReceived is the event emitted when a covenant committee
 // sends valid covenant signatures for a BTC delegation
 message EventCovenantSignatureReceived{
-  // staking_tx_hash is the hash of the staking identifing the BTC delegation
+  // staking_tx_hash is the hash of the staking identifying the BTC delegation
   // that this covenant signature is for
   string staking_tx_hash = 1;
   // covenant_btc_pk_hex is the hex str of Bitcoin secp256k1 PK of the
@@ -916,7 +916,7 @@ message EventCovenantSignatureReceived{
 // EventCovenantQuorumReached is the event emitted quorum of covenant committee
 // is reached for a BTC delegation
 message EventCovenantQuorumReached {
-  // staking_tx_hash is the hash of the staking identifing the BTC delegation
+  // staking_tx_hash is the hash of the staking identifying the BTC delegation
   // that this covenant signature is for
   string staking_tx_hash = 1;
   // new_state of the BTC delegation

--- a/x/incentive/README.md
+++ b/x/incentive/README.md
@@ -249,13 +249,13 @@ is used to store this structure.
 
 ```protobuf
 // FinalityProviderHistoricalRewards represents the cumulative rewards ratio of
-// the finality provider per sat in that period. The period is ommited here and
+// the finality provider per sat in that period. The period is omitted here and
 // should be part of the key used to store this structure. Key: Prefix +
 // Finality provider bech32 address + Period.
 message FinalityProviderHistoricalRewards {
   // The cumulative rewards of that finality provider per sat until that period
   // This coins will aways increase the value, never be reduced due to keep
-  // acumulation and when the cumulative rewards will be used to distribute
+  // accumulation and when the cumulative rewards will be used to distribute
   // rewards, 2 periods will be loaded, calculate the difference and multiplied
   // by the total sat amount delegated
   // https://github.com/cosmos/cosmos-sdk/blob/e76102f885b71fd6e1c1efb692052173c4b3c3a3/x/distribution/keeper/delegation.go#L47
@@ -317,7 +317,7 @@ satoshis delegated to a specific finality provider. Managed by the
 // BTCDelegationRewardsTracker represents the structure that holds information
 // from the last time this BTC delegator withdraw the rewards or modified his
 // active staked amount to one finality provider.
-// The finality provider address is ommitted here but should be part of the
+// The finality provider address is omitted here but should be part of the
 // key used to store this structure together with the BTC delegator address.
 message BTCDelegationRewardsTracker {
   // StartPeriodCumulativeReward the starting period the the BTC delegator


### PR DESCRIPTION


### Description
- Correct spelling in `x/btcstaking/README.md`: “identifing” → “identifying”.
- Correct spelling in `x/incentive/README.md`: “ommited” → “omitted”, “acumulation” → “accumulation”.


