### PR TITLE
Update .goreleaser.yml to use S3 for musl files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,13 +11,22 @@ before:
     - wget -nc https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.aarch64.a -O /lib/libwasmvm_muslc.aarch64.a
     - wget -nc https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
 
-    - curl -LO https://musl.cc/x86_64-linux-musl-cross.tgz
+    # - curl -LO https://musl.cc/x86_64-linux-musl-cross.tgz
+    # - tar xf x86_64-linux-musl-cross.tgz
+    # - mv -n -u x86_64-linux-musl-cross /opt/musl-cross-x86_64
+
+    # - curl -LO https://musl.cc/aarch64-linux-musl-cross.tgz
+    # - tar xf aarch64-linux-musl-cross.tgz
+    # - mv -n -u aarch64-linux-musl-cross /opt/musl-cross-aarch64
+    # START - PoC Ricardo - Babylon Artifact Store
+    - aws s3 cp s3://babylonlabs-artifact-store/musl/latest/x86_64-linux-musl-cross.tgz .
     - tar xf x86_64-linux-musl-cross.tgz
     - mv -n -u x86_64-linux-musl-cross /opt/musl-cross-x86_64
 
-    - curl -LO https://musl.cc/aarch64-linux-musl-cross.tgz
+    - aws s3 cp s3://babylonlabs-artifact-store/musl/latest/aarch64-linux-musl-cross.tgz .
     - tar xf aarch64-linux-musl-cross.tgz
     - mv -n -u aarch64-linux-musl-cross /opt/musl-cross-aarch64
+    # END - PoC Ricardo - Babylon Artifact Store
 
 builds:
   - id: babylond-linux-amd64


### PR DESCRIPTION
Replaced curl commands with aws s3 cp for musl cross compilation files.