### PR TITLE
[backport] fix: remove unnecessary validation (#1545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [#1418](https://github.com/babylonlabs-io/babylon/pull/1418) fix: add stake expansion covenant signature to the events
 - [#1740](https://github.com/babylonlabs-io/babylon/pull/1740) Simplify selective slashing message handler
 - [#1416](https://github.com/babylonlabs-io/babylon/pull/1416) Relax requirements for stake expansion funding output
+- [#1545](https://github.com/babylonlabs-io/babylon/pull/1545) fix: remove unnecessary covenant verification for stake expansion delegation
 
 ### Features
 

--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -431,15 +431,11 @@ func (ms msgServer) validateStakeExpansionSig(
 	}
 
 	// check if the btc pk was a covenant at the parameters version
-	// of the previous active staking transaction and signed it
+	// of the previous active staking transaction
 	prevBtcDel, prevParams := delInfo.PrevDel, delInfo.PrevParams
 
 	if !prevParams.HasCovenantPK(req.Pk) {
-		return errorsmod.Wrapf(types.ErrInvalidCovenantSig, "covenant with pk %s was not a member at params (version %d) of the previous stake", req.Pk.MarshalHex(), prevBtcDel.ParamsVersion)
-	}
-
-	if !prevBtcDel.IsSignedByCovMember(req.Pk) {
-		return errorsmod.Wrapf(types.ErrInvalidCovenantSig, "covenant signature for pk %s not found in previous delegation", req.Pk.MarshalHex())
+		return errorsmod.Wrapf(types.ErrInvalidCovenantSig, "covenant with pk %s was not a member at params (version %d) of the previous delegation", req.Pk.MarshalHex(), prevBtcDel.ParamsVersion)
 	}
 
 	// Covenant committee members can rotate, so we need to check


### PR DESCRIPTION
Removes the unnecessary check that covenant members signed parent delegaiton