### PR TITLE
fix: baby staking hooks in costaking deletes StkCache after using

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ baby ratio where it wasn't increasing the costaker cumulative rewards and neithe
 - [#1783](https://github.com/babylonlabs-io/babylon/pull/1783) Fix `x/costaking` calls baby delegation modified in hook `BeforeDelegationRemoved`
 as the completely removal of an baby delegation doesn't calls `AfterDelegationModified
 - [#1790](https://github.com/babylonlabs-io/babylon/pull/1790) Fix withdraw reward to only error if both `BTC_STAKER` and `COSTAKER` types have zero rewards available.
+- [#1792](https://github.com/babylonlabs-io/babylon/pull/1792) Fix costaking baby bond unbond and bond again for the same delegation pair (del, val) in the same block
 
 ## v4.0.0-rc.0
 

--- a/x/costaking/types/staking_cache.go
+++ b/x/costaking/types/staking_cache.go
@@ -52,3 +52,15 @@ func (sc *StakingCache) GetStakedAmount(delAddr sdk.AccAddress, valAddr sdk.ValA
 func (sc *StakingCache) Clear() {
 	sc.amtByValByDel = make(map[string]map[string]math.LegacyDec)
 }
+
+// Delete removes one entry from the cache
+func (sc *StakingCache) Delete(delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+	delAddrStr := delAddr.String()
+	_, exists := sc.amtByValByDel[delAddrStr]
+	if !exists {
+		return
+	}
+
+	valAddrStr := valAddr.String()
+	delete(sc.amtByValByDel[delAddrStr], valAddrStr)
+}

--- a/x/costaking/types/staking_cache_test.go
+++ b/x/costaking/types/staking_cache_test.go
@@ -143,3 +143,77 @@ func TestStakingCacheClear(t *testing.T) {
 	result = cache.GetStakedAmount(delAddr, valAddr)
 	require.True(t, result.IsZero())
 }
+
+func TestStakingCacheDelete(t *testing.T) {
+	cache := NewStakingCache()
+
+	delAddr := sdk.AccAddress("delAddr")
+	valAddr := sdk.ValAddress("valAddr")
+	amount := math.LegacyNewDec(100)
+
+	cache.SetStakedAmount(delAddr, valAddr, amount)
+
+	result := cache.GetStakedAmount(delAddr, valAddr)
+	require.True(t, result.Equal(amount))
+
+	cache.Delete(delAddr, valAddr)
+
+	result = cache.GetStakedAmount(delAddr, valAddr)
+	require.True(t, result.IsZero())
+}
+
+func TestStakingCacheDeleteNonExistentDelegator(t *testing.T) {
+	cache := NewStakingCache()
+
+	delAddr := sdk.AccAddress("delAddr")
+	valAddr := sdk.ValAddress("valAddr")
+
+	cache.Delete(delAddr, valAddr)
+
+	result := cache.GetStakedAmount(delAddr, valAddr)
+	require.True(t, result.IsZero())
+}
+
+func TestStakingCacheDeleteNonExistentValidator(t *testing.T) {
+	cache := NewStakingCache()
+
+	delAddr := sdk.AccAddress("delAddr")
+	valAddr1 := sdk.ValAddress("valAddr1")
+	valAddr2 := sdk.ValAddress("valAddr2")
+	amount := math.LegacyNewDec(100)
+
+	cache.SetStakedAmount(delAddr, valAddr1, amount)
+
+	cache.Delete(delAddr, valAddr2)
+
+	result := cache.GetStakedAmount(delAddr, valAddr1)
+	require.True(t, result.Equal(amount))
+}
+
+func TestStakingCacheDeletePreservesOtherValidators(t *testing.T) {
+	cache := NewStakingCache()
+
+	delAddr := sdk.AccAddress("delAddr")
+	valAddr1 := sdk.ValAddress("valAddr1")
+	valAddr2 := sdk.ValAddress("valAddr2")
+	valAddr3 := sdk.ValAddress("valAddr3")
+
+	amount1 := math.LegacyNewDec(100)
+	amount2 := math.LegacyNewDec(200)
+	amount3 := math.LegacyNewDec(300)
+
+	cache.SetStakedAmount(delAddr, valAddr1, amount1)
+	cache.SetStakedAmount(delAddr, valAddr2, amount2)
+	cache.SetStakedAmount(delAddr, valAddr3, amount3)
+
+	cache.Delete(delAddr, valAddr2)
+
+	result1 := cache.GetStakedAmount(delAddr, valAddr1)
+	require.True(t, result1.Equal(amount1))
+
+	result2 := cache.GetStakedAmount(delAddr, valAddr2)
+	require.True(t, result2.IsZero())
+
+	result3 := cache.GetStakedAmount(delAddr, valAddr3)
+	require.True(t, result3.Equal(amount3))
+}


### PR DESCRIPTION
Issue case: 

1. Del1 baby stake to val1 10BABY
2. Del1 baby unbond from val1 10BABY
3. Del1 baby stake to val1 25BABY
4. Active BABY would result in 15BABY 

The stk cache was not being properly cleaned after using it. 

Fix is to clean the pair after using it
