### PR TITLE
fix: correct contraction in msg_server.go

### DIFF
--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -693,7 +693,7 @@ func (ms msgServer) SelectiveSlashingEvidence(goCtx context.Context, req *types.
 
 	// slashing the provider - this method also checks:
 	// - that the fp first exists and can be found
-	// - that the finality provider isnt already slashed
+	// - that the finality provider isn't already slashed
 	if err := ms.SlashFinalityProvider(ctx, fpBTCPK.MustMarshal()); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
Fixed spelling error in code comment.

⚠️ **Note:** This is a comment-only change. No functional code is modified. This is a minor documentation improvement to the repository.

## Changes
- Fixed `isnt` → `isn't` in finality provider comment

## Files Modified
- x/btcstaking/keeper/msg_server.go (comment line 696)

## Impact
- No functional changes to code logic
- Comment clarity improvement only
- No API or behavior changes