### PR TITLE
docs: link Immunefi bounty program and require authenticated commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 - [Contributing](#contributing)
   - [Overview](#overview)
+    - [Contributor eligibility](#contributor-eligibility)
     - [Pull request rules](#pull-request-rules)
   - [Development Procedure](#development-procedure)
     - [Testing](#testing)
@@ -18,6 +19,32 @@
 
 This document codifies rules that must be followed when contributing to
 the Babylon node repository.
+
+### Contributor eligibility
+
+Anyone can open issues and suggest improvements. Issues are public and require
+no verification, so the community is free to report bugs and propose ideas.
+
+Code contributions are different. In the era of AI and LLMs, and to preserve the
+provenance and integrity of the codebase, **only commits signed by a public key
+on Babylon's allowed-signers list are accepted.** This is enforced by the
+required `Authenticate Commits` check, which verifies every commit in a pull
+request. Being able to sign a commit is not enough on its own: the signing key
+must be explicitly allowlisted, and it must be a hardware-backed key.
+
+Before contributing code:
+
+* Your signing key must be on Babylon's allowed-signers list (the org-level
+  `BABYLON_ALLOWED_SIGNERS` configuration), which is maintained by the Babylon
+  maintainers. Commits signed by a key that is not on the list fail the check,
+  so reach out to the maintainers to have your key reviewed and added.
+* Sign commits with a FIDO2 hardware-backed SSH key (`sk-ssh-ed25519`, i.e.
+  ED25519-SK). Software SSH keys, GPG, and S/MIME do not satisfy the key-type
+  requirement.
+* Make sure every commit in your pull request is signed by that key.
+
+> Automated dependency updates (Dependabot) are verified separately via GitHub's
+> GPG signing and are exempt from the hardware-key requirement.
 
 ### Pull request rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,9 @@ Before contributing code:
 * Your signing key must be on Babylon's allowed-signers list (the org-level
   `BABYLON_ALLOWED_SIGNERS` configuration), which is maintained by the Babylon
   Labs team. Commits signed by a key that is not on the list will fail the check.
-* Sign your commits with a FIDO2 hardware-backed SSH key (`sk-ssh-ed25519`,
-  also known as ED25519-SK). Software SSH keys, GPG, and S/MIME do not meet the
-  key-type requirement.
+* Sign your commits with a FIDO2 hardware-backed SSH key — the
+  `sk-ssh-ed25519@openssh.com` algorithm, generated with
+  `ssh-keygen -t ed25519-sk`.
 * Ensure every commit in your pull request is signed with that key.
 
 > Automated dependency updates (Dependabot) are verified separately through

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,29 +22,29 @@ the Babylon node repository.
 
 ### Contributor eligibility
 
-Anyone can open issues and suggest improvements. Issues are public and require
-no verification, so the community is free to report bugs and propose ideas.
+Anyone is welcome to open issues and suggest improvements. Issues are public
+and require no verification, so the wider community can freely report bugs and
+propose ideas.
 
-Code contributions are different. In the era of AI and LLMs, and to preserve the
-provenance and integrity of the codebase, **only commits signed by a public key
-on Babylon's allowed-signers list are accepted.** This is enforced by the
-required `Authenticate Commits` check, which verifies every commit in a pull
-request. Being able to sign a commit is not enough on its own: the signing key
-must be explicitly allowlisted, and it must be a hardware-backed key.
+Code contributions are held to a higher bar. In an age of AI- and
+LLM-generated code, and to safeguard the provenance and integrity of the
+codebase, **we accept only commits signed by a public key on Babylon's
+allowed-signers list.** The required `Authenticate Commits` check enforces this
+on every commit in a pull request. Signing a commit is not enough on its own:
+the key must be explicitly allowlisted, and it must be hardware-backed.
 
 Before contributing code:
 
 * Your signing key must be on Babylon's allowed-signers list (the org-level
   `BABYLON_ALLOWED_SIGNERS` configuration), which is maintained by the Babylon
-  maintainers. Commits signed by a key that is not on the list fail the check,
-  so reach out to the maintainers to have your key reviewed and added.
-* Sign commits with a FIDO2 hardware-backed SSH key (`sk-ssh-ed25519`, i.e.
-  ED25519-SK). Software SSH keys, GPG, and S/MIME do not satisfy the key-type
-  requirement.
-* Make sure every commit in your pull request is signed by that key.
+  Labs team. Commits signed by a key that is not on the list will fail the check.
+* Sign your commits with a FIDO2 hardware-backed SSH key (`sk-ssh-ed25519`,
+  also known as ED25519-SK). Software SSH keys, GPG, and S/MIME do not meet the
+  key-type requirement.
+* Ensure every commit in your pull request is signed with that key.
 
-> Automated dependency updates (Dependabot) are verified separately via GitHub's
-> GPG signing and are exempt from the hardware-key requirement.
+> Automated dependency updates (Dependabot) are verified separately through
+> GitHub's GPG signing and are exempt from the hardware-key requirement.
 
 ### Pull request rules
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,14 +67,14 @@ During this time:
 
 ## Bug Bounty
 
-Babylon Labs runs an official bug bounty program on Immunefi. Review the program scope, rules, and reward tiers, and
+Babylon Labs runs an official bug bounty program on Immunefi. Please review its scope, rules, and reward tiers, then
 submit eligible vulnerabilities through the program page:
 
 - [Babylon Labs Bug Bounty on Immunefi](https://immunefi.com/bug-bounty/babylon-labs/information/)
 
-We continue to accept vulnerability reports through the channels listed above (email and GitHub Private Vulnerability
-Reporting). However, **only reports submitted through the Immunefi program are eligible for a bounty.** Reports received
-through other channels will still be reviewed and addressed, but will not qualify for a reward.
+We still welcome vulnerability reports through the channels listed above (email and GitHub Private Vulnerability
+Reporting). However, **only reports submitted through the Immunefi program are eligible for a bounty.** Reports
+received through other channels will be reviewed and addressed, but they will not qualify for a reward.
 
 > [!WARNING]
 > Targeting our production environments will disqualify you from receiving any bounty.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,12 +67,14 @@ During this time:
 
 ## Bug Bounty
 
-Though we don't have an official bug bounty program, we generally offer rewards to security researchers who responsibly
-disclose vulnerabilities to us. Bounties are generally awarded for vulnerabilities classified as **high** or
-**critical** severity. Bounty amounts will be determined during the disclosure process, after the severity has been
-assessed.
-We are setting a bug bounty program at the moment. Rewards will be offered in retrospective, once the program is in
-place.
+Babylon Labs runs an official bug bounty program on Immunefi. Review the program scope, rules, and reward tiers, and
+submit eligible vulnerabilities through the program page:
+
+- [Babylon Labs Bug Bounty on Immunefi](https://immunefi.com/bug-bounty/babylon-labs/information/)
+
+We continue to accept vulnerability reports through the channels listed above (email and GitHub Private Vulnerability
+Reporting). However, **only reports submitted through the Immunefi program are eligible for a bounty.** Reports received
+through other channels will still be reviewed and addressed, but will not qualify for a reward.
 
 > [!WARNING]
 > Targeting our production environments will disqualify you from receiving any bounty.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,12 @@ we encourage you to notify us using one of the methods outlined below.
 
 To privately report a security vulnerability, please choose one of the following options:
 
+> [!IMPORTANT]
+> **Seeking a bounty?** Rewards are awarded only for reports submitted through the
+> [Babylon Labs Immunefi program](https://immunefi.com/bug-bounty/babylon-labs/information/)
+> (see [Bug Bounty](#bug-bounty)). The channels below remain open for confidential
+> disclosure but are **not** bounty-eligible.
+
 ### 1. Email
 
 Send your detailed vulnerability report to `security@babylonlabs.io`.


### PR DESCRIPTION
## Summary

Updates two policy docs:

**`SECURITY.md` — Bug Bounty**
- Replaces the outdated "we don't have an official bug bounty program" text with a link to the live [Babylon Labs Immunefi program](https://immunefi.com/bug-bounty/babylon-labs/information/).
- Clarifies that vulnerability reports are still accepted through the existing private channels (email, GitHub Private Vulnerability Reporting), but **only reports submitted through Immunefi are eligible for a bounty**.

**`CONTRIBUTING.md` — Contributor eligibility**
- New section: anyone may open public issues and suggest improvements (no verification required).
- Code contributions are gated by the required `Authenticate Commits` check. Documents the actual enforcement:
  - The signing key must be on Babylon's allowed-signers list (`BABYLON_ALLOWED_SIGNERS`), maintained by maintainers — signing alone is not enough.
  - Commits must be signed with a FIDO2 hardware-backed SSH key (`sk-ssh-ed25519`); GPG, S/MIME, and software SSH keys do not qualify.
  - Dependabot is verified separately (GitHub GPG) and exempt from the hardware-key requirement.
- Adds a TOC entry.

## Notes
- Docs-only change.
- Contributor-eligibility wording was verified against the org-level `reusable_authenticate_commits.yml` workflow that backs the required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)