### PR TITLE
chore: upgrade GitHub Actions to latest pinned versions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -36,6 +36,6 @@ jobs:
         )
       )
     steps:
-      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2 https://github.com/tibdex/backport/releases/tag/v2
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4 https://github.com/tibdex/backport/releases/tag/v2.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   changelog_reminder:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@5d014a155c08d56a1b5673d049f2b4e7d4427825 # v0.19.0 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@5d014a155c08d56a1b5673d049f2b4e7d4427825 # v0.19.0 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     secrets: inherit
     with:
       go-version: '1.25'
@@ -37,7 +37,7 @@ jobs:
       contents: read         # Required by reusable workflow
       id-token: write        # Required for AWS OIDC
       security-events: write # Required for Trivy SARIF uploads
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5d014a155c08d56a1b5673d049f2b4e7d4427825 # v0.19.0 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     secrets: inherit
     with:
      publish: false
@@ -61,7 +61,7 @@ jobs:
         run: |
           docker save -o /tmp/docker-babylond.tar.gz babylonlabs-io/babylond:latest
       - name: Upload babylon artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 https://github.com/actions/upload-artifact/releases/tag/v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2 https://github.com/actions/upload-artifact/releases/tag/v4.6.2
         with:
           name: babylond-${{ github.sha }} # so it renovates at every new sha
           path: /tmp/docker-babylond.tar.gz
@@ -78,7 +78,7 @@ jobs:
         run: |
           docker save -o /tmp/docker-init-chain.tar.gz babylonlabs-io/babylond-e2e-init-chain:latest
       - name: Upload init-chain artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 https://github.com/actions/upload-artifact/releases/tag/v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2 https://github.com/actions/upload-artifact/releases/tag/v4.6.2
         with:
           name: init-chain
           path: /tmp/docker-init-chain.tar.gz
@@ -90,7 +90,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -98,7 +98,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestIBCTranferTestSuite
@@ -112,7 +112,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -120,7 +120,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestBTCTimestampingTestSuite
@@ -134,7 +134,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -142,7 +142,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestBTCStakingTestSuite
@@ -156,7 +156,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -164,7 +164,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestGovResumeFinality
@@ -178,7 +178,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -186,7 +186,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestBTCRewardsDistribution
@@ -200,7 +200,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -208,7 +208,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestBTCStakingPreApprovalTestSuite
@@ -222,7 +222,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -230,7 +230,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestICATestSuite
@@ -244,7 +244,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -252,7 +252,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestEpochingSpamPreventionTestSuite
@@ -266,7 +266,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -274,7 +274,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestBTCStakeExpansionTestSuite
@@ -288,7 +288,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -296,7 +296,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestCostakingTestSuite
@@ -310,7 +310,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -318,7 +318,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2e TestValidatorJailingTestSuite
@@ -332,7 +332,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Download babylon artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 https://github.com/actions/download-artifact/releases/tag/v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
         with:
           name: babylond-${{ github.sha }}
           path: /tmp
@@ -340,7 +340,7 @@ jobs:
         run: |
           docker load < /tmp/docker-babylond.tar.gz
       - name: Cache Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: 1.25
       - name: Run e2eV2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@5d014a155c08d56a1b5673d049f2b4e7d4427825 # v0.19.0 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs['skip-lint-test'] == true) }}
     secrets: inherit
     with:
@@ -35,7 +35,7 @@ jobs:
           (github.event_name == 'workflow_dispatch' && inputs['skip-lint-test'] == true) ||
           needs.lint_test.result == 'success'
         )}}
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5d014a155c08d56a1b5673d049f2b4e7d4427825 # v0.19.0 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     needs: ["lint_test"]
     secrets: inherit
     permissions:
@@ -61,7 +61,7 @@ jobs:
               needs.lint_test.result == 'success'
             )
           ) }}
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5d014a155c08d56a1b5673d049f2b4e7d4427825 # v0.19.0 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     needs: ["lint_test"]
     secrets: inherit
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/sync_pr_main_to_base.yml
+++ b/.github/workflows/sync_pr_main_to_base.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   call_sync_branch:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_sync_branch.yml@5d014a155c08d56a1b5673d049f2b4e7d4427825 # v0.19.0 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_sync_branch.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1 https://github.com/babylonlabs-io/.github/releases/tag/v0.19.1
     with:
       base_branch: "main"
       target_branch: "base/consumer-chain-support"


### PR DESCRIPTION
## Summary

- Upgrade all `uses:` references in `.github/workflows/` to the latest full `vX.Y.Z` versions
- Pin each action to its immutable 40-char commit SHA
- Version tag preserved in trailing comment (e.g. `# v6.0.2 https://...`) for readability

## Why

SHA pinning prevents supply-chain attacks: a version tag can be silently force-pushed to malicious code, but a commit SHA is immutable.

## Files changed

-     Files updated: backport.yml changelog-reminder.yml ci.yml publish.yml release.yml sync_pr_main_to_base.yml
-       - babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
-       - babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
-       - babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
-       - babylonlabs-io/.github/.github/workflows/reusable_sync_branch.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
-  .github/workflows/backport.yml             |  2 +-
-  .github/workflows/changelog-reminder.yml   |  2 +-
-  .github/workflows/ci.yml                   | 56 +++++++++++++++---------------
-  .github/workflows/publish.yml              |  6 ++--
-  .github/workflows/release.yml              |  2 +-
-  .github/workflows/sync_pr_main_to_base.yml |  2 +-

## Pinned actions

- actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
- actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
- actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
- babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
- babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
- babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
- babylonlabs-io/.github/.github/workflows/reusable_sync_branch.yml@98e4de18638b3d0738c9cbf7e7dfc6e34524db54 # v0.19.1
- tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4