### PR TITLE
 finality: sort GetVotingPowerTableOrdered by voting power desc with hex tiebreak

### DIFF
--- a/x/finality/keeper/power_table.go
+++ b/x/finality/keeper/power_table.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"cosmossdk.io/store/prefix"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -123,6 +124,14 @@ func (k Keeper) GetVotingPowerTableOrdered(ctx context.Context, height uint64) [
 			VotingPower: sdk.BigEndianToUint64(iter.Value()),
 		})
 	}
+
+	// Ensure ordering by voting power desc, tiebreak by BTC PK hex asc
+	sort.SliceStable(fps, func(i, j int) bool {
+		if fps[i].VotingPower == fps[j].VotingPower {
+			return fps[i].FpPk.MarshalHex() < fps[j].FpPk.MarshalHex()
+		}
+		return fps[i].VotingPower > fps[j].VotingPower
+	})
 
 	return fps
 }


### PR DESCRIPTION
Ensure GetVotingPowerTableOrdered() in /finality/keeper/power_table.go actually returns providers ordered by voting power. The previous implementation iterated a key-ordered prefix store (height || fpBTCPK) and returned entries in lexicographic key order,not by value.Added explicit sorting of the collected slice:
- Primary key: VotingPower descending.
- Tiebreaker: FpPk.MarshalHex() ascending for determinism.

This matches how active set ordering is defined and tested in x/finality/types/power_table.go (SortFinalityProvidersWithZeroedVotingPower) and the expectations in x/finality/keeper/liveness.go which iterates “in sorted order by the voting power.”