### PR TITLE
chore: empty the token_distribution list

### DIFF
--- a/app/upgrades/v1/testnet/token_distribution.go
+++ b/app/upgrades/v1/testnet/token_distribution.go
@@ -1,6 +1,5 @@
 package testnet
 
-// Simulates 50k wallets receiving funds between 1000000ubbn ~ 3000000ubbn
 const TokensDistributionStr = `{
   "token_distribution": []
 }`


### PR DESCRIPTION
When starting a new network, the address_sender may not have enough balance for the token_distribution, causing the upgrade to fail. While this can be fixed by sending tokens to the address before the upgrade, it would be better to remove the list so we don’t need to send tokens every time a new testnet is created