### PR TITLE
chore: update the reusable go lint test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@4cb00d8b8edbcd22684ecb2b26b5f915beb7f58c
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@4cb00d8b8edbcd22684ecb2b26b5f915beb7f58c  # v0.13.5
     secrets: inherit
     with:
       go-version: '1.23'


### PR DESCRIPTION
fix golang ci version compatibility - https://github.com/babylonlabs-io/babylon/actions/runs/18512201380/job/52755366057