### PR TITLE
Use cancellable context in gRPC Gateway registration (epoching module)

### DIFF
--- a/x/epoching/module.go
+++ b/x/epoching/module.go
@@ -82,7 +82,7 @@ func (AppModuleBasic) RegisterRESTRoutes(clientCtx client.Context, rtr *mux.Rout
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+	if err := types.RegisterQueryHandlerClient(clientCtx.Context(), mux, types.NewQueryClient(clientCtx)); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION


### Description
- Replace context.Background() with clientCtx.Context() in RegisterGRPCGatewayRoutes to ensure proper cancellation and resource cleanup.
- This prevents potential goroutine/socket leaks during node shutdown or restart and aligns with gRPC-Gateway lifecycle expectations.

- Changes:
  - x/epoching/module.go: RegisterQueryHandlerClient now uses clientCtx.Context().


