### PR TITLE
fix(finality): reject retroactive public randomness commitments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### State breaking
 
-- [#1984](https://github.com/babylonlabs-io/babylon/pull/1984) fix(finality): reject retroactive public randomness commitments in `CommitPubRandList`
+- [#1994](https://github.com/babylonlabs-io/babylon/pull/1994) fix(finality): reject retroactive public randomness commitments in `CommitPubRandList`
 - [#1956](https://github.com/babylonlabs-io/babylon/pull/1956) fix: add sort of fps by pub key in `GetVotingPowerTableOrdered`
 - [#1855](https://github.com/babylonlabs-io/babylon/pull/1855) Add check for `fundingInputValue <= 0` in stake extension
 - [#1867](https://github.com/babylonlabs-io/babylon/pull/1867) bump wasmd `v0.60.2`
@@ -64,7 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
-- [#1984](https://github.com/babylonlabs-io/babylon/pull/1984) fix(finality): enforce `StartHeight > currentBlockHeight` in `CommitPubRandList` to prevent retroactive randomness commitments
+- [#1994](https://github.com/babylonlabs-io/babylon/pull/1994) fix(finality): enforce `StartHeight > currentBlockHeight` in `CommitPubRandList` to prevent retroactive randomness commitments
 - [#1875](https://github.com/babylonlabs-io/babylon/pull/1875) chore: ensure soft-deleted FPs cannot receive new/extended BTC stake, or commit pub rand
 - [#1911](https://github.com/babylonlabs-io/babylon/pull/1911) fix: avoid panic in `ProcessProposal` when injected checkpoint tx contains a wrong message type
 - [#1953](https://github.com/babylonlabs-io/babylon/pull/1953) fix: refresh commission of active FPs in voting power distribution cache prior to reward distribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### State breaking
 
+- [#1984](https://github.com/babylonlabs-io/babylon/pull/1984) fix(finality): reject retroactive public randomness commitments in `CommitPubRandList`
 - [#1956](https://github.com/babylonlabs-io/babylon/pull/1956) fix: add sort of fps by pub key in `GetVotingPowerTableOrdered`
 - [#1855](https://github.com/babylonlabs-io/babylon/pull/1855) Add check for `fundingInputValue <= 0` in stake extension
 - [#1867](https://github.com/babylonlabs-io/babylon/pull/1867) bump wasmd `v0.60.2`
@@ -63,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
+- [#1984](https://github.com/babylonlabs-io/babylon/pull/1984) fix(finality): enforce `StartHeight > currentBlockHeight` in `CommitPubRandList` to prevent retroactive randomness commitments
 - [#1875](https://github.com/babylonlabs-io/babylon/pull/1875) chore: ensure soft-deleted FPs cannot receive new/extended BTC stake, or commit pub rand
 - [#1911](https://github.com/babylonlabs-io/babylon/pull/1911) fix: avoid panic in `ProcessProposal` when injected checkpoint tx contains a wrong message type
 - [#1953](https://github.com/babylonlabs-io/babylon/pull/1953) fix: refresh commission of active FPs in voting power distribution cache prior to reward distribution

--- a/test/e2e/btc_rewards_distribution_e2e_test.go
+++ b/test/e2e/btc_rewards_distribution_e2e_test.go
@@ -227,7 +227,7 @@ func (s *BtcRewardsDistribution) CommitPublicRandomnessAndSealed() {
 	// start height must be strictly greater than the current block height
 	curHeight, err := n1.QueryCurrentHeight()
 	s.NoError(err)
-	commitStartHeight := uint64(curHeight) + 1
+	commitStartHeight := uint64(curHeight) + 2 // +2 to account for block advancement between query and tx inclusion
 
 	fp1RandListInfo, fp1CommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fp1BTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)

--- a/test/e2e/btc_rewards_distribution_e2e_test.go
+++ b/test/e2e/btc_rewards_distribution_e2e_test.go
@@ -224,7 +224,10 @@ func (s *BtcRewardsDistribution) CommitPublicRandomnessAndSealed() {
 	s.NoError(err)
 
 	// commit public randomness list
-	commitStartHeight := uint64(5)
+	// start height must be strictly greater than the current block height
+	curHeight, err := n1.QueryCurrentHeight()
+	s.NoError(err)
+	commitStartHeight := uint64(curHeight) + 1
 
 	fp1RandListInfo, fp1CommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fp1BTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)

--- a/test/e2e/btc_staking_e2e_test.go
+++ b/test/e2e/btc_staking_e2e_test.go
@@ -245,7 +245,10 @@ func (s *BTCStakingTestSuite) Test3CommitPublicRandomnessAndSubmitFinalitySignat
 	*/
 	// commit public randomness list
 	numPubRand := uint64(100)
-	commitStartHeight := uint64(1)
+	// start height must be strictly greater than the current block height
+	curHeight, err := nonValidatorNode.QueryCurrentHeight()
+	s.NoError(err)
+	commitStartHeight := uint64(curHeight) + 1
 
 	randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fptBTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)

--- a/test/e2e/btc_staking_e2e_test.go
+++ b/test/e2e/btc_staking_e2e_test.go
@@ -248,7 +248,7 @@ func (s *BTCStakingTestSuite) Test3CommitPublicRandomnessAndSubmitFinalitySignat
 	// start height must be strictly greater than the current block height
 	curHeight, err := nonValidatorNode.QueryCurrentHeight()
 	s.NoError(err)
-	commitStartHeight := uint64(curHeight) + 1
+	commitStartHeight := uint64(curHeight) + 2 // +2 to account for block advancement between query and tx inclusion
 
 	randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fptBTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)

--- a/test/e2e/btc_staking_pre_approval_e2e_test.go
+++ b/test/e2e/btc_staking_pre_approval_e2e_test.go
@@ -305,7 +305,10 @@ func (s *BTCStakingPreApprovalTestSuite) Test4CommitPublicRandomnessAndSubmitFin
 	*/
 	// commit public randomness list
 	numPubRand := uint64(100)
-	commitStartHeight := uint64(1)
+	// start height must be strictly greater than the current block height
+	curHeight, err := n.QueryCurrentHeight()
+	s.NoError(err)
+	commitStartHeight := uint64(curHeight) + 1
 
 	randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fptBTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)

--- a/test/e2e/btc_staking_pre_approval_e2e_test.go
+++ b/test/e2e/btc_staking_pre_approval_e2e_test.go
@@ -308,7 +308,7 @@ func (s *BTCStakingPreApprovalTestSuite) Test4CommitPublicRandomnessAndSubmitFin
 	// start height must be strictly greater than the current block height
 	curHeight, err := n.QueryCurrentHeight()
 	s.NoError(err)
-	commitStartHeight := uint64(curHeight) + 1
+	commitStartHeight := uint64(curHeight) + 2 // +2 to account for block advancement between query and tx inclusion
 
 	randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fptBTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)

--- a/test/e2e/costaking_e2e_test.go
+++ b/test/e2e/costaking_e2e_test.go
@@ -86,7 +86,7 @@ func (s *CostakingTestSuite) TestFinalityProviderExit() {
 	// start height must be strictly greater than the current block height
 	curHeight, err := delegatorNode.QueryCurrentHeight()
 	s.NoError(err)
-	commitStartHeight := uint64(curHeight) + 1
+	commitStartHeight := uint64(curHeight) + 2 // +2 to account for block advancement between query and tx inclusion
 	_, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, fpSk, commitStartHeight, numPubRand)
 	s.NoError(err)
 	delegatorNode.CommitPubRandListFromNode(

--- a/test/e2e/costaking_e2e_test.go
+++ b/test/e2e/costaking_e2e_test.go
@@ -83,7 +83,10 @@ func (s *CostakingTestSuite) TestFinalityProviderExit() {
 	fp := chain.CreateFpFromNodeAddr(s.T(), s.r, fpSk, delegatorNode)
 
 	numPubRand := uint64(1000)
-	commitStartHeight := uint64(1)
+	// start height must be strictly greater than the current block height
+	curHeight, err := delegatorNode.QueryCurrentHeight()
+	s.NoError(err)
+	commitStartHeight := uint64(curHeight) + 1
 	_, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, fpSk, commitStartHeight, numPubRand)
 	s.NoError(err)
 	delegatorNode.CommitPubRandListFromNode(

--- a/test/e2e/gov_finality_resume.go
+++ b/test/e2e/gov_finality_resume.go
@@ -251,7 +251,7 @@ func (s *GovFinalityResume) Test3CommitPublicRandomnessAndSubmitFinalitySignatur
 	// start height must be strictly greater than the current block height
 	curHeight, err := nonValidatorNode.QueryCurrentHeight()
 	s.NoError(err)
-	commitStartHeight := uint64(curHeight) + 1
+	commitStartHeight := uint64(curHeight) + 2 // +2 to account for block advancement between query and tx inclusion
 
 	randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fptBTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)

--- a/test/e2e/gov_finality_resume.go
+++ b/test/e2e/gov_finality_resume.go
@@ -248,7 +248,10 @@ func (s *GovFinalityResume) Test3CommitPublicRandomnessAndSubmitFinalitySignatur
 	*/
 	// commit public randomness list
 	numPubRand := uint64(100)
-	commitStartHeight := uint64(1)
+	// start height must be strictly greater than the current block height
+	curHeight, err := nonValidatorNode.QueryCurrentHeight()
+	s.NoError(err)
+	commitStartHeight := uint64(curHeight) + 1
 
 	randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fptBTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)

--- a/test/e2e/software_upgrade_e2e_v4_test.go
+++ b/test/e2e/software_upgrade_e2e_v4_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 const (
-	commitStartHeightV23 = uint64(5)
-	govPropFileV4        = "v4_upgrade_temp.json"
+	govPropFileV4 = "v4_upgrade_temp.json"
 )
 
 type SoftwareUpgradeV23To4TestSuite struct {
@@ -273,11 +272,16 @@ func (s *SoftwareUpgradeV23To4TestSuite) SetupVerifiedBtcDelegationsWithBabyStak
 }
 
 func (s *SoftwareUpgradeV23To4TestSuite) FpCommitPubRandAndVote(n *chain.NodeConfig) {
-	fp1RandListInfo, fp1CommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fp1BTCSK, commitStartHeightV23, numPubRand)
+	// start height must be strictly greater than the current block height
+	curHeight, err := n.QueryCurrentHeight()
+	s.NoError(err)
+	commitStartHeight := uint64(curHeight) + 1
+
+	fp1RandListInfo, fp1CommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fp1BTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)
 	s.fp1RandListInfo = fp1RandListInfo
 
-	fp2RandListInfo, fp2CommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fp2BTCSK, commitStartHeightV23, numPubRand)
+	fp2RandListInfo, fp2CommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fp2BTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)
 	s.fp2RandListInfo = fp2RandListInfo
 
@@ -302,11 +306,11 @@ func (s *SoftwareUpgradeV23To4TestSuite) FpCommitPubRandAndVote(n *chain.NodeCon
 	n.WaitForNextBlocks(2)
 
 	fp1CommitPubRand := n.QueryListPubRandCommit(fp1CommitPubRandList.FpBtcPk)
-	fp1PubRand := fp1CommitPubRand[commitStartHeightV23]
+	fp1PubRand := fp1CommitPubRand[commitStartHeight]
 	s.Require().Equal(fp1PubRand.NumPubRand, numPubRand)
 
 	fp2CommitPubRand := n.QueryListPubRandCommit(fp2CommitPubRandList.FpBtcPk)
-	fp2PubRand := fp2CommitPubRand[commitStartHeightV23]
+	fp2PubRand := fp2CommitPubRand[commitStartHeight]
 	s.Require().Equal(fp2PubRand.NumPubRand, numPubRand)
 
 	finalizedEpoch := n.WaitUntilCurrentEpochIsSealedAndFinalized(1)
@@ -336,7 +340,7 @@ func (s *SoftwareUpgradeV23To4TestSuite) FpCommitPubRandAndVote(n *chain.NodeCon
 	}
 
 	s.finalityBlockHeightVoted = n.WaitFinalityIsActivated()
-	s.finalityIdx = s.finalityBlockHeightVoted - commitStartHeightV23
+	s.finalityIdx = s.finalityBlockHeightVoted - commitStartHeight
 
 	n.WaitForNextBlockWithSleep50ms()
 

--- a/test/e2e/software_upgrade_e2e_v4_test.go
+++ b/test/e2e/software_upgrade_e2e_v4_test.go
@@ -275,7 +275,7 @@ func (s *SoftwareUpgradeV23To4TestSuite) FpCommitPubRandAndVote(n *chain.NodeCon
 	// start height must be strictly greater than the current block height
 	curHeight, err := n.QueryCurrentHeight()
 	s.NoError(err)
-	commitStartHeight := uint64(curHeight) + 1
+	commitStartHeight := uint64(curHeight) + 2 // +2 to account for block advancement between query and tx inclusion
 
 	fp1RandListInfo, fp1CommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(s.r, s.fp1BTCSK, commitStartHeight, numPubRand)
 	s.NoError(err)

--- a/test/e2ev2/tmanager/finality_provider.go
+++ b/test/e2ev2/tmanager/finality_provider.go
@@ -51,7 +51,7 @@ func (fp *FinalityProvider) CommitPubRand() {
 	// start height must be strictly greater than the current block height
 	curHeight, err := fp.Node.LatestBlockNumber()
 	require.NoError(fp.T(), err)
-	commitStartHeight := uint64(curHeight) + 1
+	commitStartHeight := uint64(curHeight) + 2 // +2 to account for block advancement between query and tx inclusion
 
 	randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(fp.Node.Tm.R, fp.BtcPrivKey, commitStartHeight, numPubRand)
 	require.NoError(fp.T(), err)

--- a/test/e2ev2/tmanager/finality_provider.go
+++ b/test/e2ev2/tmanager/finality_provider.go
@@ -48,7 +48,10 @@ func (n *Node) NewFpWithWallet(wallet *WalletSender) *FinalityProvider {
 
 func (fp *FinalityProvider) CommitPubRand() {
 	numPubRand := uint64(1000)
-	commitStartHeight := uint64(5)
+	// start height must be strictly greater than the current block height
+	curHeight, err := fp.Node.LatestBlockNumber()
+	require.NoError(fp.T(), err)
+	commitStartHeight := uint64(curHeight) + 1
 
 	randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(fp.Node.Tm.R, fp.BtcPrivKey, commitStartHeight, numPubRand)
 	require.NoError(fp.T(), err)

--- a/x/finality/keeper/liveness_test.go
+++ b/x/finality/keeper/liveness_test.go
@@ -126,8 +126,8 @@ func FuzzHandleLivenessDeterminism(f *testing.F) {
 			fpSK, fpPK, fp := h1.CreateFinalityProvider(r)
 			require.NoError(t, err)
 			h2.AddFinalityProvider(fp)
-			h1.CommitPubRandList(r, fpSK, fp, 1, 1000, true)
-			h2.CommitPubRandList(r, fpSK, fp, 1, 1000, true)
+			h1.CommitPubRandList(r, fpSK, fp, 2, 1000, true)
+			h2.CommitPubRandList(r, fpSK, fp, 2, 1000, true)
 			fps[i] = fp
 
 			// Create delegation for each FP

--- a/x/finality/keeper/msg_server.go
+++ b/x/finality/keeper/msg_server.go
@@ -259,7 +259,7 @@ func (ms msgServer) CommitPubRandList(goCtx context.Context, req *types.MsgCommi
 
 	// check the commit start height is not too far into the future
 	if req.StartHeight >= currentHeight+types.MaxPubRandCommitOffset {
-		return nil, types.ErrInvalidPubRand.Wrapf("start height %d is too far into the future. Current height is %d and max offset is %d", req.StartHeight, ctx.BlockHeader().Height, types.MaxPubRandCommitOffset)
+		return nil, types.ErrInvalidPubRand.Wrapf("start height %d is too far into the future. Current height is %d and max offset is %d", req.StartHeight, currentHeight, types.MaxPubRandCommitOffset)
 	}
 
 	activationHeight, errMod := ms.validateActivationHeight(ctx, req.StartHeight)

--- a/x/finality/keeper/msg_server.go
+++ b/x/finality/keeper/msg_server.go
@@ -247,8 +247,18 @@ func (ms msgServer) CommitPubRandList(goCtx context.Context, req *types.MsgCommi
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	currentHeight := uint64(ctx.BlockHeader().Height)
+
+	// check the commit start height is not in the past (must be strictly future)
+	if req.StartHeight <= currentHeight {
+		return nil, types.ErrInvalidPubRand.Wrapf(
+			"start height %d must be greater than current block height %d",
+			req.StartHeight, currentHeight,
+		)
+	}
+
 	// check the commit start height is not too far into the future
-	if req.StartHeight >= uint64(ctx.BlockHeader().Height)+types.MaxPubRandCommitOffset {
+	if req.StartHeight >= currentHeight+types.MaxPubRandCommitOffset {
 		return nil, types.ErrInvalidPubRand.Wrapf("start height %d is too far into the future. Current height is %d and max offset is %d", req.StartHeight, ctx.BlockHeader().Height, types.MaxPubRandCommitOffset)
 	}
 

--- a/x/finality/keeper/msg_server_test.go
+++ b/x/finality/keeper/msg_server_test.go
@@ -11,6 +11,7 @@ import (
 	"cosmossdk.io/core/header"
 	sdkmath "cosmossdk.io/math"
 	"github.com/btcsuite/btcd/btcec/v2"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -62,7 +63,7 @@ func FuzzCommitPubRandList(f *testing.F) {
 
 		// Case 1: fail if the finality provider is not registered
 		bsKeeper.EXPECT().HasFinalityProvider(gomock.Any(), gomock.Eq(fpBTCPKBytes)).Return(false).Times(1)
-		startHeight := datagen.RandomInt(r, 10)
+		startHeight := uint64(1) + datagen.RandomInt(r, 10)
 		numPubRand := uint64(200)
 		_, msg, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, startHeight, numPubRand)
 		require.NoError(t, err)
@@ -74,7 +75,7 @@ func FuzzCommitPubRandList(f *testing.F) {
 		bsKeeper.EXPECT().IsFinalityProviderDeleted(gomock.Any(), gomock.Any()).Return(false).AnyTimes()
 
 		// Case 2: commit a list of <minPubRand pubrand and it should fail
-		startHeight = datagen.RandomInt(r, 10)
+		startHeight = uint64(1) + datagen.RandomInt(r, 10)
 		numPubRand = datagen.RandomInt(r, int(fKeeper.GetParams(ctx).MinPubRand))
 		_, msg, err = datagen.GenRandomMsgCommitPubRandList(r, btcSK, startHeight, numPubRand)
 		require.NoError(t, err)
@@ -82,7 +83,7 @@ func FuzzCommitPubRandList(f *testing.F) {
 		require.Error(t, err)
 
 		// Case 3: when the finality provider commits pubrand list and it should succeed
-		startHeight = datagen.RandomInt(r, 10)
+		startHeight = uint64(1) + datagen.RandomInt(r, 10)
 		numPubRand = 100 + datagen.RandomInt(r, int(fKeeper.GetParams(ctx).MinPubRand))
 		_, msg, err = datagen.GenRandomMsgCommitPubRandList(r, btcSK, startHeight, numPubRand)
 		require.NoError(t, err)
@@ -126,6 +127,31 @@ func FuzzCommitPubRandList(f *testing.F) {
 		_, err = ms.CommitPubRandList(ctx, msg)
 		require.Error(t, err)
 		require.ErrorContains(t, err, fmt.Sprintf("start height %d is too far into the future", startHeight))
+
+		// Case 8: fail if startHeight is not greater than the current block height (retroactive commitment)
+		// Simulate a chain at a higher block height by setting the CometBFT header
+		futureBlockHeight := int64(500)
+		ctxAtHeight := ctx.WithBlockHeader(cmtproto.Header{Height: futureBlockHeight})
+		// Try to commit randomness for a height at or below the current block height
+		retroStartHeight := uint64(futureBlockHeight) - datagen.RandomInt(r, 10)
+		_, msg, err = datagen.GenRandomMsgCommitPubRandList(r, btcSK, retroStartHeight, numPubRand)
+		require.NoError(t, err)
+		_, err = ms.CommitPubRandList(ctxAtHeight, msg)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "must be greater than current block height")
+
+		// Also verify that startHeight == currentHeight is rejected
+		_, msg, err = datagen.GenRandomMsgCommitPubRandList(r, btcSK, uint64(futureBlockHeight), numPubRand)
+		require.NoError(t, err)
+		_, err = ms.CommitPubRandList(ctxAtHeight, msg)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "must be greater than current block height")
+
+		// Verify startHeight = currentHeight + 1 succeeds
+		_, msg, err = datagen.GenRandomMsgCommitPubRandList(r, btcSK, uint64(futureBlockHeight)+1, numPubRand)
+		require.NoError(t, err)
+		_, err = ms.CommitPubRandList(ctxAtHeight, msg)
+		require.NoError(t, err)
 	})
 }
 
@@ -162,7 +188,7 @@ func FuzzAddFinalitySig(f *testing.F) {
 		cKeeper.EXPECT().GetEpoch(gomock.Any()).Return(&epochingtypes.Epoch{EpochNumber: committedEpochNum}).AnyTimes()
 
 		// commit some public randomness
-		startHeight := uint64(0)
+		startHeight := uint64(1)
 		numPubRand := uint64(200)
 		randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, startHeight, numPubRand)
 		require.NoError(t, err)
@@ -382,7 +408,7 @@ func TestVoteForConflictingHashShouldRetrieveEvidenceAndSlash(t *testing.T) {
 	cKeeper.EXPECT().GetEpoch(gomock.Any()).Return(&epochingtypes.Epoch{EpochNumber: 1}).AnyTimes()
 	cKeeper.EXPECT().GetLastFinalizedEpoch(gomock.Any()).Return(uint64(1)).AnyTimes()
 	// commit some public randomness
-	startHeight := uint64(0)
+	startHeight := uint64(1)
 	numPubRand := uint64(200)
 	randListInfo, msgCommitPubRandList, err :=
 		datagen.GenRandomMsgCommitPubRandList(r, btcSK, startHeight,
@@ -459,7 +485,7 @@ func TestDoNotPanicOnNilProof(t *testing.T) {
 	cKeeper.EXPECT().GetEpoch(gomock.Any()).Return(&epochingtypes.Epoch{EpochNumber: committedEpochNum}).AnyTimes()
 
 	// commit some public randomness
-	startHeight := uint64(0)
+	startHeight := uint64(1)
 	numPubRand := uint64(200)
 	randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, startHeight, numPubRand)
 	require.NoError(t, err)
@@ -503,13 +529,18 @@ func TestVerifyActivationHeight(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	fKeeper, ctx := keepertest.FinalityKeeper(t, nil, nil, nil, nil)
 	ms := keeper.NewMsgServerImpl(*fKeeper)
-	err := fKeeper.SetParams(ctx, types.DefaultParams())
+	// set a higher activation height so we can test with startHeight > currentBlockHeight
+	// but still below activation height
+	params := types.DefaultParams()
+	params.FinalityActivationHeight = 100
+	err := fKeeper.SetParams(ctx, params)
 	require.NoError(t, err)
 	activationHeight := fKeeper.GetParams(ctx).FinalityActivationHeight
 
 	// checks pub rand commit
 	btcSK, _, err := datagen.GenRandomBTCKeyPair(r)
 	require.NoError(t, err)
+	// startHeight must be > currentBlockHeight (0) but < activationHeight (100)
 	startHeight := activationHeight - 1
 	numPubRand := uint64(200)
 	randListInfo, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, startHeight, numPubRand)
@@ -568,8 +599,8 @@ func TestBtcDelegationRewards(t *testing.T) {
 	stakingTime := uint16(1000)
 
 	fp1SK, fp1PK, fp1 := h.CreateFinalityProvider(r)
-	// commit some public randomness
-	startHeight := uint64(0)
+	// commit some public randomness (must be > current block height which is 1 in test helper)
+	startHeight := uint64(2)
 	h.FpAddPubRand(r, fp1SK, startHeight)
 
 	_, _, fp1Del1, _ := h.CreateActiveBtcDelegation(r, covenantSKs, fp1PK, stakingValueFp1Del1, stakingTime, btcLightClientTipHeight)
@@ -643,8 +674,8 @@ func TestBtcDelegationRewardsEarlyUnbondingAndExpire(t *testing.T) {
 	stakingTime := uint16(1001)
 
 	fpSK, fpPK, fp := h.CreateFinalityProvider(r)
-	// commit some public randomness
-	startHeight := uint64(0)
+	// commit some public randomness (must be > current block height which is 1 in test helper)
+	startHeight := uint64(2)
 	h.FpAddPubRand(r, fpSK, startHeight)
 	btcLightClientTipHeight := uint32(30)
 

--- a/x/finality/keeper/power_dist_change_test.go
+++ b/x/finality/keeper/power_dist_change_test.go
@@ -834,7 +834,7 @@ func FuzzSlashFinalityProviderEvent(f *testing.F) {
 
 		// generate and insert new finality provider
 		fpSK, fpPK, fp := h.CreateFinalityProvider(r)
-		h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+		h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 
 		/*
 			insert new BTC delegation and give it covenant quorum
@@ -864,7 +864,7 @@ func FuzzSlashFinalityProviderEvent(f *testing.F) {
 
 		// execute BeginBlock
 		btcTip := &btclctypes.BTCHeaderInfo{Height: 30}
-		babylonHeight := datagen.RandomInt(r, 10) + 1
+		babylonHeight := datagen.RandomInt(r, 10) + 2
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(btcTip).AnyTimes()
 		h.BeginBlocker()
@@ -927,7 +927,7 @@ func FuzzJailFinalityProviderEvents(f *testing.F) {
 
 		// generate and insert new finality provider
 		fpSK, fpPK, fp := h.CreateFinalityProvider(r)
-		h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+		h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 
 		/*
 			insert new BTC delegation and give it covenant quorum
@@ -957,7 +957,7 @@ func FuzzJailFinalityProviderEvents(f *testing.F) {
 
 		// execute BeginBlock
 		btcTip := &btclctypes.BTCHeaderInfo{Height: 30}
-		babylonHeight := datagen.RandomInt(r, 10) + 1
+		babylonHeight := datagen.RandomInt(r, 10) + 2
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(btcTip)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Any()).Return(btcTip)
@@ -1067,7 +1067,7 @@ func FuzzUnjailFinalityProviderEvents(f *testing.F) {
 
 		// generate and insert new finality provider
 		fpSK, fpPK, fp := h.CreateFinalityProvider(r)
-		h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+		h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 
 		/*
 			insert new BTC delegation and give it covenant quorum
@@ -1097,7 +1097,7 @@ func FuzzUnjailFinalityProviderEvents(f *testing.F) {
 
 		// execute BeginBlock
 		btcTip := &btclctypes.BTCHeaderInfo{Height: 30}
-		babylonHeight := datagen.RandomInt(r, 10) + 1
+		babylonHeight := datagen.RandomInt(r, 10) + 2
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(btcTip).AnyTimes()
 		h.BeginBlocker()
@@ -1235,7 +1235,7 @@ func FuzzBTCDelegationEvents_NoPreApproval(f *testing.F) {
 		require.Equal(t, btcstktypes.BTCDelegationStatus_EXPIRED, btcDelStateUpdate.NewState)
 
 		// ensure this finality provider does not have voting power at the current height
-		babylonHeight := datagen.RandomInt(r, 10) + 1
+		babylonHeight := datagen.RandomInt(r, 10) + 2
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(btcTip).Times(2)
 		h.BeginBlocker()
@@ -1267,7 +1267,7 @@ func FuzzBTCDelegationEvents_NoPreApproval(f *testing.F) {
 		babylonHeight += 1
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(btcTip)
-		h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+		h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 		h.BeginBlocker()
 		require.Equal(t, uint64(stakingValue), h.FinalityKeeper.GetVotingPower(h.Ctx, *fp.BtcPk, babylonHeight))
 
@@ -1338,7 +1338,7 @@ func FuzzBTCDelegationEvents_WithPreApproval(f *testing.F) {
 		btcTip := btclctypes.BTCHeaderInfo{Height: 30} // TODO: parameterise
 
 		// ensure this finality provider does not have voting power at the current height
-		babylonHeight := datagen.RandomInt(r, 10) + 1
+		babylonHeight := datagen.RandomInt(r, 10) + 2
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(&btcTip)
 		h.BeginBlocker()
@@ -1398,7 +1398,7 @@ func FuzzBTCDelegationEvents_WithPreApproval(f *testing.F) {
 		babylonHeight += 1
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(&btcTip)
-		h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+		h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 		h.BeginBlocker()
 		require.Equal(t, uint64(stakingValue), h.FinalityKeeper.GetVotingPower(h.Ctx, *fp.BtcPk, babylonHeight))
 
@@ -1477,7 +1477,7 @@ func TestDoNotGenerateDuplicateEventsAfterHavingCovenantQuorum(t *testing.T) {
 	require.Equal(t, btcstktypes.BTCDelegationStatus_EXPIRED, btcDelStateUpdate.NewState)
 
 	// ensure this finality provider does not have voting power at the current height
-	babylonHeight := datagen.RandomInt(r, 10) + 1
+	babylonHeight := datagen.RandomInt(r, 10) + 2
 	h.SetCtxHeight(babylonHeight)
 	h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(btcTip).AnyTimes()
 	h.BeginBlocker()
@@ -1912,7 +1912,8 @@ func createAndCommitFinalityProvider(
 	_, err := btcStakingMsgServer.CreateFinalityProvider(ctx, fpMsg)
 	require.NoError(t, err)
 
-	_, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(r, fpSK, 1, 300)
+	commitStartHeight := uint64(ctx.BlockHeader().Height) + 1
+	_, msgCommitPubRandList, err := datagen.GenRandomMsgCommitPubRandList(r, fpSK, commitStartHeight, 300)
 	require.NoError(t, err)
 	_, err = finalityMsgServer.CommitPubRandList(ctx, msgCommitPubRandList)
 	require.NoError(t, err)
@@ -2189,7 +2190,7 @@ func TestGovernanceJailingAfterUnjailInSameBlock(t *testing.T) {
 
 	// generate and insert new finality provider
 	fpSK, fpPK, fp := h.CreateFinalityProvider(r)
-	h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+	h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 
 	// create BTC delegation to give the FP voting power
 	stakingValue := int64(2 * 10e8)

--- a/x/finality/keeper/power_dist_change_test.go
+++ b/x/finality/keeper/power_dist_change_test.go
@@ -1267,7 +1267,7 @@ func FuzzBTCDelegationEvents_NoPreApproval(f *testing.F) {
 		babylonHeight += 1
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(btcTip)
-		h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
+		h.CommitPubRandList(r, fpSK, fp, babylonHeight+1, 100, true)
 		h.BeginBlocker()
 		require.Equal(t, uint64(stakingValue), h.FinalityKeeper.GetVotingPower(h.Ctx, *fp.BtcPk, babylonHeight))
 
@@ -1398,7 +1398,7 @@ func FuzzBTCDelegationEvents_WithPreApproval(f *testing.F) {
 		babylonHeight += 1
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(&btcTip)
-		h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
+		h.CommitPubRandList(r, fpSK, fp, babylonHeight+1, 100, true)
 		h.BeginBlocker()
 		require.Equal(t, uint64(stakingValue), h.FinalityKeeper.GetVotingPower(h.Ctx, *fp.BtcPk, babylonHeight))
 

--- a/x/finality/keeper/power_table_test.go
+++ b/x/finality/keeper/power_table_test.go
@@ -48,7 +48,7 @@ func FuzzVotingPowerTable(f *testing.F) {
 		numFps := numFpsWithVotingPower + datagen.RandomInt(r, 10)
 		for i := uint64(0); i < numFps; i++ {
 			fpSK, _, fp := h.CreateFinalityProvider(r)
-			h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+			h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 			fps = append(fps, fp)
 		}
 
@@ -81,7 +81,7 @@ func FuzzVotingPowerTable(f *testing.F) {
 		/*
 			assert the first numFpsWithVotingPower finality providers have voting power
 		*/
-		babylonHeight := datagen.RandomInt(r, 10) + 1
+		babylonHeight := datagen.RandomInt(r, 10) + 2
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(&btclctypes.BTCHeaderInfo{Height: 30}).AnyTimes()
 		err := h.BTCStakingKeeper.BeginBlocker(h.Ctx)
@@ -206,7 +206,7 @@ func FuzzRecordVotingPowerDistCache(f *testing.F) {
 		fpsWithVotingPowerMap := map[string]*types.FinalityProvider{}
 		for i := uint64(0); i < numFps; i++ {
 			fpSK, _, fp := h.CreateFinalityProvider(r)
-			h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+			h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 			if i < numFpsWithVotingPower {
 				// these finality providers will receive BTC delegations and have voting power
 				fpsWithVotingPowerMap[fp.Addr] = fp
@@ -241,7 +241,7 @@ func FuzzRecordVotingPowerDistCache(f *testing.F) {
 		}
 
 		// record voting power distribution cache
-		babylonHeight := datagen.RandomInt(r, 10) + 1
+		babylonHeight := datagen.RandomInt(r, 10) + 2
 		h.Ctx = datagen.WithCtxHeight(h.Ctx, babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(&btclctypes.BTCHeaderInfo{Height: 30}).AnyTimes()
 		h.BeginBlocker()
@@ -316,11 +316,11 @@ func FuzzVotingPowerTable_ActiveFinalityProviders(f *testing.F) {
 			// zero voting power in the table
 			fpDistInfo := &ftypes.FinalityProviderDistInfo{BtcPk: fp.BtcPk, TotalBondedSat: stakingValue}
 			if r.Intn(10) <= 2 {
-				h.CommitPubRandList(r, fpSK, fp, 1, 100, false)
+				h.CommitPubRandList(r, fpSK, fp, 2, 100, false)
 				noTimestampedFps[fp.BtcPk.MarshalHex()] = true
 				fpDistInfo.IsTimestamped = false
 			} else {
-				h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+				h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 				fpDistInfo.IsTimestamped = true
 			}
 
@@ -338,7 +338,7 @@ func FuzzVotingPowerTable_ActiveFinalityProviders(f *testing.F) {
 		}
 
 		// record voting power table
-		babylonHeight := datagen.RandomInt(r, 10) + 1
+		babylonHeight := datagen.RandomInt(r, 10) + 2
 		h.SetCtxHeight(babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(&btclctypes.BTCHeaderInfo{Height: 30}).AnyTimes()
 		h.BeginBlocker()
@@ -412,7 +412,7 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 			// generate finality provider
 			// generate and insert new finality provider
 			fpSK, fpPK, fp := h.CreateFinalityProvider(r)
-			h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+			h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 
 			// create BTC delegation and add covenant signatures to activate it
 			stakingValue := datagen.RandomInt(r, 100000) + 100000
@@ -479,7 +479,7 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 		h.CheckpointingKeeperForFinality.EXPECT().GetLastFinalizedEpoch(gomock.Any()).Return(uint64(2)).AnyTimes()
 
 		// record voting power table
-		babylonHeight := datagen.RandomInt(r, 10) + 1
+		babylonHeight := datagen.RandomInt(r, 10) + 2
 		h.Ctx = datagen.WithCtxHeight(h.Ctx, babylonHeight)
 		h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(&btclctypes.BTCHeaderInfo{Height: 30})
 		h.BeginBlocker()
@@ -548,7 +548,7 @@ func FuzzVotingPowerTable_ActiveFinalityProviderRotation(f *testing.F) {
 		// 	// generate finality provider
 		// 	// generate and insert new finality provider
 		// 	fpSK, fpPK, fp := h.CreateFinalityProvider(r)
-		// 	h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+		// 	h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 
 		// 	// create BTC delegation and add covenant signatures to activate it
 		// 	stakingValue := datagen.RandomInt(r, 100000) + 100000
@@ -759,7 +759,7 @@ func TestVotingPowerTable_ActiveFinalityProviderRotation_Seed0(t *testing.T) {
 	fpsWithMeta := []*FinalityProviderWithMetaCostaker{}
 	for i := uint64(0); i < numFps; i++ {
 		fpSK, fpPK, fp := h.CreateFinalityProvider(r)
-		h.CommitPubRandList(r, fpSK, fp, 1, 100, true)
+		h.CommitPubRandList(r, fpSK, fp, 2, 100, true)
 
 		stakingValue := datagen.RandomInt(r, 100000) + 100000
 		delSK, _, err := datagen.GenRandomBTCKeyPair(r)
@@ -829,7 +829,7 @@ func TestVotingPowerTable_ActiveFinalityProviderRotation_Seed0(t *testing.T) {
 
 	h.CheckpointingKeeperForFinality.EXPECT().GetLastFinalizedEpoch(gomock.Any()).Return(uint64(2)).AnyTimes()
 
-	babylonHeight := datagen.RandomInt(r, 10) + 1
+	babylonHeight := datagen.RandomInt(r, 10) + 2
 	h.Ctx = datagen.WithCtxHeight(h.Ctx, babylonHeight)
 	h.BTCLightClientKeeper.EXPECT().GetTipInfo(gomock.Eq(h.Ctx)).Return(&btclctypes.BTCHeaderInfo{Height: 30})
 

--- a/x/finality/keeper/votes_bench_test.go
+++ b/x/finality/keeper/votes_bench_test.go
@@ -42,7 +42,7 @@ func benchmarkAddFinalitySig(b *testing.B) {
 
 	// commit enough public randomness
 	// TODO: generalise commit public randomness to allow arbitrary benchtime
-	randListInfo, msg, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, 0, 100000)
+	randListInfo, msg, err := datagen.GenRandomMsgCommitPubRandList(r, btcSK, 1, 100000)
 	require.NoError(b, err)
 	_, err = ms.CommitPubRandList(ctx, msg)
 	require.NoError(b, err)


### PR DESCRIPTION
## Summary

- Adds a lower-bound check in `CommitPubRandList` requiring `StartHeight > currentBlockHeight`, preventing finality providers from backfilling randomness for already-observed blocks
- Adds dedicated test cases (retroactive, equal-height, and future-height scenarios)
- Updates all e2e and unit tests to use dynamic/valid start heights

Closes #1984

## Test plan

- [x] New unit test case in `FuzzCommitPubRandList` verifying retroactive commits are rejected
- [x] New unit test case verifying `startHeight == currentHeight` is rejected
- [x] New unit test case verifying `startHeight == currentHeight + 1` succeeds
- [x] All existing test start heights updated to comply with the new constraint
- [ ] CI passes `make test` (blocked locally by pre-existing Go 1.26 / sonic dependency issue on main)