### PR TITLE
docs(btcstaking): document MsgBTCUndelegate as intent-based

### DIFF
--- a/x/btcstaking/README.md
+++ b/x/btcstaking/README.md
@@ -685,6 +685,19 @@ Upon `BTCUndelegate`, a Babylon node will execute as follows:
    storage. Babylon will consider this BTC delegation to be unbonded from now
    on.
 
+Ordinary (non stake-expansion) undelegation is **intent-based**: the staker's
+signed spend of the staking output is enough for Babylon to treat the
+delegation as unbonded. The spending transaction's inclusion proof is only
+checked for Merkle validity against a known BTC header — it is **not**
+required to be `BtcConfirmationDepth` ("k") deep, unlike
+`MsgCreateBTCDelegation` and `MsgAddBTCDelegationInclusionProof`, which do
+enforce k-depth before granting voting power. As a consequence, a BTC reorg
+smaller than `BtcConfirmationDepth` that removes the unbonding transaction
+from the canonical chain does **not** restore the delegation; once the
+staker's intent to unbond has been observed, the delegation stays unbonded.
+See [btc-reorg.md](./docs/btc-reorg.md) for the large-reorg recovery
+procedure.
+
 ### MsgUpdateParams
 
 The `MsgUpdateParams` message is used for updating the module parameters for the

--- a/x/btcstaking/docs/btc-reorg.md
+++ b/x/btcstaking/docs/btc-reorg.md
@@ -95,6 +95,30 @@ to remove the data from the 3 modules states.
 
 #### 3.3 `MsgBTCUndelegate`
 
+> **Design note.** Ordinary (non stake-expansion) `MsgBTCUndelegate` is
+> **intent-based**: the staker's signed spend of the staking output is enough
+> for Babylon to treat the delegation as `UNBONDED`, and the spending tx's
+> inclusion proof is only checked for Merkle validity against a known BTC
+> header — it is **not** required to be `BtcConfirmationDepth` ("k") deep.
+> This is intentionally different from `MsgCreateBTCDelegation` /
+> `MsgAddBTCDelegationInclusionProof`, which enforce k-depth before granting
+> voting power.
+>
+> A direct consequence of this design is that a BTC reorg smaller than
+> `BtcConfirmationDepth` that removes the unbonding transaction from the
+> canonical chain does **not** restore the delegation. Once Babylon has
+> observed the staker's intent to unbond, the delegation stays `UNBONDED`
+> regardless of whether the unbonding spend remains in BTC's canonical chain.
+> The repair procedure described below therefore only applies to reorgs
+> larger than `BtcConfirmationDepth` that have already halted the chain as
+> described in [Chain Halt](#chain-halt); shallower reorgs that reorg out an
+> accepted undelegation are expected and require no repair.
+>
+> The stake-expansion branch of `MsgBTCUndelegate` is the exception: it
+> activates a new delegation and therefore still enforces the k-depth check
+> on the spending transaction, and the repair steps for that branch match
+> those of [3.1](#31-msgcreatebtcdelegation) / [3.2](#32-msgaddbtcdelegationinclusionproof).
+
 Check if the inclusion proof had a reorg in the BTC blocks, if it is not
 rollbacked, there is nothing to do. If it was rollbacked it is needed
 to remove the existence of this BTC undelegation and affecting 3 modules state

--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -520,7 +520,28 @@ func getFundingTxTransactions(txs [][]byte) ([]*wire.MsgTx, error) {
 
 // BTCUndelegate adds a signature on the unbonding tx from the BTC delegator
 // this effectively proves that the BTC delegator wants to unbond and Babylon
-// will consider its BTC delegation unbonded
+// will consider its BTC delegation unbonded.
+//
+// By design, ordinary (non stake-expansion) undelegation is intent-based: the
+// staker's signed spend of the staking output is enough for Babylon to treat
+// the delegation as UNBONDED, and the inclusion proof is only required to be
+// verifiable against a known BTC header — it is NOT required to be
+// `BtcConfirmationDepth` ("k") deep. This is intentionally different from
+// MsgCreateBTCDelegation / MsgAddBTCDelegationInclusionProof, which DO enforce
+// k-depth before activating a delegation, because an activation grants voting
+// power while an undelegation only revokes it.
+//
+// A direct consequence of this design is that a BTC reorg which removes the
+// unbonding transaction from the canonical chain does NOT restore the
+// delegation: once Babylon has observed the staker's intent to unbond, the
+// delegation stays UNBONDED regardless of whether the unbonding spend remains
+// in BTC's canonical chain. Only reorgs deeper than `BtcConfirmationDepth`
+// halt the chain (see x/btcstaking/docs/btc-reorg.md); shallower reorgs that
+// reorg out an accepted undelegation are expected and require no repair.
+//
+// The stake-expansion branch below is the exception: it activates a new
+// delegation and therefore routes through AddBTCDelegationInclusionProof,
+// which still enforces the k-depth check on the spending tx.
 func (ms msgServer) BTCUndelegate(goCtx context.Context, req *types.MsgBTCUndelegate) (*types.MsgBTCUndelegateResponse, error) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), types.MetricsKeyBTCUndelegate)
 
@@ -564,6 +585,8 @@ func (ms msgServer) BTCUndelegate(goCtx context.Context, req *types.MsgBTCUndele
 			return nil, types.ErrInvalidBTCUndelegateReq.Wrapf("failed to handle stake expansion inclusion: %s", err)
 		}
 	} else {
+		// Intentionally only a Merkle-inclusion check, NOT a k-depth check:
+		// ordinary undelegation is intent-based (see the BTCUndelegate godoc).
 		proofValid := btcckpttypes.VerifyInclusionProof(
 			btcutil.NewTx(stakeSpendingTx),
 			&btcHeader.MerkleRoot,


### PR DESCRIPTION
## Summary

- Expands the godoc on `msgServer.BTCUndelegate` to spell out that ordinary undelegation is intent-based: the staker's signed spend of the staking output is enough for Babylon to treat the delegation as `UNBONDED`, and the inclusion proof is only checked for Merkle validity — it is **not** required to be `BtcConfirmationDepth` ("k") deep.
- Adds a matching design note to `x/btcstaking/docs/btc-reorg.md` (section 3.3) and `x/btcstaking/README.md`, stating that a sub-k BTC reorg that removes the unbonding tx from the canonical chain does **not** restore the delegation. The stake-expansion branch remains the exception since it activates a new delegation via `AddBTCDelegationInclusionProof`.
- Adds a short inline comment next to the `VerifyInclusionProof` call in the msg server to flag that the lack of a k-depth check there is intentional.

No behavior changes. Documentation only. No changelog entry per request.

Prompted by several reports claiming that accepting sub-k undelegation proofs is a bug after a BTC reorg — this is working as designed; these changes make that explicit so future reviewers/auditors see it in both the godoc and the module docs.
