### PR TITLE
fix: backport wrong-epoch VE and stake-expansion early-unbond security fixes from release/v4.3.x to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [#1969](https://github.com/babylonlabs-io/babylon/pull/1969) fix: set v4.3 upgrade handler to run at second block of an epoch
 - [#1923](https://github.com/babylonlabs-io/babylon/pull/1923) fix: add max bytes size for vote extension
 - [#1981](https://github.com/babylonlabs-io/babylon/pull/1981) fix: correctly link wasm IBC stack handler
+- [GHSA-786p-4f8h-946w](https://github.com/babylonlabs-io/babylon/security/advisories/GHSA-786p-4f8h-946w)
+  fix(checkpointing): reject vote extensions with mismatched epoch number
+  (forward-port to `main`; already shipped on `release/v4.3.x` and `release/v4.4.x`)
+- [GHSA-4rm2-cj74-f62h](https://github.com/babylonlabs-io/babylon/security/advisories/GHSA-4rm2-cj74-f62h)
+  fix(btcstaking): allow unbonding the parent of a stake-expansion child that
+  unbonds before becoming `ACTIVE` (forward-port to `main`)
 
 ## v4.2.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,12 +77,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [#1969](https://github.com/babylonlabs-io/babylon/pull/1969) fix: set v4.3 upgrade handler to run at second block of an epoch
 - [#1923](https://github.com/babylonlabs-io/babylon/pull/1923) fix: add max bytes size for vote extension
 - [#1981](https://github.com/babylonlabs-io/babylon/pull/1981) fix: correctly link wasm IBC stack handler
-- [GHSA-786p-4f8h-946w](https://github.com/babylonlabs-io/babylon/security/advisories/GHSA-786p-4f8h-946w)
-  fix(checkpointing): reject vote extensions with mismatched epoch number
-  (forward-port to `main`; already shipped on `release/v4.3.x` and `release/v4.4.x`)
-- [GHSA-4rm2-cj74-f62h](https://github.com/babylonlabs-io/babylon/security/advisories/GHSA-4rm2-cj74-f62h)
-  fix(btcstaking): allow unbonding the parent of a stake-expansion child that
-  unbonds before becoming `ACTIVE` (forward-port to `main`)
+
+## v4.3.0
+
+### Bug Fixes
+
+- [GHSA-4rm2-cj74-f62h](https://github.com/babylonlabs-io/babylon/security/advisories/GHSA-4rm2-cj74-f62h) fix: add possibility to unbond parent
+of stake expansion child transaction that unbonds before being `ACTIVE`
+- [GHSA-786p-4f8h-946w](https://github.com/babylonlabs-io/babylon/security/advisories/GHSA-786p-4f8h-946w) fix(checkpointing): reject vote extensions with mismatched epoch number
 
 ## v4.2.7
 

--- a/app/include_upgrade_mainnet.go
+++ b/app/include_upgrade_mainnet.go
@@ -12,6 +12,7 @@ import (
 	v41 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_1"
 	v42 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_2"
 	v43 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_3"
+	v44 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_4"
 )
 
 var WhitelistedChannelsID = map[string]struct{}{
@@ -27,6 +28,7 @@ var WhitelistedChannelsID = map[string]struct{}{
 // init is used to include v2.2 upgrade for mainnet data
 func init() {
 	Upgrades = []upgrades.Upgrade{
+		v44.Upgrade,
 		v43.Upgrade,
 		v42.Upgrade,
 		v41.Upgrade,

--- a/app/include_upgrade_testnet.go
+++ b/app/include_upgrade_testnet.go
@@ -16,6 +16,7 @@ import (
 	v41 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_1"
 	v42 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_2"
 	v43 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_3"
+	v44 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_4"
 	v4rc3 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4rc3/testnet"
 )
 
@@ -23,6 +24,7 @@ import (
 // it is also used for e2e testing
 func init() {
 	Upgrades = []upgrades.Upgrade{
+		v44.Upgrade,
 		v43.Upgrade,
 		v42.Upgrade,
 		v41.Upgrade,

--- a/app/upgrades/v4_3/upgrade.go
+++ b/app/upgrades/v4_3/upgrade.go
@@ -2,351 +2,281 @@ package v4_3
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"cosmossdk.io/collections"
-	corestoretypes "cosmossdk.io/core/store"
-	"cosmossdk.io/math"
 	store "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/types/query"
-	stkkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
-	stktypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/babylonlabs-io/babylon/v4/app/keepers"
 	"github.com/babylonlabs-io/babylon/v4/app/upgrades"
-	"github.com/babylonlabs-io/babylon/v4/app/upgrades/epoching"
-	costkkeeper "github.com/babylonlabs-io/babylon/v4/x/costaking/keeper"
-	costktypes "github.com/babylonlabs-io/babylon/v4/x/costaking/types"
-	epochingkeeper "github.com/babylonlabs-io/babylon/v4/x/epoching/keeper"
+	btcstkkeeper "github.com/babylonlabs-io/babylon/v4/x/btcstaking/keeper"
+	btcstktypes "github.com/babylonlabs-io/babylon/v4/x/btcstaking/types"
 )
 
-const UpgradeName = "v4.3"
+const (
+	UpgradeName = "v4.3"
+
+	// EventTypePhantomStakeExpansionRemediated is emitted once per parent
+	// delegation that is force-unbonded by the GHSA-4rm2-cj74-f62h remediation.
+	// External indexers can use it to reconcile prior phantom voting power.
+	EventTypePhantomStakeExpansionRemediated = "phantom_stake_expansion_remediated"
+
+	AttrParentStakingTxHash = "parent_staking_tx_hash"
+	AttrChildStakingTxHash  = "child_staking_tx_hash"
+)
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
 	CreateUpgradeHandler: CreateUpgradeHandler,
-	StoreUpgrades: store.StoreUpgrades{
-		Added:   []string{},
-		Deleted: []string{},
-	},
+	StoreUpgrades:        store.StoreUpgrades{},
 }
 
-func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
-	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// Run migrations before applying any other state changes.
-		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
+func CreateUpgradeHandler(mm *module.Manager, cfg module.Configurator, k *keepers.AppKeepers) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		logger := sdkCtx.Logger().With("upgrade", UpgradeName)
+
+		logger.Info("running module migrations")
+		vm, err := mm.RunMigrations(ctx, cfg, fromVM)
 		if err != nil {
+			logger.Error("module migrations failed", "error", err.Error())
 			return nil, err
 		}
 
-		// Validate that we are at the second block of the epoch.
-		// The second block is required because GetCurrentValidatorSet depends
-		// on InitValidatorSet which runs in the epoching BeginBlocker on the
-		// first block of the epoch.
-		if err := epoching.ValidateSecondBlockOfEpoch(ctx, keepers.EpochingKeeper); err != nil {
-			return nil, fmt.Errorf("epoch boundary validation failed: %w", err)
-		}
-
-		costkStoreKey := keepers.GetKey(costktypes.StoreKey)
-		if costkStoreKey == nil {
-			return nil, errors.New("invalid costaking types store key")
-		}
-		coStkStoreService := runtime.NewKVStoreService(costkStoreKey)
-
-		// Reset co-staker rewards tracker for ActiveBaby
-		if err := ResetCoStakerRwdsTrackerActiveBaby(
-			ctx,
-			keepers.EncCfg.Codec,
-			coStkStoreService,
-			keepers.EpochingKeeper,
-			keepers.StakingKeeper,
-			keepers.CostakingKeeper,
-		); err != nil {
+		logger.Info("scanning BTC staking store for poisoned stake-expansion parents (GHSA-4rm2-cj74-f62h)")
+		remediated, err := RemediatePoisonedStakeExpansions(sdkCtx, k.BTCStakingKeeper)
+		if err != nil {
+			logger.Error("stake-expansion remediation failed — upgrade aborting",
+				"error", err.Error())
 			return nil, err
 		}
-
-		return migrations, nil
+		logger.Info("upgrade complete", "remediated_parents", len(remediated))
+		return vm, nil
 	}
 }
 
-// ResetCoStakerRwdsTrackerActiveBaby resets the ActiveBaby in costaker rewards tracker
-// It recalculates ActiveBaby for all BABY stakers based on current delegations to active validators
-func ResetCoStakerRwdsTrackerActiveBaby(
-	ctx context.Context,
-	cdc codec.BinaryCodec,
-	costkStoreService corestoretypes.KVStoreService,
-	epochingKeeper epochingkeeper.Keeper,
-	stkKeeper *stkkeeper.Keeper,
-	coStkKeeper costkkeeper.Keeper,
-) error {
-	sb := collections.NewSchemaBuilder(costkStoreService)
-	rwdTrackers := collections.NewMap(
-		sb,
-		costktypes.CostakerRewardsTrackerKeyPrefix,
-		"costaker_rewards_tracker",
-		collections.BytesKey,
-		codec.CollValue[costktypes.CostakerRewardsTracker](cdc),
+// RemediatePoisonedStakeExpansions scans the BTC staking store for
+// stake-expansion children that were unbonded early before their inclusion
+// proof was added (the GHSA-4rm2-cj74-f62h attack pattern) and force-unbonds
+// the corresponding parent delegations. The child's own staking transaction
+// is the canonical proof that the parent's UTXO was spent on Bitcoin, so it
+// is recorded as the parent's `DelegatorUnbondingInfo.SpendStakeTx`.
+//
+// The remediation is intentionally idempotent: parents that are already
+// unbonded (legitimately or by a previous run) are skipped. Returns the
+// staking-tx hashes (as hex strings) of remediated parents in iteration
+// order.
+func RemediatePoisonedStakeExpansions(
+	ctx sdk.Context,
+	bk btcstkkeeper.Keeper,
+) ([]string, error) {
+	logger := ctx.Logger().With("upgrade", UpgradeName, "module", "stake_expansion_remediation")
+
+	type pair struct {
+		parent     *btcstktypes.BTCDelegation
+		spendTxBz  []byte
+		childHash  string
+		parentHash string
+	}
+	// Collect first, mutate after — avoids invalidating the store iterator.
+	var toRemediate []pair
+	// Dedupe by parent hash. On Bitcoin, only ONE spender of the parent's
+	// UTXO can ever confirm; on babylon we may have registered multiple
+	// stake expansions of the same ACTIVE parent before any of them
+	// confirmed. We only need to mark the parent UNBONDED once, so dedupe
+	// here and record the first encountered child as SpendStakeTx.
+	seenParent := make(map[string]struct{})
+
+	var (
+		scanned                    int
+		poisonedChildren           int
+		skippedParentMissing       int
+		skippedParentAlreadyUnbond int
+		skippedParentNotActive     int
+		skippedDuplicateParent     int
+		skippedNoPrevStkQuorum     int
 	)
 
-	// Zero out ActiveBaby in all existing rewards trackers and track previous values
-	accsWithActiveBaby, err := zeroOutCoStakerRwdsActiveBaby(ctx, rwdTrackers)
-	if err != nil {
-		return err
-	}
-
-	params := coStkKeeper.GetParams(ctx)
-	endedPeriod, err := coStkKeeper.IncrementRewardsPeriod(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Recalculate ActiveBaby for all BABY stakers based on current delegations to active validators
-	if err := updateBABYStakersRwdTracker(ctx, endedPeriod, rwdTrackers, accsWithActiveBaby, epochingKeeper, stkKeeper, coStkKeeper, params); err != nil {
-		return err
-	}
-
-	totalScore, err := getTotalScore(ctx, rwdTrackers)
-	if err != nil {
-		return err
-	}
-
-	currentRwd, err := coStkKeeper.GetCurrentRewards(ctx)
-	if err != nil {
-		return err
-	}
-
-	currentRwd.TotalScore = totalScore
-	if err := currentRwd.Validate(); err != nil {
-		return err
-	}
-
-	return coStkKeeper.SetCurrentRewards(ctx, *currentRwd)
-}
-
-type ActiveBabyTracked struct {
-	PreviousActiveBaby math.Int
-	CurrentActiveBaby  math.Int
-}
-
-// updateBABYStakersRwdTracker retrieves all BABY stakers delegating to active validators and updates their ActiveBaby
-func updateBABYStakersRwdTracker(
-	ctx context.Context,
-	period uint64,
-	rwdTrackers collections.Map[[]byte, costktypes.CostakerRewardsTracker],
-	accsWithActiveBaby map[string]ActiveBabyTracked,
-	epochingKeeper epochingkeeper.Keeper,
-	stkKeeper *stkkeeper.Keeper,
-	coStkKeeper costkkeeper.Keeper,
-	params costktypes.Params,
-) error {
-	// Get all BABY stakers delegating to active validators in the current epoch
-	babyStakers, err := getAllBABYStakers(ctx, epochingKeeper, stkKeeper)
-	if err != nil {
-		return fmt.Errorf("failed to get all BABY stakers: %w", err)
-	}
-
-	// Add current BABY delegations to the tracking map
-	for delegatorAddr, babyAmount := range babyStakers {
-		data, found := accsWithActiveBaby[delegatorAddr]
-		if found {
-			data.CurrentActiveBaby = data.CurrentActiveBaby.Add(babyAmount)
-			accsWithActiveBaby[delegatorAddr] = data
-		} else {
-			accsWithActiveBaby[delegatorAddr] = ActiveBabyTracked{
-				PreviousActiveBaby: math.ZeroInt(),
-				CurrentActiveBaby:  babyAmount,
-			}
+	if err := bk.IterateBTCDelegations(ctx, func(child *btcstktypes.BTCDelegation) error {
+		scanned++
+		if !child.IsStakeExpansion() {
+			return nil
 		}
-	}
-
-	// Update the costaker rewards trackers for all accounts
-	for accAddrStr, babyTracked := range accsWithActiveBaby {
-		if err := updateCostakerActiveBabyRewardsTracker(
-			ctx,
-			coStkKeeper,
-			period,
-			rwdTrackers,
-			sdk.MustAccAddressFromBech32(accAddrStr),
-			params,
-			babyTracked,
-		); err != nil {
-			return err
+		if child.HasInclusionProof() {
+			return nil
 		}
-	}
-
-	return nil
-}
-
-// getAllBABYStakers retrieves all BABY stakers by iterating over the current epoch's active validators
-func getAllBABYStakers(ctx context.Context, epochingKeeper epochingkeeper.Keeper, stkKeeper *stkkeeper.Keeper) (map[string]math.Int, error) {
-	stkQuerier := stkkeeper.NewQuerier(stkKeeper)
-	babyStakers := make(map[string]math.Int)
-
-	// Get the current epoch's validator set from epoching keeper
-	valSet := epochingKeeper.GetCurrentValidatorSet(ctx)
-
-	// Iterate over validators in the current epoch
-	for _, val := range valSet {
-		valAddr := sdk.ValAddress(val.Addr)
-
-		// Get all delegations for this active validator
-		if err := getValidatorDelegations(ctx, stkQuerier, valAddr.String(), babyStakers); err != nil {
-			return nil, fmt.Errorf("failed to get delegations for validator %s: %w", valAddr.String(), err)
-		}
-	}
-
-	return babyStakers, nil
-}
-
-// getValidatorDelegations gets all delegations for a specific validator
-func getValidatorDelegations(ctx context.Context, stkQuerier stkkeeper.Querier, validatorAddr string, babyStakers map[string]math.Int) error {
-	var nextKey []byte
-
-	for {
-		req := &stktypes.QueryValidatorDelegationsRequest{
-			ValidatorAddr: validatorAddr,
-			Pagination: &query.PageRequest{
-				Key: nextKey,
-			},
+		if child.BtcUndelegation == nil || child.BtcUndelegation.DelegatorUnbondingInfo == nil {
+			return nil
 		}
 
-		res, err := stkQuerier.ValidatorDelegations(ctx, req)
+		// At this point the child is the GHSA-4rm2-cj74-f62h pattern:
+		// stake-expansion, no inclusion proof, but DelegatorUnbondingInfo set.
+		poisonedChildren++
+		childHashStr := child.MustGetStakingTxHash().String()
+
+		prevHash, err := child.StakeExpansionTxHash()
 		if err != nil {
-			return err
+			logger.Error("invalid stake-expansion previous tx hash on poisoned child — aborting upgrade",
+				"child_staking_tx_hash", childHashStr,
+				"error", err.Error())
+
+			return fmt.Errorf("invalid stake-expansion previous tx hash on child %s: %w",
+				childHashStr, err)
+		}
+		parentHashStr := prevHash.String()
+
+		parent, err := bk.GetBTCDelegation(ctx, parentHashStr)
+		if err != nil {
+			// Parent not in store — nothing to remediate. Could happen if the
+			// parent was already pruned by a future feature; safe to skip but
+			// unusual enough to warrant a Warn so operators notice.
+			skippedParentMissing++
+			logger.Warn("found poisoned child but parent delegation is not in store, skipping",
+				"child_staking_tx_hash", childHashStr,
+				"parent_staking_tx_hash", parentHashStr,
+				"error", err.Error())
+
+			return nil //nolint:nilerr
+		}
+		if parent.BtcUndelegation != nil && parent.BtcUndelegation.DelegatorUnbondingInfo != nil {
+			// Already unbonded — either remediated previously or unbonded
+			// through a legitimate path that succeeded.
+			skippedParentAlreadyUnbond++
+			logger.Debug("found poisoned child but parent already unbonded, skipping",
+				"child_staking_tx_hash", childHashStr,
+				"parent_staking_tx_hash", parentHashStr)
+
+			return nil
 		}
 
-		for _, delegation := range res.DelegationResponses {
-			delegatorAddr := delegation.Delegation.DelegatorAddress
-			amount := delegation.Balance.Amount
+		// Defense-in-depth: only remediate when the child's previous-stake
+		// covenant quorum was collected. Without `PreviousStkCovenantSigs`
+		// satisfying the parent's CovenantQuorum, the child cannot have
+		// produced a valid witness on TxIn[0] (which spends the parent's
+		// staking output via the parent's unbonding-path script), so the
+		// parent's UTXO was never actually spent on Bitcoin and the child's
+		// SpendStakeTx is not a true unbonding proof. Force-unbonding the
+		// parent in that case would remove voting power from a delegation
+		// whose UTXO is still alive on Bitcoin.
+		//
+		// The quorum is resolved from the PARENT's own ParamsVersion: the
+		// covenant committee that signs the parent's unbonding path is the
+		// committee that was active at parent registration (locked into the
+		// staking script), not whatever the chain-current params say.
+		parentParams := bk.GetParamsByVersion(ctx, parent.ParamsVersion)
+		if parentParams == nil {
+			skippedParentMissing++
+			logger.Warn("found poisoned child but parent ParamsVersion is unknown, skipping",
+				"child_staking_tx_hash", childHashStr,
+				"parent_staking_tx_hash", parentHashStr,
+				"parent_params_version", parent.ParamsVersion)
 
-			if existing, found := babyStakers[delegatorAddr]; found {
-				babyStakers[delegatorAddr] = existing.Add(amount)
-			} else {
-				babyStakers[delegatorAddr] = amount
-			}
+			return nil
+		}
+		if child.StkExp == nil || !child.StkExp.HasCovenantQuorums(parentParams.CovenantQuorum) {
+			skippedNoPrevStkQuorum++
+			logger.Warn("found poisoned child but PreviousStkCovenantSigs do not meet parent quorum, skipping — parent UTXO cannot have been spent",
+				"child_staking_tx_hash", childHashStr,
+				"parent_staking_tx_hash", parentHashStr,
+				"prev_stk_covenant_quorum", parentParams.CovenantQuorum)
+
+			return nil
 		}
 
-		if res.Pagination == nil || len(res.Pagination.NextKey) == 0 {
-			break
+		// Skip parents that are no longer ACTIVE for any reason (e.g.,
+		// their staking timelock expired and status became EXPIRED). The
+		// phantom-voting-power harm we are remediating only applies while
+		// the parent is contributing voting power; force-unbonding an
+		// already-zero-power parent would enqueue a redundant
+		// EventBTCDelegationStateUpdate{UNBONDED} on top of the prior
+		// expiry transition.
+		//
+		// IsBtcDelegationActive is the canonical "is this delegation
+		// ACTIVE?" check: it resolves the delegation's covenant quorum
+		// from its OWN ParamsVersion (not the chain-current params, which
+		// may have been bumped since the delegation was created), and for
+		// chained stake expansions also resolves the prev-stake's quorum
+		// from the prev-stake's own ParamsVersion. It returns a non-nil
+		// error for both real failures (delegation missing, params version
+		// missing) and the not-ACTIVE case; either way we skip the parent.
+		_, parentActive, _ := bk.IsBtcDelegationActive(ctx, parentHashStr)
+		if !parentActive {
+			skippedParentNotActive++
+			logger.Debug("found poisoned child but parent is not ACTIVE, skipping",
+				"child_staking_tx_hash", childHashStr,
+				"parent_staking_tx_hash", parentHashStr)
+
+			return nil
 		}
-		nextKey = res.Pagination.NextKey
-	}
 
-	return nil
-}
+		if _, dup := seenParent[parentHashStr]; dup {
+			// Multiple registered stake expansions for the same ACTIVE parent
+			// are possible on babylon (registration only checks the parent is
+			// ACTIVE), but only one can ever confirm on Bitcoin. The recorded
+			// SpendStakeTx is best-effort — the first child encountered in
+			// iteration order. Voting power deduction works regardless of
+			// which one we pick.
+			skippedDuplicateParent++
+			logger.Warn("multiple poisoned children point to the same parent — only one stake expansion can spend the parent's UTXO on Bitcoin, skipping duplicate",
+				"child_staking_tx_hash", childHashStr,
+				"parent_staking_tx_hash", parentHashStr)
 
-// updateCostakerActiveBabyRewardsTracker creates or updates a costaker rewards tracker with ActiveBaby
-func updateCostakerActiveBabyRewardsTracker(
-	ctx context.Context,
-	coStkKeeper costkkeeper.Keeper,
-	endedPeriod uint64,
-	rwdTrackers collections.Map[[]byte, costktypes.CostakerRewardsTracker],
-	stakerAddr sdk.AccAddress,
-	params costktypes.Params,
-	babyTracked ActiveBabyTracked,
-) error {
-	addrKey := []byte(stakerAddr)
+			return nil
+		}
+		seenParent[parentHashStr] = struct{}{}
 
-	// Try to get existing tracker
-	rt, err := rwdTrackers.Get(ctx, addrKey)
-	if err != nil && !errors.Is(err, collections.ErrNotFound) {
-		return err
-	}
+		logger.Info("queued poisoned parent for remediation",
+			"parent_staking_tx_hash", parentHashStr,
+			"child_staking_tx_hash", childHashStr)
 
-	if errors.Is(err, collections.ErrNotFound) {
-		// This should not happen as we're updating existing trackers only
+		toRemediate = append(toRemediate, pair{
+			parent:     parent,
+			spendTxBz:  child.StakingTx,
+			childHash:  childHashStr,
+			parentHash: parentHashStr,
+		})
+
 		return nil
+	}); err != nil {
+		return nil, err
 	}
 
-	// Update existing tracker (set the ActiveBaby because it was zeroed out before)
-	// Update the StartPeriodCumulativeReward only if the ActiveBaby is changing
-	rt.ActiveBaby = rt.ActiveBaby.Add(babyTracked.CurrentActiveBaby)
-	diff := babyTracked.CurrentActiveBaby.Sub(babyTracked.PreviousActiveBaby)
-	if !diff.IsZero() { // if there is any diff, the period needs to be increased
-		rt.StartPeriodCumulativeReward = endedPeriod
-		if err := coStkKeeper.CalculateCostakerRewardsAndSendToGauge(ctx, stakerAddr, endedPeriod); err != nil {
-			return err
-		}
+	logger.Info("scan complete",
+		"delegations_scanned", scanned,
+		"poisoned_children_found", poisonedChildren,
+		"to_remediate", len(toRemediate),
+		"skipped_parent_missing", skippedParentMissing,
+		"skipped_parent_already_unbonded", skippedParentAlreadyUnbond,
+		"skipped_parent_not_active", skippedParentNotActive,
+		"skipped_duplicate_parent", skippedDuplicateParent,
+		"skipped_no_prev_stk_quorum", skippedNoPrevStkQuorum,
+	)
+
+	if len(toRemediate) == 0 {
+		logger.Info("no poisoned stake-expansion parents to remediate")
+
+		return nil, nil
 	}
 
-	// Update score
-	rt.UpdateScore(params.ScoreRatioBtcByBaby)
-
-	// Save tracker
-	if err := rwdTrackers.Set(ctx, addrKey, rt); err != nil {
-		return err
+	remediated := make([]string, 0, len(toRemediate))
+	for _, p := range toRemediate {
+		bk.BtcUndelegate(ctx, p.parent, &btcstktypes.DelegatorUnbondingInfo{
+			SpendStakeTx: p.spendTxBz,
+		})
+		ctx.EventManager().EmitEvent(sdk.NewEvent(
+			EventTypePhantomStakeExpansionRemediated,
+			sdk.NewAttribute(AttrParentStakingTxHash, p.parentHash),
+			sdk.NewAttribute(AttrChildStakingTxHash, p.childHash),
+		))
+		logger.Info("force-unbonded poisoned parent",
+			"parent_staking_tx_hash", p.parentHash,
+			"child_staking_tx_hash", p.childHash)
+		remediated = append(remediated, p.parentHash)
 	}
 
-	return nil
-}
+	logger.Info("remediation complete", "remediated_parents", len(remediated))
 
-// zeroOutCoStakerRwdsActiveBaby zeros out ActiveBaby in all costaker rewards trackers
-func zeroOutCoStakerRwdsActiveBaby(
-	ctx context.Context,
-	rwdTrackers collections.Map[[]byte, costktypes.CostakerRewardsTracker],
-) (map[string]ActiveBabyTracked, error) {
-	accsWithActiveBaby := make(map[string]ActiveBabyTracked)
-	iter, err := rwdTrackers.Iterate(ctx, nil)
-	if err != nil {
-		return accsWithActiveBaby, err
-	}
-	defer iter.Close()
-
-	for ; iter.Valid(); iter.Next() {
-		costakerAddr, err := iter.Key()
-		if err != nil {
-			return accsWithActiveBaby, err
-		}
-
-		tracker, err := iter.Value()
-		if err != nil {
-			return accsWithActiveBaby, err
-		}
-		if tracker.ActiveBaby.IsZero() {
-			continue
-		}
-
-		sdkAddr := sdk.AccAddress(costakerAddr)
-		accsWithActiveBaby[sdkAddr.String()] = ActiveBabyTracked{
-			PreviousActiveBaby: tracker.ActiveBaby,
-			CurrentActiveBaby:  math.ZeroInt(),
-		}
-
-		// Zero out ActiveBaby
-		tracker.ActiveBaby = math.ZeroInt()
-		if err := rwdTrackers.Set(ctx, costakerAddr, tracker); err != nil {
-			return accsWithActiveBaby, err
-		}
-	}
-
-	return accsWithActiveBaby, nil
-}
-
-func getTotalScore(
-	ctx context.Context,
-	rwdTrackers collections.Map[[]byte, costktypes.CostakerRewardsTracker],
-) (math.Int, error) {
-	totalScore := math.ZeroInt()
-	iter, err := rwdTrackers.Iterate(ctx, nil)
-	if err != nil {
-		return totalScore, err
-	}
-	defer iter.Close()
-
-	for ; iter.Valid(); iter.Next() {
-		tracker, err := iter.Value()
-		if err != nil {
-			return totalScore, err
-		}
-
-		totalScore = totalScore.Add(tracker.TotalScore)
-	}
-
-	return totalScore, nil
+	return remediated, nil
 }

--- a/app/upgrades/v4_3/upgrade.go
+++ b/app/upgrades/v4_3/upgrade.go
@@ -96,7 +96,6 @@ func RemediatePoisonedStakeExpansions(
 		skippedParentAlreadyUnbond int
 		skippedParentNotActive     int
 		skippedDuplicateParent     int
-		skippedNoPrevStkQuorum     int
 	)
 
 	if err := bk.IterateBTCDelegations(ctx, func(child *btcstktypes.BTCDelegation) error {
@@ -147,40 +146,6 @@ func RemediatePoisonedStakeExpansions(
 			logger.Debug("found poisoned child but parent already unbonded, skipping",
 				"child_staking_tx_hash", childHashStr,
 				"parent_staking_tx_hash", parentHashStr)
-
-			return nil
-		}
-
-		// Defense-in-depth: only remediate when the child's previous-stake
-		// covenant quorum was collected. Without `PreviousStkCovenantSigs`
-		// satisfying the parent's CovenantQuorum, the child cannot have
-		// produced a valid witness on TxIn[0] (which spends the parent's
-		// staking output via the parent's unbonding-path script), so the
-		// parent's UTXO was never actually spent on Bitcoin and the child's
-		// SpendStakeTx is not a true unbonding proof. Force-unbonding the
-		// parent in that case would remove voting power from a delegation
-		// whose UTXO is still alive on Bitcoin.
-		//
-		// The quorum is resolved from the PARENT's own ParamsVersion: the
-		// covenant committee that signs the parent's unbonding path is the
-		// committee that was active at parent registration (locked into the
-		// staking script), not whatever the chain-current params say.
-		parentParams := bk.GetParamsByVersion(ctx, parent.ParamsVersion)
-		if parentParams == nil {
-			skippedParentMissing++
-			logger.Warn("found poisoned child but parent ParamsVersion is unknown, skipping",
-				"child_staking_tx_hash", childHashStr,
-				"parent_staking_tx_hash", parentHashStr,
-				"parent_params_version", parent.ParamsVersion)
-
-			return nil
-		}
-		if child.StkExp == nil || !child.StkExp.HasCovenantQuorums(parentParams.CovenantQuorum) {
-			skippedNoPrevStkQuorum++
-			logger.Warn("found poisoned child but PreviousStkCovenantSigs do not meet parent quorum, skipping — parent UTXO cannot have been spent",
-				"child_staking_tx_hash", childHashStr,
-				"parent_staking_tx_hash", parentHashStr,
-				"prev_stk_covenant_quorum", parentParams.CovenantQuorum)
 
 			return nil
 		}
@@ -251,7 +216,6 @@ func RemediatePoisonedStakeExpansions(
 		"skipped_parent_already_unbonded", skippedParentAlreadyUnbond,
 		"skipped_parent_not_active", skippedParentNotActive,
 		"skipped_duplicate_parent", skippedDuplicateParent,
-		"skipped_no_prev_stk_quorum", skippedNoPrevStkQuorum,
 	)
 
 	if len(toRemediate) == 0 {

--- a/app/upgrades/v4_3/upgrade_test.go
+++ b/app/upgrades/v4_3/upgrade_test.go
@@ -1,0 +1,482 @@
+package v4_3_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"cosmossdk.io/math"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	v4_3 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_3"
+	"github.com/babylonlabs-io/babylon/v4/testutil/datagen"
+	testutilkeeper "github.com/babylonlabs-io/babylon/v4/testutil/keeper"
+	bbn "github.com/babylonlabs-io/babylon/v4/types"
+	btcctypes "github.com/babylonlabs-io/babylon/v4/x/btccheckpoint/types"
+	btclctypes "github.com/babylonlabs-io/babylon/v4/x/btclightclient/types"
+	btcstkkeeper "github.com/babylonlabs-io/babylon/v4/x/btcstaking/keeper"
+	btcstktypes "github.com/babylonlabs-io/babylon/v4/x/btcstaking/types"
+)
+
+// setup builds a minimal BTC staking keeper with mocked BTC light client and
+// checkpoint keepers, and seeds the params so AddBTCDelegation works.
+//
+// The mocked BTC light client tip is set so that delegations created via
+// genDelegation evaluate as ACTIVE (StartHeight=10, EndHeight≈210,
+// UnbondingTime=101 ⇒ ACTIVE iff tip < EndHeight - UnbondingTime ≈ 109).
+func setup(t *testing.T) (sdk.Context, btcstkkeeper.Keeper, *gomock.Controller) {
+	return setupWithBtcTip(t, 100)
+}
+
+// setupWithBtcTip is like setup but lets the caller pin the BTC tip height,
+// so individual tests can force genDelegation parents into EXPIRED status by
+// passing a tip past their EndHeight.
+func setupWithBtcTip(t *testing.T, btcTipHeight uint32) (sdk.Context, btcstkkeeper.Keeper, *gomock.Controller) {
+	ctrl := gomock.NewController(t)
+
+	btclc := btcstktypes.NewMockBTCLightClientKeeper(ctrl)
+	btclc.EXPECT().GetTipInfo(gomock.Any()).Return(&btclctypes.BTCHeaderInfo{Height: btcTipHeight}).AnyTimes()
+
+	btcc := btcstktypes.NewMockBtcCheckpointKeeper(ctrl)
+	btcc.EXPECT().GetParams(gomock.Any()).Return(btcctypes.DefaultParams()).AnyTimes()
+
+	k, ctx := testutilkeeper.BTCStakingKeeper(t, btclc, btcc, nil)
+	return ctx, *k, ctrl
+}
+
+// genDelegation produces a fully-formed BTCDelegation with a valid serialized
+// staking tx. Its HasInclusionProof() is true (StartHeight, EndHeight > 0)
+// and BtcUndelegation has no DelegatorUnbondingInfo.
+func genDelegation(t *testing.T, r *rand.Rand) *btcstktypes.BTCDelegation {
+	delSK, _, err := datagen.GenRandomBTCKeyPair(r)
+	require.NoError(t, err)
+
+	fp, err := datagen.GenRandomFinalityProvider(r)
+	require.NoError(t, err)
+
+	startHeight := uint32(10)
+	endHeight := startHeight + btcctypes.DefaultParams().CheckpointFinalizationTimeout + 100
+	stakingTime := endHeight - startHeight
+
+	slashingAddr, err := datagen.GenRandomBTCAddress(r, &chaincfg.RegressionNetParams)
+	require.NoError(t, err)
+	slashingPkScript, err := txscript.PayToAddrScript(slashingAddr)
+	require.NoError(t, err)
+
+	covSKs, covPKs, covQ := datagen.GenCovenantCommittee(r)
+	del, err := datagen.GenRandomBTCDelegation(
+		r, t, &chaincfg.RegressionNetParams,
+		[]bbn.BIP340PubKey{*fp.BtcPk},
+		delSK, covSKs, covPKs, covQ,
+		slashingPkScript,
+		stakingTime, startHeight, endHeight, 50000,
+		math.LegacyNewDecWithPrec(15, 2),
+		uint16(101),
+	)
+	require.NoError(t, err)
+	del.StakerAddr = datagen.GenRandomAccount().GetAddress().String()
+	return del
+}
+
+// markStakeExpansionOf turns child into a stake-expansion delegation of parent
+// and populates PreviousStkCovenantSigs to meet the parent's covenant quorum
+// (default 3-of-5). The handler gates remediation on this quorum being met,
+// because without prev-stake covenant sigs the child cannot have spent the
+// parent on Bitcoin.
+func markStakeExpansionOf(child, parent *btcstktypes.BTCDelegation) {
+	parentHash := parent.MustGetStakingTxHash()
+	child.StkExp = &btcstktypes.StakeExpansion{
+		PreviousStakingTxHash: parentHash[:],
+		// OtherFundingTxOut intentionally left empty — the remediation handler
+		// does not parse it.
+		PreviousStkCovenantSigs: dummyPrevStkCovenantSigs(3),
+	}
+}
+
+// markStakeExpansionOfNoPrevStkQuorum is like markStakeExpansionOf but leaves
+// PreviousStkCovenantSigs empty, modelling a child that never reached
+// prev-stake covenant quorum and therefore cannot have produced a valid
+// spending witness on the parent's UTXO.
+func markStakeExpansionOfNoPrevStkQuorum(child, parent *btcstktypes.BTCDelegation) {
+	parentHash := parent.MustGetStakingTxHash()
+	child.StkExp = &btcstktypes.StakeExpansion{
+		PreviousStakingTxHash: parentHash[:],
+	}
+}
+
+func dummyPrevStkCovenantSigs(n int) []*btcstktypes.SignatureInfo {
+	// The remediation handler only inspects len(PreviousStkCovenantSigs)
+	// against the parent's CovenantQuorum, so the field values just need to
+	// pass proto unmarshal length checks (BIP340 pub key = 32 bytes, sig = 64
+	// bytes). They do not need to be valid signatures.
+	out := make([]*btcstktypes.SignatureInfo, n)
+	for i := 0; i < n; i++ {
+		pk := make(bbn.BIP340PubKey, bbn.BIP340PubKeyLen)
+		sig := make(bbn.BIP340Signature, bbn.BIP340SignatureLen)
+		pk[0] = byte(i + 1)
+		sig[0] = byte(i + 1)
+		out[i] = &btcstktypes.SignatureInfo{Pk: &pk, Sig: &sig}
+	}
+	return out
+}
+
+// poison clears child's inclusion proof and sets DelegatorUnbondingInfo,
+// matching the GHSA-4rm2-cj74-f62h attack pattern: child was unbonded early
+// before its inclusion proof was added.
+func poison(child *btcstktypes.BTCDelegation, spendTx []byte) {
+	child.StartHeight = 0
+	child.EndHeight = 0
+	child.BtcUndelegation.DelegatorUnbondingInfo = &btcstktypes.DelegatorUnbondingInfo{
+		SpendStakeTx: spendTx,
+	}
+}
+
+func TestRemediate_RemediatesPoisonedParent(t *testing.T) {
+	ctx, k, ctrl := setup(t)
+	defer ctrl.Finish()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	parent := genDelegation(t, r)
+	child := genDelegation(t, r)
+	markStakeExpansionOf(child, parent)
+	poison(child, child.StakingTx)
+
+	require.NoError(t, k.AddBTCDelegation(ctx, parent))
+	require.NoError(t, k.AddBTCDelegation(ctx, child))
+
+	// Pre-condition: parent has no DelegatorUnbondingInfo yet.
+	parentHash := parent.MustGetStakingTxHash().String()
+	pre, err := k.GetBTCDelegation(ctx, parentHash)
+	require.NoError(t, err)
+	require.Nil(t, pre.BtcUndelegation.DelegatorUnbondingInfo)
+
+	remediated, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+	require.Equal(t, []string{parentHash}, remediated)
+
+	// Post-condition: parent is unbonded with the child's staking tx as proof.
+	post, err := k.GetBTCDelegation(ctx, parentHash)
+	require.NoError(t, err)
+	require.NotNil(t, post.BtcUndelegation.DelegatorUnbondingInfo)
+	require.Equal(t, child.StakingTx, post.BtcUndelegation.DelegatorUnbondingInfo.SpendStakeTx)
+
+	// Audit event must be emitted exactly once for this pair.
+	requireRemediationEvent(t, ctx, parentHash, child.MustGetStakingTxHash().String())
+}
+
+func TestRemediate_SkipsHealthyDelegations(t *testing.T) {
+	ctx, k, ctrl := setup(t)
+	defer ctrl.Finish()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// Case A: plain delegation, not stake expansion.
+	plain := genDelegation(t, r)
+	require.NoError(t, k.AddBTCDelegation(ctx, plain))
+
+	// Case B: stake-expansion child WITH inclusion proof (legitimately activated).
+	parentB := genDelegation(t, r)
+	childB := genDelegation(t, r)
+	markStakeExpansionOf(childB, parentB)
+	// keep child's StartHeight/EndHeight nonzero — has inclusion proof.
+	require.NoError(t, k.AddBTCDelegation(ctx, parentB))
+	require.NoError(t, k.AddBTCDelegation(ctx, childB))
+
+	// Case C: stake-expansion child without inclusion proof, but NOT
+	// unbonded early (no DelegatorUnbondingInfo). Just a pending verified
+	// expansion — not poisoned.
+	parentC := genDelegation(t, r)
+	childC := genDelegation(t, r)
+	markStakeExpansionOf(childC, parentC)
+	childC.StartHeight = 0
+	childC.EndHeight = 0
+	require.NoError(t, k.AddBTCDelegation(ctx, parentC))
+	require.NoError(t, k.AddBTCDelegation(ctx, childC))
+
+	remediated, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+	require.Empty(t, remediated)
+
+	// All parents must remain non-unbonded.
+	for _, p := range []*btcstktypes.BTCDelegation{parentB, parentC} {
+		got, err := k.GetBTCDelegation(ctx, p.MustGetStakingTxHash().String())
+		require.NoError(t, err)
+		require.Nil(t, got.BtcUndelegation.DelegatorUnbondingInfo)
+	}
+}
+
+func TestRemediate_Idempotent(t *testing.T) {
+	ctx, k, ctrl := setup(t)
+	defer ctrl.Finish()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	parent := genDelegation(t, r)
+	child := genDelegation(t, r)
+	markStakeExpansionOf(child, parent)
+	poison(child, child.StakingTx)
+	require.NoError(t, k.AddBTCDelegation(ctx, parent))
+	require.NoError(t, k.AddBTCDelegation(ctx, child))
+
+	first, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	// Second run sees parent already unbonded and reports nothing.
+	second, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+	require.Empty(t, second)
+}
+
+func TestRemediate_MultipleVictims(t *testing.T) {
+	ctx, k, ctrl := setup(t)
+	defer ctrl.Finish()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	const n = 5
+	parents := make([]*btcstktypes.BTCDelegation, n)
+	for i := 0; i < n; i++ {
+		parent := genDelegation(t, r)
+		child := genDelegation(t, r)
+		markStakeExpansionOf(child, parent)
+		poison(child, child.StakingTx)
+		require.NoError(t, k.AddBTCDelegation(ctx, parent))
+		require.NoError(t, k.AddBTCDelegation(ctx, child))
+		parents[i] = parent
+	}
+
+	remediated, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+	require.Len(t, remediated, n)
+
+	for _, p := range parents {
+		got, err := k.GetBTCDelegation(ctx, p.MustGetStakingTxHash().String())
+		require.NoError(t, err)
+		require.NotNil(t, got.BtcUndelegation.DelegatorUnbondingInfo)
+	}
+}
+
+func TestRemediate_SkipsAlreadyUnbondedParent(t *testing.T) {
+	// Models the case where parent unbonding succeeded through the patched
+	// BTCUndelegate path (commit 78b0ed2f) before the upgrade ran.
+	ctx, k, ctrl := setup(t)
+	defer ctrl.Finish()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	parent := genDelegation(t, r)
+	child := genDelegation(t, r)
+	markStakeExpansionOf(child, parent)
+	poison(child, child.StakingTx)
+
+	// Pre-mark parent as legitimately unbonded with some other spend tx.
+	otherSpend := []byte{0xde, 0xad, 0xbe, 0xef}
+	parent.BtcUndelegation.DelegatorUnbondingInfo = &btcstktypes.DelegatorUnbondingInfo{
+		SpendStakeTx: otherSpend,
+	}
+
+	require.NoError(t, k.AddBTCDelegation(ctx, parent))
+	require.NoError(t, k.AddBTCDelegation(ctx, child))
+
+	remediated, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+	require.Empty(t, remediated)
+
+	got, err := k.GetBTCDelegation(ctx, parent.MustGetStakingTxHash().String())
+	require.NoError(t, err)
+	require.Equal(t, otherSpend, got.BtcUndelegation.DelegatorUnbondingInfo.SpendStakeTx,
+		"existing DelegatorUnbondingInfo must not be overwritten")
+}
+
+// TestRemediate_SkipsExpiredParent guards against double-counting voting power
+// when a poisoned child's parent has already transitioned to a non-ACTIVE
+// status (typically EXPIRED via timelock at parent.EndHeight). For such a
+// parent, the prior expiry transition already drove voting power to zero;
+// force-unbonding now would enqueue a redundant
+// EventBTCDelegationStateUpdate{UNBONDED} on top.
+//
+// We pin the gate by mocking the BTC light-client tip far past the parent's
+// EndHeight; IsBtcDelegationActive then evaluates the parent as EXPIRED. The
+// handler must skip the parent (no remediation, no DelegatorUnbondingInfo
+// write).
+func TestRemediate_SkipsExpiredParent(t *testing.T) {
+	// btcTipHeight far past parent.EndHeight ⇒ status is EXPIRED.
+	// genDelegation builds parents with EndHeight ≈ 210 and UnbondingTime 101,
+	// so any tip at or above 109 expires the parent.
+	const expiredTip uint32 = 100_000
+	ctx, k, ctrl := setupWithBtcTip(t, expiredTip)
+	defer ctrl.Finish()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	parent := genDelegation(t, r)
+	child := genDelegation(t, r)
+	markStakeExpansionOf(child, parent)
+	poison(child, child.StakingTx)
+
+	require.NoError(t, k.AddBTCDelegation(ctx, parent))
+	require.NoError(t, k.AddBTCDelegation(ctx, child))
+
+	remediated, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+	require.Empty(t, remediated, "EXPIRED parent must be skipped — no force-unbond")
+
+	// Parent's BtcUndelegation must still have no DelegatorUnbondingInfo: the
+	// handler did NOT touch it. (Expiry alone does not set this field.)
+	got, err := k.GetBTCDelegation(ctx, parent.MustGetStakingTxHash().String())
+	require.NoError(t, err)
+	require.Nil(t, got.BtcUndelegation.DelegatorUnbondingInfo,
+		"EXPIRED parent must not be force-unbonded by the handler")
+}
+
+func TestRemediate_SkipsChildWithMissingParent(t *testing.T) {
+	// Models the case where a poisoned child references a parent that is no
+	// longer in the store (e.g., pruned by a future feature). Should be a
+	// silent no-op rather than an error.
+	ctx, k, ctrl := setup(t)
+	defer ctrl.Finish()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// Build a fake "parent" purely to seed the child's PreviousStakingTxHash,
+	// but never persist it.
+	ghostParent := genDelegation(t, r)
+	child := genDelegation(t, r)
+	markStakeExpansionOf(child, ghostParent)
+	poison(child, child.StakingTx)
+	require.NoError(t, k.AddBTCDelegation(ctx, child))
+
+	remediated, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+	require.Empty(t, remediated)
+}
+
+// TestRemediate_SkipsChildWithoutPreviousStkCovenantQuorum exercises the
+// defense-in-depth gate: a poisoned-shaped child whose
+// PreviousStkCovenantSigs do NOT meet the parent's covenant quorum cannot
+// have produced a valid spending witness on the parent's UTXO, so the
+// remediation must not force-unbond the parent.
+func TestRemediate_SkipsChildWithoutPreviousStkCovenantQuorum(t *testing.T) {
+	ctx, k, ctrl := setup(t)
+	defer ctrl.Finish()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	parent := genDelegation(t, r)
+	child := genDelegation(t, r)
+	markStakeExpansionOfNoPrevStkQuorum(child, parent)
+	poison(child, child.StakingTx)
+
+	require.NoError(t, k.AddBTCDelegation(ctx, parent))
+	require.NoError(t, k.AddBTCDelegation(ctx, child))
+
+	remediated, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+	require.Empty(t, remediated,
+		"child without PreviousStkCovenantSigs quorum cannot have spent parent — must skip")
+
+	got, err := k.GetBTCDelegation(ctx, parent.MustGetStakingTxHash().String())
+	require.NoError(t, err)
+	require.Nil(t, got.BtcUndelegation.DelegatorUnbondingInfo,
+		"parent must not be force-unbonded when prev-stake covenant quorum is missing")
+}
+
+func TestRemediate_DedupesSameParent(t *testing.T) {
+	// Defense-in-depth: if two poisoned children somehow share a parent,
+	// the parent must be unbonded at most once and only one
+	// EventPowerDistUpdate must be queued.
+	ctx, k, ctrl := setup(t)
+	defer ctrl.Finish()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	parent := genDelegation(t, r)
+	child1 := genDelegation(t, r)
+	child2 := genDelegation(t, r)
+	markStakeExpansionOf(child1, parent)
+	markStakeExpansionOf(child2, parent)
+	poison(child1, child1.StakingTx)
+	poison(child2, child2.StakingTx)
+
+	require.NoError(t, k.AddBTCDelegation(ctx, parent))
+	require.NoError(t, k.AddBTCDelegation(ctx, child1))
+	require.NoError(t, k.AddBTCDelegation(ctx, child2))
+
+	remediated, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+	require.Len(t, remediated, 1, "parent must appear exactly once even with two poisoned children")
+
+	unbondedEvents := unbondedPowerDistEventsFor(ctx, k, parent.MustGetStakingTxHash().String())
+	require.Len(t, unbondedEvents, 1, "exactly one UNBONDED power-dist event must be queued for the parent")
+}
+
+func TestRemediate_QueuesUnbondedPowerDistEvent(t *testing.T) {
+	// Asserts that BtcUndelegate's power-dist event flow fires. Without this
+	// the next BeginBlock would not drop the phantom power.
+	ctx, k, ctrl := setup(t)
+	defer ctrl.Finish()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	parent := genDelegation(t, r)
+	child := genDelegation(t, r)
+	markStakeExpansionOf(child, parent)
+	poison(child, child.StakingTx)
+	require.NoError(t, k.AddBTCDelegation(ctx, parent))
+	require.NoError(t, k.AddBTCDelegation(ctx, child))
+
+	_, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
+	require.NoError(t, err)
+
+	parentHash := parent.MustGetStakingTxHash().String()
+	unbondedEvents := unbondedPowerDistEventsFor(ctx, k, parentHash)
+	require.Len(t, unbondedEvents, 1)
+}
+
+func unbondedPowerDistEventsFor(ctx sdk.Context, k btcstkkeeper.Keeper, stakingTxHash string) []*btcstktypes.EventPowerDistUpdate {
+	// Tip is mocked at height 100; scan a generous range.
+	all := k.GetAllPowerDistUpdateEvents(ctx, 0, 200)
+	var out []*btcstktypes.EventPowerDistUpdate
+	for _, ev := range all {
+		btcEv := ev.GetBtcDelStateUpdate()
+		if btcEv == nil {
+			continue
+		}
+		if btcEv.NewState != btcstktypes.BTCDelegationStatus_UNBONDED {
+			continue
+		}
+		if btcEv.StakingTxHash != stakingTxHash {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+func requireRemediationEvent(t *testing.T, ctx sdk.Context, parentHash, childHash string) {
+	t.Helper()
+	for _, ev := range ctx.EventManager().Events() {
+		if ev.Type != v4_3.EventTypePhantomStakeExpansionRemediated {
+			continue
+		}
+		var gotParent, gotChild string
+		for _, a := range ev.Attributes {
+			switch a.Key {
+			case v4_3.AttrParentStakingTxHash:
+				gotParent = a.Value
+			case v4_3.AttrChildStakingTxHash:
+				gotChild = a.Value
+			}
+		}
+		if gotParent == parentHash && gotChild == childHash {
+			return
+		}
+	}
+	t.Fatalf("expected remediation event for parent=%s child=%s not found", parentHash, childHash)
+}

--- a/app/upgrades/v4_3/upgrade_test.go
+++ b/app/upgrades/v4_3/upgrade_test.go
@@ -82,46 +82,14 @@ func genDelegation(t *testing.T, r *rand.Rand) *btcstktypes.BTCDelegation {
 	return del
 }
 
-// markStakeExpansionOf turns child into a stake-expansion delegation of parent
-// and populates PreviousStkCovenantSigs to meet the parent's covenant quorum
-// (default 3-of-5). The handler gates remediation on this quorum being met,
-// because without prev-stake covenant sigs the child cannot have spent the
-// parent on Bitcoin.
+// markStakeExpansionOf turns child into a stake-expansion delegation of parent.
 func markStakeExpansionOf(child, parent *btcstktypes.BTCDelegation) {
 	parentHash := parent.MustGetStakingTxHash()
 	child.StkExp = &btcstktypes.StakeExpansion{
 		PreviousStakingTxHash: parentHash[:],
 		// OtherFundingTxOut intentionally left empty — the remediation handler
 		// does not parse it.
-		PreviousStkCovenantSigs: dummyPrevStkCovenantSigs(3),
 	}
-}
-
-// markStakeExpansionOfNoPrevStkQuorum is like markStakeExpansionOf but leaves
-// PreviousStkCovenantSigs empty, modelling a child that never reached
-// prev-stake covenant quorum and therefore cannot have produced a valid
-// spending witness on the parent's UTXO.
-func markStakeExpansionOfNoPrevStkQuorum(child, parent *btcstktypes.BTCDelegation) {
-	parentHash := parent.MustGetStakingTxHash()
-	child.StkExp = &btcstktypes.StakeExpansion{
-		PreviousStakingTxHash: parentHash[:],
-	}
-}
-
-func dummyPrevStkCovenantSigs(n int) []*btcstktypes.SignatureInfo {
-	// The remediation handler only inspects len(PreviousStkCovenantSigs)
-	// against the parent's CovenantQuorum, so the field values just need to
-	// pass proto unmarshal length checks (BIP340 pub key = 32 bytes, sig = 64
-	// bytes). They do not need to be valid signatures.
-	out := make([]*btcstktypes.SignatureInfo, n)
-	for i := 0; i < n; i++ {
-		pk := make(bbn.BIP340PubKey, bbn.BIP340PubKeyLen)
-		sig := make(bbn.BIP340Signature, bbn.BIP340SignatureLen)
-		pk[0] = byte(i + 1)
-		sig[0] = byte(i + 1)
-		out[i] = &btcstktypes.SignatureInfo{Pk: &pk, Sig: &sig}
-	}
-	return out
 }
 
 // poison clears child's inclusion proof and sets DelegatorUnbondingInfo,
@@ -355,36 +323,6 @@ func TestRemediate_SkipsChildWithMissingParent(t *testing.T) {
 	remediated, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
 	require.NoError(t, err)
 	require.Empty(t, remediated)
-}
-
-// TestRemediate_SkipsChildWithoutPreviousStkCovenantQuorum exercises the
-// defense-in-depth gate: a poisoned-shaped child whose
-// PreviousStkCovenantSigs do NOT meet the parent's covenant quorum cannot
-// have produced a valid spending witness on the parent's UTXO, so the
-// remediation must not force-unbond the parent.
-func TestRemediate_SkipsChildWithoutPreviousStkCovenantQuorum(t *testing.T) {
-	ctx, k, ctrl := setup(t)
-	defer ctrl.Finish()
-
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	parent := genDelegation(t, r)
-	child := genDelegation(t, r)
-	markStakeExpansionOfNoPrevStkQuorum(child, parent)
-	poison(child, child.StakingTx)
-
-	require.NoError(t, k.AddBTCDelegation(ctx, parent))
-	require.NoError(t, k.AddBTCDelegation(ctx, child))
-
-	remediated, err := v4_3.RemediatePoisonedStakeExpansions(ctx, k)
-	require.NoError(t, err)
-	require.Empty(t, remediated,
-		"child without PreviousStkCovenantSigs quorum cannot have spent parent — must skip")
-
-	got, err := k.GetBTCDelegation(ctx, parent.MustGetStakingTxHash().String())
-	require.NoError(t, err)
-	require.Nil(t, got.BtcUndelegation.DelegatorUnbondingInfo,
-		"parent must not be force-unbonded when prev-stake covenant quorum is missing")
 }
 
 func TestRemediate_DedupesSameParent(t *testing.T) {

--- a/app/upgrades/v4_4/upgrade.go
+++ b/app/upgrades/v4_4/upgrade.go
@@ -1,0 +1,352 @@
+package v4_4
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"cosmossdk.io/collections"
+	corestoretypes "cosmossdk.io/core/store"
+	"cosmossdk.io/math"
+	store "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	stkkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stktypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/babylonlabs-io/babylon/v4/app/keepers"
+	"github.com/babylonlabs-io/babylon/v4/app/upgrades"
+	"github.com/babylonlabs-io/babylon/v4/app/upgrades/epoching"
+	costkkeeper "github.com/babylonlabs-io/babylon/v4/x/costaking/keeper"
+	costktypes "github.com/babylonlabs-io/babylon/v4/x/costaking/types"
+	epochingkeeper "github.com/babylonlabs-io/babylon/v4/x/epoching/keeper"
+)
+
+const UpgradeName = "v4.4"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+	},
+}
+
+func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, keepers *keepers.AppKeepers) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Run migrations before applying any other state changes.
+		migrations, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return nil, err
+		}
+
+		// Validate that we are at the second block of the epoch.
+		// The second block is required because GetCurrentValidatorSet depends
+		// on InitValidatorSet which runs in the epoching BeginBlocker on the
+		// first block of the epoch.
+		if err := epoching.ValidateSecondBlockOfEpoch(ctx, keepers.EpochingKeeper); err != nil {
+			return nil, fmt.Errorf("epoch boundary validation failed: %w", err)
+		}
+
+		costkStoreKey := keepers.GetKey(costktypes.StoreKey)
+		if costkStoreKey == nil {
+			return nil, errors.New("invalid costaking types store key")
+		}
+		coStkStoreService := runtime.NewKVStoreService(costkStoreKey)
+
+		// Reset co-staker rewards tracker for ActiveBaby
+		if err := ResetCoStakerRwdsTrackerActiveBaby(
+			ctx,
+			keepers.EncCfg.Codec,
+			coStkStoreService,
+			keepers.EpochingKeeper,
+			keepers.StakingKeeper,
+			keepers.CostakingKeeper,
+		); err != nil {
+			return nil, err
+		}
+
+		return migrations, nil
+	}
+}
+
+// ResetCoStakerRwdsTrackerActiveBaby resets the ActiveBaby in costaker rewards tracker
+// It recalculates ActiveBaby for all BABY stakers based on current delegations to active validators
+func ResetCoStakerRwdsTrackerActiveBaby(
+	ctx context.Context,
+	cdc codec.BinaryCodec,
+	costkStoreService corestoretypes.KVStoreService,
+	epochingKeeper epochingkeeper.Keeper,
+	stkKeeper *stkkeeper.Keeper,
+	coStkKeeper costkkeeper.Keeper,
+) error {
+	sb := collections.NewSchemaBuilder(costkStoreService)
+	rwdTrackers := collections.NewMap(
+		sb,
+		costktypes.CostakerRewardsTrackerKeyPrefix,
+		"costaker_rewards_tracker",
+		collections.BytesKey,
+		codec.CollValue[costktypes.CostakerRewardsTracker](cdc),
+	)
+
+	// Zero out ActiveBaby in all existing rewards trackers and track previous values
+	accsWithActiveBaby, err := zeroOutCoStakerRwdsActiveBaby(ctx, rwdTrackers)
+	if err != nil {
+		return err
+	}
+
+	params := coStkKeeper.GetParams(ctx)
+	endedPeriod, err := coStkKeeper.IncrementRewardsPeriod(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Recalculate ActiveBaby for all BABY stakers based on current delegations to active validators
+	if err := updateBABYStakersRwdTracker(ctx, endedPeriod, rwdTrackers, accsWithActiveBaby, epochingKeeper, stkKeeper, coStkKeeper, params); err != nil {
+		return err
+	}
+
+	totalScore, err := getTotalScore(ctx, rwdTrackers)
+	if err != nil {
+		return err
+	}
+
+	currentRwd, err := coStkKeeper.GetCurrentRewards(ctx)
+	if err != nil {
+		return err
+	}
+
+	currentRwd.TotalScore = totalScore
+	if err := currentRwd.Validate(); err != nil {
+		return err
+	}
+
+	return coStkKeeper.SetCurrentRewards(ctx, *currentRwd)
+}
+
+type ActiveBabyTracked struct {
+	PreviousActiveBaby math.Int
+	CurrentActiveBaby  math.Int
+}
+
+// updateBABYStakersRwdTracker retrieves all BABY stakers delegating to active validators and updates their ActiveBaby
+func updateBABYStakersRwdTracker(
+	ctx context.Context,
+	period uint64,
+	rwdTrackers collections.Map[[]byte, costktypes.CostakerRewardsTracker],
+	accsWithActiveBaby map[string]ActiveBabyTracked,
+	epochingKeeper epochingkeeper.Keeper,
+	stkKeeper *stkkeeper.Keeper,
+	coStkKeeper costkkeeper.Keeper,
+	params costktypes.Params,
+) error {
+	// Get all BABY stakers delegating to active validators in the current epoch
+	babyStakers, err := getAllBABYStakers(ctx, epochingKeeper, stkKeeper)
+	if err != nil {
+		return fmt.Errorf("failed to get all BABY stakers: %w", err)
+	}
+
+	// Add current BABY delegations to the tracking map
+	for delegatorAddr, babyAmount := range babyStakers {
+		data, found := accsWithActiveBaby[delegatorAddr]
+		if found {
+			data.CurrentActiveBaby = data.CurrentActiveBaby.Add(babyAmount)
+			accsWithActiveBaby[delegatorAddr] = data
+		} else {
+			accsWithActiveBaby[delegatorAddr] = ActiveBabyTracked{
+				PreviousActiveBaby: math.ZeroInt(),
+				CurrentActiveBaby:  babyAmount,
+			}
+		}
+	}
+
+	// Update the costaker rewards trackers for all accounts
+	for accAddrStr, babyTracked := range accsWithActiveBaby {
+		if err := updateCostakerActiveBabyRewardsTracker(
+			ctx,
+			coStkKeeper,
+			period,
+			rwdTrackers,
+			sdk.MustAccAddressFromBech32(accAddrStr),
+			params,
+			babyTracked,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getAllBABYStakers retrieves all BABY stakers by iterating over the current epoch's active validators
+func getAllBABYStakers(ctx context.Context, epochingKeeper epochingkeeper.Keeper, stkKeeper *stkkeeper.Keeper) (map[string]math.Int, error) {
+	stkQuerier := stkkeeper.NewQuerier(stkKeeper)
+	babyStakers := make(map[string]math.Int)
+
+	// Get the current epoch's validator set from epoching keeper
+	valSet := epochingKeeper.GetCurrentValidatorSet(ctx)
+
+	// Iterate over validators in the current epoch
+	for _, val := range valSet {
+		valAddr := sdk.ValAddress(val.Addr)
+
+		// Get all delegations for this active validator
+		if err := getValidatorDelegations(ctx, stkQuerier, valAddr.String(), babyStakers); err != nil {
+			return nil, fmt.Errorf("failed to get delegations for validator %s: %w", valAddr.String(), err)
+		}
+	}
+
+	return babyStakers, nil
+}
+
+// getValidatorDelegations gets all delegations for a specific validator
+func getValidatorDelegations(ctx context.Context, stkQuerier stkkeeper.Querier, validatorAddr string, babyStakers map[string]math.Int) error {
+	var nextKey []byte
+
+	for {
+		req := &stktypes.QueryValidatorDelegationsRequest{
+			ValidatorAddr: validatorAddr,
+			Pagination: &query.PageRequest{
+				Key: nextKey,
+			},
+		}
+
+		res, err := stkQuerier.ValidatorDelegations(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		for _, delegation := range res.DelegationResponses {
+			delegatorAddr := delegation.Delegation.DelegatorAddress
+			amount := delegation.Balance.Amount
+
+			if existing, found := babyStakers[delegatorAddr]; found {
+				babyStakers[delegatorAddr] = existing.Add(amount)
+			} else {
+				babyStakers[delegatorAddr] = amount
+			}
+		}
+
+		if res.Pagination == nil || len(res.Pagination.NextKey) == 0 {
+			break
+		}
+		nextKey = res.Pagination.NextKey
+	}
+
+	return nil
+}
+
+// updateCostakerActiveBabyRewardsTracker creates or updates a costaker rewards tracker with ActiveBaby
+func updateCostakerActiveBabyRewardsTracker(
+	ctx context.Context,
+	coStkKeeper costkkeeper.Keeper,
+	endedPeriod uint64,
+	rwdTrackers collections.Map[[]byte, costktypes.CostakerRewardsTracker],
+	stakerAddr sdk.AccAddress,
+	params costktypes.Params,
+	babyTracked ActiveBabyTracked,
+) error {
+	addrKey := []byte(stakerAddr)
+
+	// Try to get existing tracker
+	rt, err := rwdTrackers.Get(ctx, addrKey)
+	if err != nil && !errors.Is(err, collections.ErrNotFound) {
+		return err
+	}
+
+	if errors.Is(err, collections.ErrNotFound) {
+		// This should not happen as we're updating existing trackers only
+		return nil
+	}
+
+	// Update existing tracker (set the ActiveBaby because it was zeroed out before)
+	// Update the StartPeriodCumulativeReward only if the ActiveBaby is changing
+	rt.ActiveBaby = rt.ActiveBaby.Add(babyTracked.CurrentActiveBaby)
+	diff := babyTracked.CurrentActiveBaby.Sub(babyTracked.PreviousActiveBaby)
+	if !diff.IsZero() { // if there is any diff, the period needs to be increased
+		rt.StartPeriodCumulativeReward = endedPeriod
+		if err := coStkKeeper.CalculateCostakerRewardsAndSendToGauge(ctx, stakerAddr, endedPeriod); err != nil {
+			return err
+		}
+	}
+
+	// Update score
+	rt.UpdateScore(params.ScoreRatioBtcByBaby)
+
+	// Save tracker
+	if err := rwdTrackers.Set(ctx, addrKey, rt); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// zeroOutCoStakerRwdsActiveBaby zeros out ActiveBaby in all costaker rewards trackers
+func zeroOutCoStakerRwdsActiveBaby(
+	ctx context.Context,
+	rwdTrackers collections.Map[[]byte, costktypes.CostakerRewardsTracker],
+) (map[string]ActiveBabyTracked, error) {
+	accsWithActiveBaby := make(map[string]ActiveBabyTracked)
+	iter, err := rwdTrackers.Iterate(ctx, nil)
+	if err != nil {
+		return accsWithActiveBaby, err
+	}
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		costakerAddr, err := iter.Key()
+		if err != nil {
+			return accsWithActiveBaby, err
+		}
+
+		tracker, err := iter.Value()
+		if err != nil {
+			return accsWithActiveBaby, err
+		}
+		if tracker.ActiveBaby.IsZero() {
+			continue
+		}
+
+		sdkAddr := sdk.AccAddress(costakerAddr)
+		accsWithActiveBaby[sdkAddr.String()] = ActiveBabyTracked{
+			PreviousActiveBaby: tracker.ActiveBaby,
+			CurrentActiveBaby:  math.ZeroInt(),
+		}
+
+		// Zero out ActiveBaby
+		tracker.ActiveBaby = math.ZeroInt()
+		if err := rwdTrackers.Set(ctx, costakerAddr, tracker); err != nil {
+			return accsWithActiveBaby, err
+		}
+	}
+
+	return accsWithActiveBaby, nil
+}
+
+func getTotalScore(
+	ctx context.Context,
+	rwdTrackers collections.Map[[]byte, costktypes.CostakerRewardsTracker],
+) (math.Int, error) {
+	totalScore := math.ZeroInt()
+	iter, err := rwdTrackers.Iterate(ctx, nil)
+	if err != nil {
+		return totalScore, err
+	}
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		tracker, err := iter.Value()
+		if err != nil {
+			return totalScore, err
+		}
+
+		totalScore = totalScore.Add(tracker.TotalScore)
+	}
+
+	return totalScore, nil
+}

--- a/app/upgrades/v4_4/upgrades_costaking_test.go
+++ b/app/upgrades/v4_4/upgrades_costaking_test.go
@@ -1,4 +1,4 @@
-package v4_3_test
+package v4_4_test
 
 import (
 	"math/rand"
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	appparams "github.com/babylonlabs-io/babylon/v4/app/params"
-	v4_3 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_3"
+	v4_4 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_4"
 	"github.com/babylonlabs-io/babylon/v4/testutil/datagen"
 	testutilkeeper "github.com/babylonlabs-io/babylon/v4/testutil/keeper"
 	tkeeper "github.com/babylonlabs-io/babylon/v4/testutil/keeper"
@@ -118,7 +118,7 @@ func TestResetCoStakerRwdsTracker_WithPreexistingTrackers(t *testing.T) {
 	require.NoError(t, err)
 
 	epochK.InitValidatorSet(ctx)
-	err = v4_3.ResetCoStakerRwdsTrackerActiveBaby(ctx, cdc, storeService, epochK, stkK, costkK)
+	err = v4_4.ResetCoStakerRwdsTrackerActiveBaby(ctx, cdc, storeService, epochK, stkK, costkK)
 	require.NoError(t, err)
 
 	costkRwd, err := costkK.GetCostakerRewards(ctx, stakerAddr)

--- a/test/e2ev2/upgrades_v4_4_test.go
+++ b/test/e2ev2/upgrades_v4_4_test.go
@@ -13,7 +13,7 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 
 	appparams "github.com/babylonlabs-io/babylon/v4/app/params"
-	v43 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_3"
+	v44 "github.com/babylonlabs-io/babylon/v4/app/upgrades/v4_4"
 	"github.com/babylonlabs-io/babylon/v4/test/e2ev2/tmanager"
 	bstypes "github.com/babylonlabs-io/babylon/v4/x/btcstaking/types"
 	costktypes "github.com/babylonlabs-io/babylon/v4/x/costaking/types"
@@ -21,8 +21,8 @@ import (
 
 var ZeroInt = sdkmath.ZeroInt()
 
-// TestUpgradeV43 reproduces two costaking reward tracker bugs from
-// v4.2.x and verifies the v4.3 upgrade corrects them.
+// TestUpgradeV44 reproduces two costaking reward tracker bugs from
+// v4.2.x and verifies the v4.4 upgrade corrects them.
 //
 // Scenario 1 (unbond/re-delegate from slashed validator):
 //  1. del1 creates two BABY delegations: healthy chain validator and val1
@@ -41,8 +41,8 @@ var ZeroInt = sdkmath.ZeroInt()
 //
 // Result: del3's ActiveBaby lower than expected
 //
-// The v4.3 upgrade recalculates all ActiveBaby and scores.
-func TestUpgradeV43(t *testing.T) {
+// The v4.4 upgrade recalculates all ActiveBaby and scores.
+func TestUpgradeV44(t *testing.T) {
 	t.Parallel()
 
 	// =====================================================================
@@ -369,9 +369,9 @@ func createGovPropAndPreUpgradeFunc(t *testing.T, valWallet *tmanager.WalletSend
 	upgradeMsg := &upgradetypes.MsgSoftwareUpgrade{
 		Authority: "bbn10d07y265gmmuvt4z0w9aw880jnsr700jduz5f2",
 		Plan: upgradetypes.Plan{
-			Name:   v43.UpgradeName,
+			Name:   v44.UpgradeName,
 			Height: upgradeHeight,
-			Info:   "Upgrade to v4.3",
+			Info:   "Upgrade to v4.4",
 		},
 	}
 
@@ -383,7 +383,7 @@ func createGovPropAndPreUpgradeFunc(t *testing.T, valWallet *tmanager.WalletSend
 		InitialDeposit: []sdk.Coin{sdk.NewCoin(appparams.DefaultBondDenom, sdkmath.NewInt(1000000))},
 		Proposer:       valWallet.Address.String(),
 		Metadata:       "",
-		Title:          v43.UpgradeName,
+		Title:          v44.UpgradeName,
 		Summary:        "upgrade",
 		Expedited:      false,
 	}

--- a/test/replay/wrong_epoch_ve_test.go
+++ b/test/replay/wrong_epoch_ve_test.go
@@ -1,0 +1,379 @@
+package replay
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	babylonApp "github.com/babylonlabs-io/babylon/v4/app"
+	appsigner "github.com/babylonlabs-io/babylon/v4/app/signer"
+	"github.com/babylonlabs-io/babylon/v4/test/e2e/initialization"
+	bbn "github.com/babylonlabs-io/babylon/v4/types"
+	btclighttypes "github.com/babylonlabs-io/babylon/v4/x/btclightclient/types"
+	ckpttypes "github.com/babylonlabs-io/babylon/v4/x/checkpointing/types"
+	"github.com/boljen/go-bitmap"
+	dbmc "github.com/cometbft/cometbft-db"
+	cs "github.com/cometbft/cometbft/consensus"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	cometlog "github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/mempool"
+	"github.com/cometbft/cometbft/privval"
+	"github.com/cometbft/cometbft/proxy"
+	sm "github.com/cometbft/cometbft/state"
+	"github.com/cometbft/cometbft/store"
+	cmttypes "github.com/cometbft/cometbft/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+// validatorInfo holds all signing material for one validator
+type validatorInfo struct {
+	CometAddress []byte
+	CometPrivKey ed25519.PrivKey
+	BlsSigner    ckpttypes.BlsSigner
+	ValAddress   sdk.ValAddress
+}
+
+// multiValDriver extends BabylonAppDriver for multi-validator scenarios.
+// maliciousIdx is the index into validators of the validator that sorts
+// first in CometBFT's canonical commit-info order (lowest CometBFT address
+// among equal-power validators). Picking that validator as the attacker
+// guarantees its wrong-epoch sig lands inside the seal loop's >2/3 prefix.
+type multiValDriver struct {
+	*BabylonAppDriver
+	validators   []validatorInfo
+	maliciousIdx int
+}
+
+func newMultiValDriver(r *rand.Rand, t *testing.T) *multiValDriver {
+	dir := t.TempDir()
+	expeditedVotingPeriod := blkTime + time.Second
+
+	// Four validators with equal power. Seal threshold (PowerSum*3 > total*2)
+	// requires 3 of 4 sigs, so 3 honest validators alone can clear quorum
+	// without the malicious one. The malicious validator can therefore delay
+	// its precommit and have its VE arrive post-quorum in production
+	// which is the scenario this test models.
+	valConfigs := []*initialization.NodeConfig{
+		{Name: "val0", Pruning: "default", IsValidator: true},
+		{Name: "val1", Pruning: "default", IsValidator: true},
+		{Name: "val2", Pruning: "default", IsValidator: true},
+		{Name: "val3", Pruning: "default", IsValidator: true},
+	}
+
+	chain, err := initialization.InitChain(
+		chainID, dir, valConfigs,
+		expeditedVotingPeriod*2, expeditedVotingPeriod, 1,
+		[]*btclighttypes.BTCHeaderInfo{},
+		300_000_000,
+		&initialization.StartingBtcStakingParams{
+			CovenantCommittee: bbn.NewBIP340PKsFromBTCPKs(pks),
+			CovenantQuorum:    CovenantQuorum,
+		},
+	)
+	require.NoError(t, err)
+
+	// Load BLS signers and CometBFT keys for all validators
+	var vals []validatorInfo
+	for _, node := range chain.Nodes {
+		if !node.IsValidator {
+			continue
+		}
+		blsSigner, err := appsigner.InitBlsSigner(node.ConfigDir)
+		require.NoError(t, err)
+
+		filePV := privval.LoadFilePV(
+			node.ConfigDir+"/config/priv_validator_key.json",
+			node.ConfigDir+"/data/priv_validator_state.json",
+		)
+
+		accAddr := sdk.MustAccAddressFromBech32(node.PublicAddress)
+		vals = append(vals, validatorInfo{
+			CometAddress: filePV.Key.Address,
+			CometPrivKey: ed25519.PrivKey(node.CometPrivKey),
+			BlsSigner:    *blsSigner,
+			ValAddress:   sdk.ValAddress(accAddr),
+		})
+	}
+
+	// Boot the app using validator 0's config (same as normal driver)
+	_, doc := getGenDoc(t, chain.Nodes[0].ConfigDir)
+	genDoc, err := doc.ToGenesisDoc()
+	require.NoError(t, err)
+
+	state, err := sm.MakeGenesisState(genDoc)
+	require.NoError(t, err)
+
+	stateStore := sm.NewStore(dbmc.NewMemDB(), sm.StoreOptions{DiscardABCIResponses: false})
+	require.NoError(t, stateStore.Save(state))
+
+	blsSigner0, _ := appsigner.InitBlsSigner(chain.Nodes[0].ConfigDir)
+	appOptions := NewAppOptionsWithFlagHome(chain.Nodes[0].ConfigDir)
+	baseAppOptions := server.DefaultBaseappOptions(appOptions)
+
+	tmpApp := babylonApp.NewBabylonApp(
+		log.NewNopLogger(), dbm.NewMemDB(), nil, true,
+		map[int64]bool{}, 0, blsSigner0, appOptions,
+		babylonApp.EmptyWasmOpts, baseAppOptions...,
+	)
+
+	cmtApp := server.NewCometABCIWrapper(tmpApp)
+	proxyConn := proxy.NewMultiAppConn(proxy.NewLocalClientCreator(cmtApp), proxy.NopMetrics())
+	require.NoError(t, proxyConn.Start())
+
+	blockStore := store.NewBlockStore(dbmc.NewMemDB())
+	blockExec := sm.NewBlockExecutor(
+		stateStore, cometlog.TestingLogger(), proxyConn.Consensus(),
+		&mempool.NopMempool{}, sm.EmptyEvidencePool{}, blockStore,
+	)
+
+	hs := cs.NewHandshaker(stateStore, state, blockStore, genDoc)
+	hs.SetLogger(cometlog.TestingLogger())
+	require.NoError(t, hs.Handshake(proxyConn))
+
+	state, err = stateStore.Load()
+	require.NoError(t, err)
+
+	valPrivKey := secp256k1.PrivKey{Key: chain.Nodes[0].PrivateKey}
+
+	driver := &BabylonAppDriver{
+		r: r, t: t, App: tmpApp, BlsSigner: *blsSigner0,
+		SenderInfo: &SenderInfo{privKey: &valPrivKey, sequenceNumber: 1, accountNumber: 0},
+		BlockExec:  blockExec, BlockStore: blockStore, StateStore: stateStore,
+		NodeDir: chain.Nodes[0].ConfigDir, CometAddress: vals[0].CometAddress,
+		ValAddress: vals[0].ValAddress, CometPrivKey: vals[0].CometPrivKey,
+		CurrentTime: time.Now(),
+	}
+
+	// Pick the validator with the lowest CometBFT address. With uniform
+	// voting power, CometBFT's canonical commit-info order reduces to
+	// address ascending, so this validator is processed first by the seal
+	// loop and its sig is folded into the aggregate before the loop breaks.
+	maliciousIdx := 0
+	for i := 1; i < len(vals); i++ {
+		if bytes.Compare(vals[i].CometAddress, vals[maliciousIdx].CometAddress) < 0 {
+			maliciousIdx = i
+		}
+	}
+
+	return &multiValDriver{BabylonAppDriver: driver, validators: vals, maliciousIdx: maliciousIdx}
+}
+
+// generateBlockWithAllValidators builds a block where every validator submits
+// a vote extension. If maliciousIdx >= 0, that validator signs a VE for
+// wrongEpoch instead of the real one. epochBoundaryHeight is the last block of
+// the current epoch (0 means no BLS VEs are needed at this height).
+func (md *multiValDriver) generateBlockWithAllValidators(t *testing.T, maliciousIdx int, wrongEpoch uint64, epochBoundaryHeight int64) {
+	correctEpochNum := uint64(1) // epoch 1 for this test
+	d := md.BabylonAppDriver
+	lastState, err := d.StateStore.Load()
+	require.NoError(t, err)
+
+	var lastCommit *cmttypes.ExtendedCommit
+	if lastState.LastBlockHeight == 0 {
+		lastCommit = &cmttypes.ExtendedCommit{}
+	} else {
+		lastCommit = d.BlockStore.LoadBlockExtendedCommit(lastState.LastBlockHeight)
+		require.NotNil(t, lastCommit)
+	}
+
+	block, err := d.BlockExec.CreateProposalBlock(
+		context.Background(), lastState.LastBlockHeight+1,
+		lastState, lastCommit, md.validators[0].CometAddress,
+	)
+	require.NoError(t, err)
+
+	blockID, partSet := getBlockId(t, block)
+
+	newTime := d.CurrentTime.Add(blkTime)
+	validators := lastState.Validators
+	extendedSignatures := make([]cmttypes.ExtendedCommitSig, len(validators.Validators))
+
+	isEpochBoundary := epochBoundaryHeight > 0 && block.Height == epochBoundaryHeight
+
+	for i, val := range validators.Validators {
+		// Match the CometBFT address back to our validatorInfo entry.
+		var vi *validatorInfo
+		var viIdx int
+		for j := range md.validators {
+			if bytes.Equal(md.validators[j].CometAddress, val.Address.Bytes()) {
+				vi = &md.validators[j]
+				viIdx = j
+				break
+			}
+		}
+
+		if vi == nil {
+			extendedSignatures[i] = cmttypes.ExtendedCommitSig{
+				CommitSig: cmttypes.CommitSig{BlockIDFlag: cmttypes.BlockIDFlagAbsent},
+			}
+			continue
+		}
+
+		var extension []byte
+
+		if isEpochBoundary {
+			// At an epoch boundary every validator needs a VE signed with its
+			// own BLS key. The app's ExtendVote only signs with validator 0's
+			// key, so the test does this manually for the others.
+			var bhash ckpttypes.BlockHash
+			err := bhash.Unmarshal(block.Hash())
+			require.NoError(t, err)
+
+			epochNum := correctEpochNum
+			isMalicious := viIdx == maliciousIdx
+
+			if isMalicious {
+				epochNum = wrongEpoch
+				t.Logf("validator %d signs VE for wrong epoch %d at height %d (real epoch is %d)",
+					viIdx, wrongEpoch, block.Height, correctEpochNum)
+			}
+
+			// Sign with this validator's real BLS key.
+			signBytes := ckpttypes.GetSignBytes(epochNum, bhash)
+			blsSig, err := vi.BlsSigner.SignMsgWithBls(signBytes)
+			require.NoError(t, err)
+
+			ve := &ckpttypes.VoteExtension{
+				Signer:           vi.ValAddress.String(),
+				ValidatorAddress: sdk.ValAddress(val.Address).String(),
+				BlockHash:        &bhash,
+				EpochNum:         epochNum,
+				Height:           uint64(block.Height),
+				BlsSig:           &blsSig,
+			}
+
+			extension, err = ve.Marshal()
+			require.NoError(t, err)
+		} else {
+			// Off the epoch boundary, the real ExtendVote returns an empty VE.
+			extension = []byte{}
+		}
+
+		// Sign the CometBFT extension envelope with this validator's key.
+		extensionSig := signVoteExtension(t, extension, uint64(block.Height), vi.CometPrivKey)
+
+		extendedSignatures[i] = cmttypes.ExtendedCommitSig{
+			CommitSig: cmttypes.CommitSig{
+				BlockIDFlag:      cmttypes.BlockIDFlagCommit,
+				ValidatorAddress: val.Address,
+				Timestamp:        newTime,
+				Signature:        []byte("test"),
+			},
+			Extension:          extension,
+			ExtensionSignature: extensionSig,
+		}
+	}
+	d.CurrentTime = newTime
+
+	commit := &cmttypes.ExtendedCommit{
+		Height: block.Height, Round: 0, BlockID: blockID,
+		ExtendedSignatures: extendedSignatures,
+	}
+
+	accepted, err := d.BlockExec.ProcessProposal(block, lastState)
+	require.NoError(t, err)
+	require.True(t, accepted, "ProcessProposal should accept")
+
+	state, err := d.BlockExec.ApplyVerifiedBlock(lastState, blockID, block)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	d.BlockStore.SaveBlockWithExtendedCommit(block, partSet, commit)
+}
+
+// TestWrongEpochVoteExtensionRejectedAfterFix is the regression test for the
+// wrong-epoch vote-extension attack. Four equal-power validators run; three
+// honest validators alone clear the >2/3 quorum, so the fourth (malicious)
+// validator's vote extension can arrive post-quorum and bypass the
+// CometBFT-side VerifyVoteExtension via the late-precommit path
+// (cometbft#2361). The malicious validator's address is chosen as the
+// lowest of the four so it sorts first in canonical commit-info order and
+// would be processed before the seal loop's >2/3 break — i.e. it gets the
+// best chance of being folded into the BLS aggregate.
+//
+// Pre-fix, the proposer-side VerifyVoteExtension in
+// x/checkpointing/prepare/proposal.go did not re-check ve.EpochNum against the
+// epoch the proposer was building a checkpoint for, so the malicious VE was
+// accepted, its sig was aggregated, and VerifyRawCheckpoint over the sealed
+// aggregate failed against canonical sign-bytes.
+//
+// Post-fix, the proposer-side check rejects the wrong-epoch VE before
+// aggregation, so:
+//   - the checkpoint still seals (the three honest validators clear quorum),
+//   - the sealed aggregate verifies against canonical sign-bytes,
+//   - the malicious validator's bit in the bitmap stays unset.
+//
+// Nothing in the checkpointing or BLS code paths is mocked. The Babylon app,
+// CheckpointingKeeper, BLS signers, and CometBFT BlockExecutor are all real.
+// The harness uses NopMempool and EmptyEvidencePool, which are unrelated to
+// the code under test.
+func TestWrongEpochVoteExtensionRejectedAfterFix(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	md := newMultiValDriver(r, t)
+
+	require.Equal(t, 4, len(md.validators))
+	t.Logf("initialized chain with %d validators; malicious index = %d", len(md.validators), md.maliciousIdx)
+
+	md.generateBlockWithAllValidators(t, -1, 0, 0)
+
+	epoch := md.GetEpoch()
+	require.Equal(t, uint64(1), epoch.EpochNumber)
+	lastBlockOfEpoch1 := epoch.FirstBlockHeight + epoch.CurrentEpochInterval - 1
+	t.Logf("epoch 1: firstBlock=%d, interval=%d, lastBlock=%d",
+		epoch.FirstBlockHeight, epoch.CurrentEpochInterval, lastBlockOfEpoch1)
+
+	for md.GetLastFinalizedBlock().Height < lastBlockOfEpoch1-1 {
+		md.generateBlockWithAllValidators(t, -1, 0, 0)
+	}
+	t.Log("step 1: advanced to one block before the epoch boundary")
+
+	// At the last block of epoch 1, the malicious validator submits a
+	// wrong-epoch VE. In production it would arrive post-quorum (the three
+	// honest validators have already crossed >2/3), so CometBFT includes it
+	// in the commit info without calling VerifyVoteExtension.
+	wrongEpoch := uint64(999999)
+	md.generateBlockWithAllValidators(t, md.maliciousIdx, wrongEpoch, int64(lastBlockOfEpoch1))
+	t.Log("step 2: built last block of epoch 1; malicious validator contributed a wrong-epoch VE")
+
+	// First block of epoch 2: PrepareProposal reads the commit info, builds
+	// the checkpoint, and injects it. ProcessProposal accepts, PreBlocker
+	// seals.
+	md.generateBlockWithAllValidators(t, -1, 0, 0)
+
+	epoch = md.GetEpoch()
+	require.Equal(t, uint64(2), epoch.EpochNumber)
+	t.Log("step 3: first block of epoch 2 produced; checkpoint for epoch 1 is sealed")
+
+	ckpt := md.GetCheckpoint(t, 1)
+	require.Equal(t, ckpttypes.Sealed, ckpt.Status)
+	require.Equal(t, uint64(1), ckpt.Ckpt.EpochNum)
+	t.Log("step 4: checkpoint for epoch 1 has status Sealed")
+
+	// Post-fix: VerifyRawCheckpoint passes because the malicious VE was
+	// rejected by the proposer-side epoch check before aggregation.
+	require.NoError(t,
+		md.App.CheckpointingKeeper.VerifyRawCheckpoint(md.Ctx(), ckpt.Ckpt),
+		"VerifyRawCheckpoint should pass: the malicious VE must have been excluded")
+	t.Log("step 5: VerifyRawCheckpoint passes against canonical sign-bytes")
+
+	// The malicious validator's bit in the bitmap must be unset. The bitmap
+	// is indexed by the validator's position in the epoch's BLS validator
+	// set (epoching.ValidatorSet, sorted by ValAddress ascending), which is
+	// not necessarily the same as md.maliciousIdx (which indexed into
+	// md.validators).
+	valSet := md.App.EpochingKeeper.GetValidatorSet(md.Ctx(), 1)
+	maliciousValAddr := md.validators[md.maliciousIdx].ValAddress
+	_, bitmapIdx, err := valSet.FindValidatorWithIndex(maliciousValAddr)
+	require.NoError(t, err)
+	require.False(t, bitmap.Get(ckpt.Ckpt.Bitmap, bitmapIdx),
+		"malicious validator's bitmap bit must be 0: its wrong-epoch VE should not have been aggregated")
+	t.Logf("step 6: malicious validator (bitmap index %d) excluded from the aggregate", bitmapIdx)
+}

--- a/x/btcstaking/keeper/btc_delegations.go
+++ b/x/btcstaking/keeper/btc_delegations.go
@@ -259,6 +259,45 @@ func (k Keeper) addCovenantSigsToBTCDelegation(
 	}
 }
 
+// BtcUndelegate is the exported wrapper around btcUndelegate.
+//
+// IMPORTANT: this bypasses all MsgBTCUndelegate validation (staker signature,
+// inclusion proof, spending-tx checks). It is intended ONLY for upgrade
+// handlers that need to remediate state by force-unbonding a delegation
+// outside the normal flow — currently the GHSA-4rm2-cj74-f62h remediation in
+// app/upgrades/v4_3. Do NOT call this from msg handlers, gRPC, or any other
+// user-reachable code path.
+//
+// TODO: remove this exported wrapper once the v4.3 upgrade has run on every
+// network and `app/upgrades/v4_3` is no longer in the active upgrade list.
+func (k Keeper) BtcUndelegate(
+	ctx sdk.Context,
+	btcDel *types.BTCDelegation,
+	u *types.DelegatorUnbondingInfo,
+) {
+	k.btcUndelegate(ctx, btcDel, u)
+}
+
+// IterateBTCDelegations iterates over every BTCDelegation in the store and
+// invokes fn for each. Iteration stops if fn returns an error.
+//
+// TODO: remove this exported iterator once the v4.3 upgrade has run on every
+// network — its only consumer is the GHSA-4rm2-cj74-f62h remediation in
+// app/upgrades/v4_3.
+func (k Keeper) IterateBTCDelegations(ctx context.Context, fn func(btcDel *types.BTCDelegation) error) error {
+	store := k.btcDelegationStore(ctx)
+	iter := store.Iterator(nil, nil)
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		var btcDel types.BTCDelegation
+		k.cdc.MustUnmarshal(iter.Value(), &btcDel)
+		if err := fn(&btcDel); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // btcUndelegate adds the signature of the unbonding tx signed by the staker
 // to the given BTC delegation
 func (k Keeper) btcUndelegate(

--- a/x/btcstaking/keeper/msg_server.go
+++ b/x/btcstaking/keeper/msg_server.go
@@ -575,10 +575,12 @@ func (ms msgServer) BTCUndelegate(goCtx context.Context, req *types.MsgBTCUndele
 	spendStakeTxHash := stakeSpendingTx.TxHash()
 
 	stakeExpansionDel := ms.getBTCDelegation(ctx, spendStakeTxHash)
-	isStakeExpansion := stakeExpansionDel != nil && stakeExpansionDel.IsStakeExpansion()
+	shouldActivateStkExp := stakeExpansionDel != nil &&
+		stakeExpansionDel.IsStakeExpansion() &&
+		!stakeExpansionDel.IsUnbondedEarly() // the stk exp can unbond early prior to having the inclusion proof
 
 	// 2. Verify stake spending tx inclusion proof
-	if isStakeExpansion {
+	if shouldActivateStkExp {
 		// Add inclusion proof for stake expansion delegation if stake expansion tx is 'k' deep
 		// If successful, this will set stake expansion delegation as active
 		if err := ms.Keeper.AddBTCDelegationInclusionProof(ctx, stakeExpansionDel, req.StakeSpendingTxInclusionProof); err != nil {
@@ -644,7 +646,7 @@ func (ms msgServer) BTCUndelegate(goCtx context.Context, req *types.MsgBTCUndele
 			SpendStakeTx: []byte{},
 		}
 		types.EmitEarlyUnbondedEvent(ctx, btcDel.MustGetStakingTxHash().String(), stakerSpendigTxHeader.Height)
-	case isStakeExpansion:
+	case shouldActivateStkExp:
 		// emit an early unbonded event for the delegation (the one that is being expanded)
 		types.EmitEarlyUnbondedEventByStakeExpansion(
 			ctx,

--- a/x/checkpointing/keeper/keeper.go
+++ b/x/checkpointing/keeper/keeper.go
@@ -66,6 +66,18 @@ func (k Keeper) SealCheckpoint(ctx context.Context, ckptWithMeta *types.RawCheck
 		return fmt.Errorf("the checkpoint is not Sealed")
 	}
 
+	// Defense-in-depth: re-verify the aggregated BLS multi-sig against
+	// canonical sign-bytes (epoch + block hash) before persisting the sealed
+	// checkpoint. Catches polluted aggregates that slipped past upstream VE
+	// validation — for example, a wrong-epoch VE that bypassed the
+	// CometBFT-side VerifyVoteExtension via the late-precommit path
+	// (cometbft#2361) and the proposer-side check — as well as any future
+	// regression of those checks. Cost: one BLS pairing per epoch.
+	if err := k.VerifyRawCheckpoint(ctx, ckptWithMeta.Ckpt); err != nil {
+		return fmt.Errorf("refusing to seal invalid checkpoint for epoch %d: %w",
+			ckptWithMeta.Ckpt.EpochNum, err)
+	}
+
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	// if reaching this line, it means ckptWithMeta is updated,

--- a/x/checkpointing/keeper/keeper_test.go
+++ b/x/checkpointing/keeper/keeper_test.go
@@ -291,6 +291,84 @@ func FuzzKeeperCheckpointEpoch(f *testing.F) {
 	})
 }
 
+// TestSealCheckpoint_RefusesInvalidAggregate covers the seal-time canonical
+// multi-sig check. SealCheckpoint must accept a checkpoint whose aggregated
+// BLS multi-sig verifies against GetSignBytes(epoch, blockHash) and reject
+// one whose aggregate was polluted by a contribution signed over different
+// bytes (e.g., a wrong-epoch VE that slipped past upstream validation).
+// This is defense-in-depth on top of the proposer-side epoch check in
+// x/checkpointing/prepare.
+func TestSealCheckpoint_RefusesInvalidAggregate(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ek := mocks.NewMockEpochingKeeper(ctrl)
+	ek.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any()).Return(valSet).AnyTimes()
+	ek.EXPECT().GetTotalVotingPower(gomock.Any(), gomock.Any()).Return(int64(20)).AnyTimes()
+	ckptKeeper, ctx, _ := testkeeper.CheckpointingKeeper(t, ek, nil)
+	for i, val := range valSet {
+		err := ckptKeeper.CreateRegistration(ctx, pubkeys[i], val.Addr)
+		require.NoError(t, err)
+	}
+
+	blockHash := types.BlockHash(datagen.GenRandomByteArray(r, types.HashSize))
+	bm := bitmap.New(types.BitmapBits)
+	bm.Set(0, true)
+	bm.Set(1, true)
+
+	aggPK, err := bls12381.AggrPK(blsPubKey1, blsPubKey2)
+	require.NoError(t, err)
+
+	// Positive case: both validators sign over canonical bytes for epoch 1.
+	canonicalBytes := types.GetSignBytes(uint64(1), blockHash)
+	cleanSig1 := bls12381.Sign(blsPrivKey1, canonicalBytes)
+	cleanSig2 := bls12381.Sign(blsPrivKey2, canonicalBytes)
+	cleanAgg, err := bls12381.AggrSig(cleanSig1, cleanSig2)
+	require.NoError(t, err)
+
+	cleanCkpt := &types.RawCheckpointWithMeta{
+		Ckpt: &types.RawCheckpoint{
+			EpochNum:    1,
+			BlockHash:   &blockHash,
+			Bitmap:      bm,
+			BlsMultiSig: &cleanAgg,
+		},
+		Status:    types.Sealed,
+		BlsAggrPk: &aggPK,
+		PowerSum:  20,
+	}
+	require.NoError(t, ckptKeeper.SealCheckpoint(ctx, cleanCkpt))
+
+	// Negative case: validator 2 signs over GetSignBytes(wrongEpoch, blockHash)
+	// instead of GetSignBytes(2, blockHash). The aggregate is polluted —
+	// VerifyRawCheckpoint inside SealCheckpoint must reject it.
+	cleanSig1Epoch2 := bls12381.Sign(blsPrivKey1, types.GetSignBytes(uint64(2), blockHash))
+	pollutedSig2 := bls12381.Sign(blsPrivKey2, types.GetSignBytes(uint64(999), blockHash))
+	pollutedAgg, err := bls12381.AggrSig(cleanSig1Epoch2, pollutedSig2)
+	require.NoError(t, err)
+
+	pollutedCkpt := &types.RawCheckpointWithMeta{
+		Ckpt: &types.RawCheckpoint{
+			EpochNum:    2,
+			BlockHash:   &blockHash,
+			Bitmap:      bm,
+			BlsMultiSig: &pollutedAgg,
+		},
+		Status:    types.Sealed,
+		BlsAggrPk: &aggPK,
+		PowerSum:  20,
+	}
+	err = ckptKeeper.SealCheckpoint(ctx, pollutedCkpt)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refusing to seal invalid checkpoint")
+	require.ErrorIs(t, err, types.ErrInvalidRawCheckpoint)
+
+	// The polluted checkpoint must not have been persisted.
+	_, err = ckptKeeper.GetRawCheckpoint(ctx, 2)
+	require.Error(t, err)
+}
+
 func TestSetGetConflictingCheckpointReceived(t *testing.T) {
 	k, ctx, _ := testkeeper.CheckpointingKeeper(t, nil, nil)
 

--- a/x/checkpointing/prepare/proposal.go
+++ b/x/checkpointing/prepare/proposal.go
@@ -35,7 +35,7 @@ const (
 	MaxVoteExtensionSize = 1024 // 1KB
 )
 
-type SigValidationFn func(ctx sdk.Context, extendedVotes *abci.ExtendedCommitInfo, blockHash []byte) []ckpttypes.BlsSig
+type SigValidationFn func(ctx sdk.Context, epoch uint64, extendedVotes *abci.ExtendedCommitInfo, blockHash []byte) []ckpttypes.BlsSig
 
 var (
 	EmptyProposalRes = abci.ResponsePrepareProposal{Txs: [][]byte{}}
@@ -175,6 +175,7 @@ func (h *ProposalHandler) buildCheckpointFromVoteExtensions(
 	)
 	validBLSSigs := sigValidationFn(
 		ctx,
+		epoch,
 		extCommit,
 		prevBlockID,
 	)
@@ -221,6 +222,7 @@ func (h *ProposalHandler) buildCheckpointFromVoteExtensions(
 
 func (h *ProposalHandler) VerifyVoteExtension(
 	ctx sdk.Context,
+	expectedEpoch uint64,
 	veBytes []byte,
 	expectedBlockHash []byte,
 ) (*ckpttypes.BlsSig, error) {
@@ -260,6 +262,22 @@ func (h *ProposalHandler) VerifyVoteExtension(
 		return nil, fmt.Errorf("invalid vote extension: %w", err)
 	}
 
+	// Reject vote extensions whose claimed EpochNum does not match the epoch
+	// the proposer is building a checkpoint for. Without this check, a
+	// malicious validator can claim an arbitrary epoch in their VE, sign over
+	// GetSignBytes(claimedEpoch, blockHash), pass per-sig VerifyBLSSig (which
+	// uses sig.EpochNum), and pollute the aggregate so the sealed multi-sig
+	// no longer verifies against canonical sign-bytes. The CometBFT-side
+	// VerifyVoteExtension also checks this, but late precommits delivered to
+	// LocalLastCommit after 2/3 quorum bypass it (cometbft#2361), so this
+	// proposer-side check is load-bearing.
+	if ve.EpochNum != expectedEpoch {
+		return nil, fmt.Errorf(
+			"vote extension epoch mismatch: expected %d, got %d",
+			expectedEpoch, ve.EpochNum,
+		)
+	}
+
 	_, err = sdk.ValAddressFromBech32(ve.Signer)
 	if err != nil {
 		return nil, fmt.Errorf("invalid signer address in vote extension: %w", err)
@@ -285,13 +303,14 @@ func (h *ProposalHandler) VerifyVoteExtension(
 
 func (h *ProposalHandler) getValidBlsSigs(
 	ctx sdk.Context,
+	epoch uint64,
 	extendedVotes *abci.ExtendedCommitInfo,
 	blockHash []byte,
 ) []ckpttypes.BlsSig {
 	var validBLSSigs []ckpttypes.BlsSig
 
 	for _, vote := range extendedVotes.Votes {
-		sig, err := h.VerifyVoteExtension(ctx, vote.VoteExtension, blockHash)
+		sig, err := h.VerifyVoteExtension(ctx, epoch, vote.VoteExtension, blockHash)
 		if err != nil {
 			h.logger.Error("invalid vote extension", "err", err)
 			continue
@@ -304,13 +323,14 @@ func (h *ProposalHandler) getValidBlsSigs(
 
 func (h *ProposalHandler) getValidBlsSigsAndPruneCommitInfo(
 	ctx sdk.Context,
+	epoch uint64,
 	extendedVotes *abci.ExtendedCommitInfo,
 	blockHash []byte,
 ) []ckpttypes.BlsSig {
 	var validBLSSigs []ckpttypes.BlsSig
 
 	for i, vote := range extendedVotes.Votes {
-		sig, err := h.VerifyVoteExtension(ctx, vote.VoteExtension, blockHash)
+		sig, err := h.VerifyVoteExtension(ctx, epoch, vote.VoteExtension, blockHash)
 
 		if err != nil {
 			h.logger.Error("invalid vote extension", "err", err)

--- a/x/checkpointing/prepare/proposal_bypass_test.go
+++ b/x/checkpointing/prepare/proposal_bypass_test.go
@@ -1,6 +1,7 @@
 package prepare_test
 
 import (
+	"fmt"
 	"testing"
 
 	"cosmossdk.io/log"
@@ -81,13 +82,47 @@ func TestDuplicateField_Issue(t *testing.T) {
 		err = ve.Validate()
 		require.NoError(t, err, "Faulty validator %d: Validate() should pass", i+1)
 
-		blsSig, err := proposalHandler.VerifyVoteExtension(ctx, maliciousBytes, blockHash)
+		// epoch 1 matches the EpochNum encoded in the malicious VE; the
+		// malformed-bytes check fires before the epoch check regardless.
+		blsSig, err := proposalHandler.VerifyVoteExtension(ctx, 1, maliciousBytes, blockHash)
 		require.Nil(t, blsSig)
 		require.EqualError(t, err, ckpttypes.ErrVoteExt.Wrapf(
 			"malformed vote extension (possible malicious bytes included): original size %d, size after marshal %d",
 			len(maliciousBytes), len(bzVoteExtAfterParse)).Error(),
 		)
 	}
+}
+
+// TestVerifyVoteExtension_RejectsWrongEpoch covers the proposer-side epoch
+// check. A validator constructs a properly signed vote extension over
+// GetSignBytes(claimedEpoch, blockHash) for a claimedEpoch that differs
+// from the epoch the proposer is building a checkpoint for.
+// VerifyVoteExtension must reject it before the per-sig VerifyBLSSig step
+// (which would otherwise verify the sig against the VE's own claimed
+// epoch and pass).
+func TestVerifyVoteExtension_RejectsWrongEpoch(t *testing.T) {
+	const (
+		expectedEpoch = uint64(7)
+		claimedEpoch  = uint64(5)
+	)
+
+	tempApp := app.NewTmpBabylonApp()
+	proposalHandler := setupProposalHandler(t, tempApp)
+	ctx := setupSdkCtx(100)
+
+	// One validator signs a VE over GetSignBytes(claimedEpoch, blockHash). The
+	// signature itself is valid for that epoch — the only issue is that
+	// claimedEpoch != expectedEpoch.
+	val := genNTestValidators(t, 1)[0]
+	bh := ckpttypes.BlockHash(make([]byte, ckpttypes.HashSize))
+	ve := val.VoteExtension(&bh, claimedEpoch)
+	veBytes, err := ve.Marshal()
+	require.NoError(t, err)
+
+	blsSig, err := proposalHandler.VerifyVoteExtension(ctx, expectedEpoch, veBytes, bh)
+	require.Nil(t, blsSig)
+	require.EqualError(t, err,
+		fmt.Sprintf("vote extension epoch mismatch: expected %d, got %d", expectedEpoch, claimedEpoch))
 }
 
 func buildMaliciousVoteExtension(


### PR DESCRIPTION
## Summary

Brings `main` to parity with the canonical `release/v4.4.x` for two security fixes and the upgrade-handler / CHANGELOG layout that shipped alongside them. Neither fix was on `main` (`git merge-base --is-ancestor` confirms), `release/v4.2.x` is unpatched too, and `main` had additionally drifted out of sync on the `v4_3`/`v4_4` upgrade handlers. Tracking: babylonlabs-io/pm#501.

## Security fixes (parity with release/v4.4.x)

### 1. checkpointing, wrong-epoch vote extension (GHSA-786p-4f8h-946w), source `b6e8f182`

`VerifyVoteExtension` in `prepare/proposal.go` did not check that a VE's claimed `EpochNum` matches the epoch the proposer is building a checkpoint for. The CometBFT-side check exists but is bypassed by late precommits delivered to `LocalLastCommit` after 2/3 quorum ([cometbft#2361]). A wrong-epoch VE is self-consistent under per-sig `VerifyBLSSig`, so it would pollute the sealed aggregate. Adds the proposer-side epoch check (threaded through `SigValidationFn`, `getValidBlsSigs`, `getValidBlsSigsAndPruneCommitInfo`, for both PrepareProposal and ProcessProposal) and a seal-time canonical multi-sig re-verify in `keeper.SealCheckpoint`.

### 2. btcstaking, stake-expansion early-unbond (GHSA-4rm2-cj74-f62h), source `16e00c88`

A stake-expansion child can unbond early before it has an inclusion proof. The parent's `MsgBTCUndelegate` must not then route through `AddBTCDelegationInclusionProof` on the poisoned child, otherwise the parent stays `ACTIVE` while its UTXO is gone on BTC (phantom voting power). Guards stake-expansion activation with `!IsUnbondedEarly()`.

## Upgrade-handler realignment to release/v4.4.x

`main` had the v4 upgrade handlers out of sync: its `v4_3` was byte-identical to v4.4.x's `v4_4` (costaking reset + epoch-boundary validation) but mislabeled "v4.3", there was no `v4_4` directory, and the real stake-expansion `v4_3` remediation was missing. This PR matches v4.4.x:

| Upgrade | Now on main (= release/v4.4.x) |
| --- | --- |
| `v4_3` ("v4.3") | stake-expansion remediation (`RemediatePoisonedStakeExpansions`, GHSA-4rm2) + `upgrade_test.go` |
| `v4_4` ("v4.4") | costaking ActiveBaby reset + epoch-boundary validation (the content main previously mislabeled as v4_3) + costaking test |

Also registers `v44.Upgrade` ahead of `v43.Upgrade` in both `include_upgrade_mainnet.go` and `include_upgrade_testnet.go`, and adds the `BtcUndelegate` / `IterateBTCDelegations` exported wrappers in `btc_delegations.go` that the v4_3 remediation consumes (their doc comments mark them for removal once v4.3 has run everywhere).

## CHANGELOG

Adds the `## v4.3.0` section with the two GHSA entries, matching `release/v4.4.x` exactly (previously these were under `## Unreleased`).

## Tests

Forward-ported and passing: wrong-epoch unit tests (`TestVerifyVoteExtension_RejectsWrongEpoch`, `TestSealCheckpoint_RefusesInvalidAggregate`), the multi-validator replay regression (`TestWrongEpochVoteExtensionRejectedAfterFix`), and the v4_3 stake-expansion remediation + v4_4 costaking upgrade tests (from v4.4.x). `go build ./...`, `go vet`, and the btcstaking keeper suite are clean.

## Follow-up

The upstream stake-expansion e2ev2 Docker regression test depends on roughly 1000 lines of release-specific `tmanager` helpers and is left as a follow-up; the remediation is covered by the v4_3 `upgrade_test.go` and the code-path fix by the btcstaking keeper suite.

[cometbft#2361]: https://github.com/cometbft/cometbft/issues/2361

🤖 Generated with [Claude Code](https://claude.com/claude-code)
