### PR TITLE
fix: update the costaking portion according to future mainnet parameters

### DIFF
--- a/test/replay/costaking_test.go
+++ b/test/replay/costaking_test.go
@@ -14,6 +14,7 @@ import (
 	ictvtypes "github.com/babylonlabs-io/babylon/v4/x/incentive/types"
 	"github.com/btcsuite/btcd/wire"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	distkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 
@@ -609,4 +610,79 @@ func TestCostakingFpVotingPowerLossAndBtcUnbondSameBlockPreventsDoubleSatsRemova
 
 	// fp2's delegator should still have their correct active satoshis (unaffected)
 	d.CheckCostakerRewards(del3.Address(), del3BabyDelegatedAmt, del3BtcStakedAmtFp2, del3BtcStakedAmtFp2, currRwd.Period)
+}
+
+func TestMainnetInflationDistributionAmount(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	d := NewBabylonAppDriverTmpDir(r, t)
+	d.GenerateNewBlockAssertExecutionSuccess()
+	d.GenerateNewBlockAssertExecutionSuccess()
+
+	// exmaple with 100 ubbn to be distributed
+	// 1. incentives 2. costaking 3. distribution
+
+	// 1% of 5.5% goes to btc stakers
+	// 0,181818182 * 100 ≃ 18,181818ubbn
+
+	// 0.075% of 5.5% goes to fp directly
+	// 0,013636364 * 100 ≃ 1,3636364ubbn
+
+	// 2. costaking
+	// 100 ubbn - (18 + 1) ≃ 81ubbn
+
+	// 2.35% of 5.5% to costakers
+	// 0,531073446 * 81ubbn ≃ 43,016949153 ubbn
+
+	// 0.075% of 5.5% goes to baby validators
+	// 0,016949153 * 81ubbn ≃ 1,372881356 ubbn
+
+	// rest goes to baby stakers and validators 36,619414447ubbn
+	inflation := sdkmath.LegacyMustNewDecFromStr("5.5")
+
+	percentageBtcStakers := sdkmath.LegacyMustNewDecFromStr("1").Quo(inflation)
+	require.Equal(t, "0.181818181818181818", percentageBtcStakers.String())
+
+	percentageFpDirect := sdkmath.LegacyMustNewDecFromStr("0.075").Quo(inflation)
+	require.Equal(t, "0.013636363636363636", percentageFpDirect.String())
+
+	percentageCostakers := sdkmath.LegacyMustNewDecFromStr("2.35").Quo(inflation)
+	require.Equal(t, "0.427272727272727273", percentageCostakers.String())
+
+	percentageBabyValDirect := sdkmath.LegacyMustNewDecFromStr("0.075").Quo(inflation)
+	require.Equal(t, "0.013636363636363636", percentageBabyValDirect.String())
+
+	dstrModAcc := authtypes.NewModuleAddress(disttypes.ModuleName)
+	dstrModBalancesBefore := d.App.BankKeeper.GetAllBalances(d.Ctx(), dstrModAcc)
+
+	block := d.GenerateNewBlock()
+	amountMinted := FindEventMint(t, block.Events)
+
+	dstrModBalancesAfter := d.App.BankKeeper.GetAllBalances(d.Ctx(), dstrModAcc)
+
+	expectedBtcStaker, _ := sdk.NewDecCoinsFromCoins(amountMinted...).MulDecTruncate(percentageBtcStakers).TruncateDecimal()
+	actualBtcStakers := FindEventBtcStakers(t, block.Events)
+	require.False(t, actualBtcStakers.IsZero())
+	require.Equal(t, expectedBtcStaker.String(), actualBtcStakers.String())
+
+	expectedFpDirect, _ := sdk.NewDecCoinsFromCoins(amountMinted...).MulDecTruncate(percentageFpDirect).TruncateDecimal()
+	actualFpDirect := FindEventTypeFPDirectRewards(t, block.Events)
+	require.False(t, actualFpDirect.IsZero())
+	require.Equal(t, expectedFpDirect.String(), actualFpDirect.String())
+
+	expectedCostakers, _ := sdk.NewDecCoinsFromCoins(amountMinted...).MulDecTruncate(percentageCostakers).TruncateDecimal()
+	actualCostakers := FindEventCostakerRewards(t, block.Events)
+	require.False(t, actualCostakers.IsZero())
+	require.Equal(t, expectedCostakers.String(), actualCostakers.String())
+
+	expectedBabyVal, _ := sdk.NewDecCoinsFromCoins(amountMinted...).MulDecTruncate(percentageBabyValDirect).TruncateDecimal()
+	actualBabyVals := FindEventTypeValidatorDirectRewards(t, block.Events)
+	require.False(t, actualBabyVals.IsZero())
+	require.Equal(t, expectedBabyVal.String(), actualBabyVals.String())
+
+	// baby vals are not subtracted here, as the amount are transfered to the distribution module account as well
+	expectedDistributionModule := amountMinted.Sub(expectedBtcStaker...).Sub(expectedFpDirect...).Sub(expectedCostakers...)
+	actualDistributionModule := dstrModBalancesAfter.Sub(dstrModBalancesBefore...)
+	require.False(t, actualDistributionModule.IsZero())
+	require.Equal(t, expectedDistributionModule.String(), actualDistributionModule.String())
 }

--- a/x/costaking/types/params.go
+++ b/x/costaking/types/params.go
@@ -9,7 +9,7 @@ var (
 	// DefaultCostakingPortion defines how much of the fee_collector
 	// balances will go to costakers. Reminder that incentives gets
 	// his portion first, than costaking than the rest goes to distribution.
-	DefaultCostakingPortion = math.LegacyMustNewDecFromStr("0.530612245")
+	DefaultCostakingPortion = math.LegacyMustNewDecFromStr("0.531073446")
 	// DefaultScoreRatioBtcByBaby defines the min number of baby staked to
 	// make one BTC count as score. Each BTC staked should have at least 20k
 	// BABY staked. Tranlating that into sats and ubbn the ratio should be

--- a/x/mint/module_test.go
+++ b/x/mint/module_test.go
@@ -5,8 +5,11 @@ import (
 
 	appparams "github.com/babylonlabs-io/babylon/v4/app/params"
 	"github.com/babylonlabs-io/babylon/v4/testutil/helper"
+	btcstktypes "github.com/babylonlabs-io/babylon/v4/x/btcstaking/types"
+	ictvtypes "github.com/babylonlabs-io/babylon/v4/x/incentive/types"
 	"github.com/babylonlabs-io/babylon/v4/x/mint/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	dstrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,4 +22,7 @@ func TestItCreatesModuleAccountOnInitBlock(t *testing.T) {
 
 	feeColl := app.AccountKeeper.GetAccount(ctx, appparams.AccFeeCollector)
 	require.Equal(t, "bbn17xpfvakm2amg962yls6f84z3kell8c5l88j35y", feeColl.GetAddress().String())
+	require.Equal(t, "bbn1hfny2zhlc328ksxjsv3qrrldcgqw3684yu5vsh", authtypes.NewModuleAddress(ictvtypes.ModuleName).String())
+	require.Equal(t, "bbn13837feaxn8t0zvwcjwhw7lhpgdcx4s36eqteah", authtypes.NewModuleAddress(btcstktypes.ModuleName).String())
+	require.Equal(t, "bbn1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8sp4dkx", authtypes.NewModuleAddress(dstrtypes.ModuleName).String())
 }


### PR DESCRIPTION
- Update costaking portion to `DefaultCostakingPortion = math.LegacyMustNewDecFromStr("0.531073446")`
- Add test for mainnet values minted in one block [`TestMainnetInflationDistributionAmount`](https://github.com/babylonlabs-io/babylon/blob/ea9cddbe7b2372e67788f59eed20bbc15bd87d5e/test/replay/costaking_test.go#L615)