### PR TITLE
fix: remove dead nil-check for withdraw address and fix comment

### DIFF
--- a/x/incentive/keeper/reward_gauge.go
+++ b/x/incentive/keeper/reward_gauge.go
@@ -33,12 +33,7 @@ func (k Keeper) withdrawReward(ctx context.Context, sType types.StakeholderType,
 		return nil, err
 	}
 
-	// Fallback to the stakeholder's address if no specific withdrawal address is set
-	if withdrawAddr == nil {
-		withdrawAddr = addr
-	}
-
-	// transfer withdrawable coins from incentive module account to the stakeholder's address
+	// transfer withdrawable coins from incentive module account to the withdraw address
 	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, withdrawAddr, withdrawableCoins); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Remove unreachable nil-check for withdraw address in withdrawReward
- Clarify comment to reflect defaulting behavior of GetWithdrawAddr